### PR TITLE
added closeTo matcher for BigDecimal and the corresponding unit tests

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
@@ -1,0 +1,64 @@
+package org.hamcrest.number;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class BigDecimalCloseTo extends TypeSafeMatcher<BigDecimal> {
+
+  private final BigDecimal delta;
+  private final BigDecimal value;
+
+  public BigDecimalCloseTo(BigDecimal value, BigDecimal error) {
+      this.delta = error;
+      this.value = value;
+  }
+
+  @Override
+  public boolean matchesSafely(BigDecimal item) {
+      return actualDelta(item).compareTo(BigDecimal.ZERO) <= 0;
+  }
+
+  @Override
+  public void describeMismatchSafely(BigDecimal item, Description mismatchDescription) {
+      mismatchDescription.appendValue(item)
+              .appendText(" differed by ")
+              .appendValue(actualDelta(item));
+  }
+
+  @Override
+  public void describeTo(Description description) {
+      description.appendText("a numeric value within ")
+              .appendValue(delta)
+              .appendText(" of ")
+              .appendValue(value);
+  }
+
+  private BigDecimal actualDelta(BigDecimal item) {
+      return item.subtract(value, MathContext.DECIMAL128).abs().subtract(delta, MathContext.DECIMAL128).stripTrailingZeros();
+  }
+
+  /**
+   * Creates a matcher of {@link BigDecimal}s that matches when an examined BigDecimal is equal
+   * to the specified <code>operand</code>, within a range of +/- <code>error</code>. The comparison for equality
+   * is done by BigDecimals {@link BigDecimal#compareTo(BigDecimal))} method.
+   * <p/>
+   * For example:
+   * <pre>assertThat(new BigDecimal("1.03"), is(closeTo(new BigDecimal("1.0"), new BigDecimal("0.03"))))</pre>
+   * 
+   * @param operand
+   *     the expected value of matching BigDecimals
+   * @param error
+   *     the delta (+/-) within which matches will be allowed
+   */
+  @Factory
+  public static Matcher<BigDecimal> closeTo(BigDecimal operand, BigDecimal error) {
+      return new BigDecimalCloseTo(operand, error);
+  }
+
+}
+

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/number/BigDecimalCloseToTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/number/BigDecimalCloseToTest.java
@@ -1,0 +1,44 @@
+package org.hamcrest.number;
+
+import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
+
+import java.math.BigDecimal;
+
+import org.hamcrest.AbstractMatcherTest;
+import org.hamcrest.Matcher;
+
+public class BigDecimalCloseToTest  extends AbstractMatcherTest {
+
+  @Override
+  protected Matcher<?> createMatcher() {
+    BigDecimal irrelevant = new BigDecimal("0.01");
+    return closeTo(irrelevant, irrelevant);
+  }
+  
+  public void testEvaluatesToTrueIfArgumentIsEqualToABigDecimalWithinSomeError() {
+    Matcher<BigDecimal> p = closeTo(new BigDecimal("1.0"), new BigDecimal("0.5"));
+
+    assertTrue(p.matches(new BigDecimal("1.0")));
+    assertTrue(p.matches(new BigDecimal("0.5")));
+    assertTrue(p.matches(new BigDecimal("1.5")));
+
+    assertDoesNotMatch("too large", p, new BigDecimal("2.0"));
+    assertMismatchDescription("<2.0> differed by <0.5>", p, new BigDecimal("2.0"));
+    assertDoesNotMatch("number too small", p, new BigDecimal("0.0"));
+    assertMismatchDescription("<0.0> differed by <0.5>", p, new BigDecimal("0.0"));
+  }
+  
+  public void testEvaluatesToTrueIfArgumentHasDifferentScale() {
+    Matcher<BigDecimal> p = closeTo(new BigDecimal("1.0"), new BigDecimal("0.5"));
+
+    assertTrue(p.matches(new BigDecimal("1.000000")));
+    assertTrue(p.matches(new BigDecimal("0.500000")));
+    assertTrue(p.matches(new BigDecimal("1.500000")));
+
+    assertDoesNotMatch("too large", p, new BigDecimal("2.000000"));
+    assertMismatchDescription("<2.000000> differed by <0.5>", p, new BigDecimal("2.000000"));
+    assertDoesNotMatch("number too small", p, new BigDecimal("0.000000"));
+    assertMismatchDescription("<0.000000> differed by <0.5>", p, new BigDecimal("0.000000"));
+  }
+
+}


### PR DESCRIPTION
Pull request to provide a suggestion for Issue 177: Provide the closeTo matcher to be able to handle BigDecimals
