### PR TITLE
Issue 100 (Google Code):  hasItem matcher factory has wrong generic wildcard

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/core/Every.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/Every.java
@@ -5,19 +5,19 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-public class Every<T, I extends Iterable<T>> extends TypeSafeDiagnosingMatcher<I> {
-    private final Matcher<? super T> matcher;
+public class Every<I extends Iterable<?>> extends TypeSafeDiagnosingMatcher<I> {
+    private final Matcher<?> matcher;
 
-    public Every(Matcher<? super T> matcher) {
+    public Every(Matcher<?> matcher) {
         this.matcher= matcher;
     }
 
     @Override
     public boolean matchesSafely(I collection, Description mismatchDescription) {
-        for (T t : collection) {
-            if (!matcher.matches(t)) {
+        for (Object o : collection) {
+            if (!matcher.matches(o)) {
                 mismatchDescription.appendText("an item ");
-                matcher.describeMismatch(t, mismatchDescription);
+                matcher.describeMismatch(o, mismatchDescription);
                 return false;
             }
         }
@@ -41,7 +41,7 @@ public class Every<T, I extends Iterable<T>> extends TypeSafeDiagnosingMatcher<I
      *     the matcher to apply to every item provided by the examined {@link Iterable}
      */
     @Factory
-    public static <U, I extends Iterable<U>> Matcher<I> everyItem(final Matcher<U> itemMatcher) {
-        return new Every<U, I>(itemMatcher);
+    public static <I extends Iterable<?>> Matcher<I> everyItem(final Matcher<?> itemMatcher) {
+        return new Every<I>(itemMatcher);
     }
 }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/Every.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/Every.java
@@ -5,7 +5,7 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-public class Every<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
+public class Every<T, I extends Iterable<T>> extends TypeSafeDiagnosingMatcher<I> {
     private final Matcher<? super T> matcher;
 
     public Every(Matcher<? super T> matcher) {
@@ -13,7 +13,7 @@ public class Every<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
     }
 
     @Override
-    public boolean matchesSafely(Iterable<T> collection, Description mismatchDescription) {
+    public boolean matchesSafely(I collection, Description mismatchDescription) {
         for (T t : collection) {
             if (!matcher.matches(t)) {
                 mismatchDescription.appendText("an item ");
@@ -36,12 +36,12 @@ public class Every<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("bar", "baz"), everyItem(startsWith("ba")))</pre>
-     * 
+     *
      * @param itemMatcher
      *     the matcher to apply to every item provided by the examined {@link Iterable}
      */
     @Factory
-    public static <U> Matcher<Iterable<U>> everyItem(final Matcher<U> itemMatcher) {
-        return new Every<U>(itemMatcher);
+    public static <U, I extends Iterable<U>> Matcher<I> everyItem(final Matcher<U> itemMatcher) {
+        return new Every<U, I>(itemMatcher);
     }
 }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/IsAnything.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/IsAnything.java
@@ -37,8 +37,8 @@ public class IsAnything<T> extends BaseMatcher<T> {
      * Creates a matcher that always matches, regardless of the examined object.
      */
     @Factory
-    public static Matcher<Object> anything() {
-        return new IsAnything<Object>();
+    public static <T> Matcher<T> anything() {
+        return new IsAnything<T>();
     }
 
     /**
@@ -49,7 +49,7 @@ public class IsAnything<T> extends BaseMatcher<T> {
      *     a meaningful {@link String} used when describing itself
      */
     @Factory
-    public static Matcher<Object> anything(String description) {
-        return new IsAnything<Object>(description);
+    public static <T> Matcher<T> anything(String description) {
+        return new IsAnything<T>(description);
     }
 }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -11,10 +11,10 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-public class IsCollectionContaining<T, I extends Iterable<T>> extends TypeSafeDiagnosingMatcher<I> {
-    private final Matcher<? super T> elementMatcher;
+public class IsCollectionContaining<I extends Iterable<?>> extends TypeSafeDiagnosingMatcher<I> {
+    private final Matcher<?> elementMatcher;
 
-    public IsCollectionContaining(Matcher<? super T> elementMatcher) {
+    public IsCollectionContaining(Matcher<?> elementMatcher) {
         this.elementMatcher = elementMatcher;
     }
 
@@ -69,8 +69,8 @@ public class IsCollectionContaining<T, I extends Iterable<T>> extends TypeSafeDi
      *     the matcher to apply to items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T, I extends Iterable<T>> Matcher<I> hasItem(Matcher<? super T> itemMatcher) {
-        return new IsCollectionContaining<T, I>(itemMatcher);
+    public static <I extends Iterable<?>> Matcher<I> hasItem(Matcher<?> itemMatcher) {
+        return new IsCollectionContaining<I>(itemMatcher);
     }
 
     /**
@@ -86,9 +86,8 @@ public class IsCollectionContaining<T, I extends Iterable<T>> extends TypeSafeDi
      *     the item to compare against the items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T, I extends Iterable<T>> Matcher<I> hasItem(T item) {
-        // Doesn't forward to hasItem() method so compiler can sort out generics.
-        return new IsCollectionContaining<T, I>(equalTo(item));
+    public static <I extends Iterable<?>> Matcher<I> hasItem(Object item) {
+        return hasItem(equalTo(item));
     }
 
     /**
@@ -104,12 +103,11 @@ public class IsCollectionContaining<T, I extends Iterable<T>> extends TypeSafeDi
      *     the matchers to apply to items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T, I extends Iterable<T>> Matcher<I> hasItems(Matcher<? super T>... itemMatchers) {
+    public static <I extends Iterable<?>> Matcher<I> hasItems(Matcher<?>... itemMatchers) {
         List<Matcher<? super I>> all = new ArrayList<Matcher<? super I>>(itemMatchers.length);
 
-        for (Matcher<? super T> elementMatcher : itemMatchers) {
-          // Doesn't forward to hasItem() method so compiler can sort out generics.
-          all.add(new IsCollectionContaining<T, I>(elementMatcher));
+        for (Matcher<?> elementMatcher : itemMatchers) {
+          all.add(hasItem(elementMatcher));
         }
 
         return allOf(all);
@@ -128,9 +126,9 @@ public class IsCollectionContaining<T, I extends Iterable<T>> extends TypeSafeDi
      *     the items to compare against the items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T, I extends Iterable<T>> Matcher<I> hasItems(T... items) {
+    public static <I extends Iterable<?>> Matcher<I> hasItems(Object... items) {
         List<Matcher<? super I>> all = new ArrayList<Matcher<? super I>>(items.length);
-        for (T element : items) {
+        for (Object element : items) {
             all.add(hasItem(element));
         }
 

--- a/hamcrest-core/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -11,7 +11,7 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
+public class IsCollectionContaining<T, I extends Iterable<T>> extends TypeSafeDiagnosingMatcher<I> {
     private final Matcher<? super T> elementMatcher;
 
     public IsCollectionContaining(Matcher<? super T> elementMatcher) {
@@ -19,7 +19,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<T> collection, Description mismatchDescription) {
+    protected boolean matchesSafely(I collection, Description mismatchDescription) {
         boolean empty = true;
         for (Object item : collection) {
             empty = false;
@@ -27,12 +27,12 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
                 return true;
             }
         }
-        
+
         if (empty) {
             mismatchDescription.appendText("was an empty collection");
             return false;
         }
-        
+
         mismatchDescription.appendText("was a collection that did not contain ")
                            .appendDescriptionOf(elementMatcher)
                            .appendText(" -- mismatches were: [");
@@ -55,7 +55,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
             .appendDescriptionOf(elementMatcher);
     }
 
-    
+
     /**
      * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
      * examined {@link Iterable} yields at least one item that is matched by the specified
@@ -64,13 +64,13 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem(startsWith("ba")))</pre>
-     * 
+     *
      * @param itemMatcher
      *     the matcher to apply to items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<T>> hasItem(Matcher<? super T> itemMatcher) {
-        return new IsCollectionContaining<T>(itemMatcher);
+    public static <T, I extends Iterable<T>> Matcher<I> hasItem(Matcher<? super T> itemMatcher) {
+        return new IsCollectionContaining<T, I>(itemMatcher);
     }
 
     /**
@@ -81,14 +81,14 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem("bar"))</pre>
-     * 
+     *
      * @param item
      *     the item to compare against the items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<T>> hasItem(T item) {
+    public static <T, I extends Iterable<T>> Matcher<I> hasItem(T item) {
         // Doesn't forward to hasItem() method so compiler can sort out generics.
-        return new IsCollectionContaining<T>(equalTo(item));
+        return new IsCollectionContaining<T, I>(equalTo(item));
     }
 
     /**
@@ -99,22 +99,22 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems(endsWith("z"), endsWith("o")))</pre>
-     * 
+     *
      * @param itemMatchers
      *     the matchers to apply to items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<T>> hasItems(Matcher<? super T>... itemMatchers) {
-        List<Matcher<? super Iterable<T>>> all = new ArrayList<Matcher<? super Iterable<T>>>(itemMatchers.length);
-        
+    public static <T, I extends Iterable<T>> Matcher<I> hasItems(Matcher<? super T>... itemMatchers) {
+        List<Matcher<? super I>> all = new ArrayList<Matcher<? super I>>(itemMatchers.length);
+
         for (Matcher<? super T> elementMatcher : itemMatchers) {
           // Doesn't forward to hasItem() method so compiler can sort out generics.
-          all.add(new IsCollectionContaining<T>(elementMatcher));
+          all.add(new IsCollectionContaining<T, I>(elementMatcher));
         }
-        
+
         return allOf(all);
     }
-    
+
     /**
      * Creates a matcher for {@link Iterable}s that matches when consecutive passes over the
      * examined {@link Iterable} yield at least one item that is equal to the corresponding
@@ -123,17 +123,17 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems("baz", "foo"))</pre>
-     * 
+     *
      * @param items
      *     the items to compare against the items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<T>> hasItems(T... items) {
-        List<Matcher<? super Iterable<T>>> all = new ArrayList<Matcher<? super Iterable<T>>>(items.length);
+    public static <T, I extends Iterable<T>> Matcher<I> hasItems(T... items) {
+        List<Matcher<? super I>> all = new ArrayList<Matcher<? super I>>(items.length);
         for (T element : items) {
             all.add(hasItem(element));
         }
-        
+
         return allOf(all);
     }
 

--- a/hamcrest-core/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -11,7 +11,7 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? super T>> {
+public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
     private final Matcher<? super T> elementMatcher;
 
     public IsCollectionContaining(Matcher<? super T> elementMatcher) {
@@ -19,7 +19,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<? super T> collection, Description mismatchDescription) {
+    protected boolean matchesSafely(Iterable<T> collection, Description mismatchDescription) {
         boolean empty = true;
         for (Object item : collection) {
             empty = false;
@@ -69,7 +69,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      *     the matcher to apply to items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<? super T>> hasItem(Matcher<? super T> itemMatcher) {
+    public static <T> Matcher<Iterable<T>> hasItem(Matcher<? super T> itemMatcher) {
         return new IsCollectionContaining<T>(itemMatcher);
     }
 
@@ -86,7 +86,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      *     the item to compare against the items provided by the examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<? super T>> hasItem(T item) {
+    public static <T> Matcher<Iterable<T>> hasItem(T item) {
         // Doesn't forward to hasItem() method so compiler can sort out generics.
         return new IsCollectionContaining<T>(equalTo(item));
     }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/IsNull.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/IsNull.java
@@ -27,11 +27,11 @@ public class IsNull<T> extends BaseMatcher<T> {
      * <p/>
      * For example:
      * <pre>assertThat(cheese, is(nullValue())</pre>
-     * 
+     *
      */
     @Factory
-    public static Matcher<Object> nullValue() {
-        return new IsNull<Object>();
+    public static <T> Matcher<T> nullValue() {
+        return new IsNull<T>();
     }
 
     /**
@@ -41,11 +41,12 @@ public class IsNull<T> extends BaseMatcher<T> {
      * <pre>assertThat(cheese, is(notNullValue()))</pre>
      * instead of:
      * <pre>assertThat(cheese, is(not(nullValue())))</pre>
-     * 
+     *
      */
     @Factory
-    public static Matcher<Object> notNullValue() {
-        return not(nullValue());
+    public static <T> Matcher<T> notNullValue() {
+        Matcher<T> nullValue = nullValue();
+        return not(nullValue);
     }
 
     /**
@@ -54,7 +55,7 @@ public class IsNull<T> extends BaseMatcher<T> {
      * <p/>
      * For example:
      * <pre>assertThat(cheese, is(nullValue(Cheese.class))</pre>
-     * 
+     *
      * @param type
      *     dummy parameter used to infer the generic type of the returned matcher
      */
@@ -71,10 +72,10 @@ public class IsNull<T> extends BaseMatcher<T> {
      * <pre>assertThat(cheese, is(notNullValue(X.class)))</pre>
      * instead of:
      * <pre>assertThat(cheese, is(not(nullValue(X.class))))</pre>
-     * 
+     *
      * @param type
      *     dummy parameter used to infer the generic type of the returned matcher
-     *  
+     *
      */
     @Factory
     public static <T> Matcher<T> notNullValue(Class<T> type) {

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -1,5 +1,6 @@
 package org.hamcrest.collection;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import java.util.ArrayList;
@@ -13,11 +14,11 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
-    private final IsIterableContainingInAnyOrder<E> iterableMatcher;
-    private final Collection<Matcher<? super E>> matchers;
+    private final IsIterableContainingInAnyOrder<Iterable<E>> iterableMatcher;
+    private final Collection<Matcher<?>> matchers;
 
-    public IsArrayContainingInAnyOrder(Collection<Matcher<? super E>> matchers) {
-        this.iterableMatcher = new IsIterableContainingInAnyOrder<E>(matchers);
+    public IsArrayContainingInAnyOrder(Collection<Matcher<?>> matchers) {
+        this.iterableMatcher = new IsIterableContainingInAnyOrder<Iterable<E>>(matchers);
         this.matchers = matchers;
     }
 
@@ -54,8 +55,8 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      *     a list of matchers, each of which must be satisfied by an entry in an examined array
      */
     @Factory
-    public static <E> Matcher<E[]> arrayContainingInAnyOrder(Matcher<? super E>... itemMatchers) {
-        return arrayContainingInAnyOrder(Arrays.asList(itemMatchers));
+    public static <E> Matcher<E[]> arrayContainingInAnyOrder(Matcher<?>... itemMatchers) {
+        return arrayContainingInAnyOrder(asList(itemMatchers));
     }
 
     /**
@@ -75,7 +76,7 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      *     a list of matchers, each of which must be satisfied by an item provided by an examined array
      */
     @Factory
-    public static <E> Matcher<E[]> arrayContainingInAnyOrder(Collection<Matcher<? super E>> itemMatchers) {
+    public static <E> Matcher<E[]> arrayContainingInAnyOrder(Collection<Matcher<?>> itemMatchers) {
         return new IsArrayContainingInAnyOrder<E>(itemMatchers);
     }
 
@@ -97,10 +98,10 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      */
     @Factory
     public static <E> Matcher<E[]> arrayContainingInAnyOrder(E... items) {
-      List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
+      List<Matcher<?>> matchers = new ArrayList<Matcher<?>>();
       for (E item : items) {
           matchers.add(equalTo(item));
       }
-      return new IsArrayContainingInAnyOrder<E>(matchers);
+      return arrayContainingInAnyOrder(matchers);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -13,11 +13,11 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
-    private final Collection<Matcher<? super E>> matchers;
-    private final IsIterableContainingInOrder<E> iterableMatcher;
+    private final Collection<Matcher<?>> matchers;
+    private final IsIterableContainingInOrder<Iterable<E>> iterableMatcher;
 
-    public IsArrayContainingInOrder(List<Matcher<? super E>> matchers) {
-        this.iterableMatcher = new IsIterableContainingInOrder<E>(matchers);
+    public IsArrayContainingInOrder(List<Matcher<?>> matchers) {
+        this.iterableMatcher = new IsIterableContainingInOrder<Iterable<E>>(matchers);
         this.matchers = matchers;
     }
 
@@ -49,7 +49,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      */
     @Factory
     public static <E> Matcher<E[]> arrayContaining(E... items) {
-        List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
+        List<Matcher<?>> matchers = new ArrayList<Matcher<?>>();
         for (E item : items) {
             matchers.add(equalTo(item));
         }
@@ -68,7 +68,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      *     the matchers that must be satisfied by the items in the examined array
      */
     @Factory
-    public static <E> Matcher<E[]> arrayContaining(Matcher<? super E>... itemMatchers) {
+    public static <E> Matcher<E[]> arrayContaining(Matcher<?>... itemMatchers) {
         return arrayContaining(asList(itemMatchers));
     }
 
@@ -84,7 +84,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      *     a list of matchers, each of which must be satisfied by the corresponding item in an examined array
      */
     @Factory
-    public static <E> Matcher<E[]> arrayContaining(List<Matcher<? super E>> itemMatchers) {
+    public static <E> Matcher<E[]> arrayContaining(List<Matcher<?>> itemMatchers) {
         return new IsArrayContainingInOrder<E>(itemMatchers);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -11,13 +11,13 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * Matches if collection size satisfies a nested matcher.
  */
-public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends E>, Integer> {
+public class IsCollectionWithSize<E, C extends Collection<E>> extends FeatureMatcher<C, Integer> {
     public IsCollectionWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a collection with size", "collection size");
     }
 
     @Override
-    protected Integer featureValueOf(Collection<? extends E> actual) {
+    protected Integer featureValueOf(C actual) {
       return actual.size();
     }
 
@@ -27,13 +27,13 @@ public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(equalTo(2)))</pre>
-     * 
+     *
      * @param sizeMatcher
      *     a matcher for the size of an examined {@link java.util.Collection}
      */
     @Factory
-    public static <E> Matcher<Collection<? extends E>> hasSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsCollectionWithSize<E>(sizeMatcher);
+    public static <E, C extends Collection<E>> Matcher<C> hasSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsCollectionWithSize<E, C>(sizeMatcher);
     }
 
     /**
@@ -42,14 +42,14 @@ public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(2))</pre>
-     * 
+     *
      * @param size
      *     the expected size of an examined {@link java.util.Collection}
      */
     @Factory
-    public static <E> Matcher<Collection<? extends E>> hasSize(int size) {
+    public static <E, C extends Collection<E>> Matcher<C> hasSize(int size) {
         Matcher<? super Integer> matcher = equalTo(size);
-        return IsCollectionWithSize.<E>hasSize(matcher);
+        return IsCollectionWithSize.<E, C>hasSize(matcher);
     }
 
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -11,7 +11,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * Matches if collection size satisfies a nested matcher.
  */
-public class IsCollectionWithSize<E, C extends Collection<E>> extends FeatureMatcher<C, Integer> {
+public class IsCollectionWithSize<C extends Collection<?>> extends FeatureMatcher<C, Integer> {
     public IsCollectionWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a collection with size", "collection size");
     }
@@ -32,8 +32,8 @@ public class IsCollectionWithSize<E, C extends Collection<E>> extends FeatureMat
      *     a matcher for the size of an examined {@link java.util.Collection}
      */
     @Factory
-    public static <E, C extends Collection<E>> Matcher<C> hasSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsCollectionWithSize<E, C>(sizeMatcher);
+    public static <C extends Collection<?>> Matcher<C> hasSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsCollectionWithSize<C>(sizeMatcher);
     }
 
     /**
@@ -47,9 +47,8 @@ public class IsCollectionWithSize<E, C extends Collection<E>> extends FeatureMat
      *     the expected size of an examined {@link java.util.Collection}
      */
     @Factory
-    public static <E, C extends Collection<E>> Matcher<C> hasSize(int size) {
-        Matcher<? super Integer> matcher = equalTo(size);
-        return IsCollectionWithSize.<E, C>hasSize(matcher);
+    public static <C extends Collection<?>> Matcher<C> hasSize(int size) {
+        return hasSize(equalTo(size));
     }
 
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -10,15 +10,15 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Tests if collection is empty.
  */
-public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E>> {
+public class IsEmptyCollection<E, C extends Collection<E>> extends TypeSafeMatcher<C> {
 
     @Override
-    public boolean matchesSafely(Collection<? extends E> item) {
+    public boolean matchesSafely(C item) {
         return item.isEmpty();
     }
 
     @Override
-    public void describeMismatchSafely(Collection<? extends E> item, Description mismatchDescription) {
+    public void describeMismatchSafely(C item, Description mismatchDescription) {
       mismatchDescription.appendValue(item);
     }
 
@@ -33,11 +33,11 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * <p/>
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(empty()))</pre>
-     * 
+     *
      */
     @Factory
-    public static <E> Matcher<Collection<? extends E>> empty() {
-        return new IsEmptyCollection<E>();
+    public static <E, C extends Collection<E>> Matcher<C> empty() {
+        return new IsEmptyCollection<E, C>();
     }
 
     /**
@@ -46,14 +46,14 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * <p/>
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyCollectionOf(String.class)))</pre>
-     * 
+     *
      * @param type
      *     the type of the collection's content
      */
     @Factory
-    public static <E> Matcher<Collection<E>> emptyCollectionOf(Class<E> type) {
+    public static <E, C extends Collection<E>> Matcher<C> emptyCollectionOf(Class<E> type) {
         @SuppressWarnings({ "rawtypes", "unchecked" })
-        final Matcher<Collection<E>> result = (Matcher)empty();
+        final Matcher<C> result = (Matcher)empty();
         return result;
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -51,7 +51,7 @@ public class IsEmptyCollection<C extends Collection<?>> extends TypeSafeMatcher<
      *     the type of the collection's content
      */
     @Factory
-    public static <E, C extends Collection<E>> Matcher<C> emptyCollectionOf(Class<E> type) {
+    public static <T> Matcher<Collection<T>> emptyCollectionOf(Class<T> type) {
         return empty();
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -10,7 +10,7 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Tests if collection is empty.
  */
-public class IsEmptyCollection<E, C extends Collection<E>> extends TypeSafeMatcher<C> {
+public class IsEmptyCollection<C extends Collection<?>> extends TypeSafeMatcher<C> {
 
     @Override
     public boolean matchesSafely(C item) {
@@ -36,8 +36,8 @@ public class IsEmptyCollection<E, C extends Collection<E>> extends TypeSafeMatch
      *
      */
     @Factory
-    public static <E, C extends Collection<E>> Matcher<C> empty() {
-        return new IsEmptyCollection<E, C>();
+    public static <C extends Collection<?>> Matcher<C> empty() {
+        return new IsEmptyCollection<C>();
     }
 
     /**
@@ -52,8 +52,6 @@ public class IsEmptyCollection<E, C extends Collection<E>> extends TypeSafeMatch
      */
     @Factory
     public static <E, C extends Collection<E>> Matcher<C> emptyCollectionOf(Class<E> type) {
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        final Matcher<C> result = (Matcher)empty();
-        return result;
+        return empty();
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
@@ -8,14 +8,14 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Tests if collection is empty.
  */
-public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
+public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<E>> {
 
     @Override
-    public boolean matchesSafely(Iterable<? extends E> iterable) {
+    public boolean matchesSafely(Iterable<E> iterable) {
         return !iterable.iterator().hasNext();
     }
     @Override
-    public void describeMismatchSafely(Iterable<? extends E> iter, Description mismatchDescription) {
+    public void describeMismatchSafely(Iterable<E> iter, Description mismatchDescription) {
         mismatchDescription.appendValueList("[", ",", "]", iter);
     }
 
@@ -29,10 +29,10 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * <p/>
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterable()))</pre>
-     * 
+     *
      */
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> emptyIterable() {
+    public static <E> Matcher<Iterable<E>> emptyIterable() {
         return new IsEmptyIterable<E>();
     }
 
@@ -41,7 +41,7 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * <p/>
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterableOf(String.class)))</pre>
-     * 
+     *
      * @param type
      *     the type of the iterable's content
      */

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -1,7 +1,9 @@
 package org.hamcrest.collection;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.IsEqual.equalTo;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -10,19 +12,17 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import static org.hamcrest.core.IsEqual.equalTo;
+public class IsIterableContainingInAnyOrder<I extends Iterable<?>> extends TypeSafeDiagnosingMatcher<I> {
+    private final Collection<Matcher<?>> matchers;
 
-public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
-    private final Collection<Matcher<? super T>> matchers;
-
-    public IsIterableContainingInAnyOrder(Collection<Matcher<? super T>> matchers) {
+    public IsIterableContainingInAnyOrder(Collection<Matcher<?>> matchers) {
         this.matchers = matchers;
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<T> items, Description mismatchDescription) {
-      Matching<T> matching = new Matching<T>(matchers, mismatchDescription);
-      for (T item : items) {
+    protected boolean matchesSafely(I items, Description mismatchDescription) {
+      Matching matching = new Matching(matchers, mismatchDescription);
+      for (Object item : items) {
         if (! matching.matches(item)) {
           return false;
         }
@@ -38,20 +38,20 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
           .appendText(" in any order");
     }
 
-    private static class Matching<S> {
-      private final Collection<Matcher<? super S>> matchers;
+    private static class Matching {
+      private final Collection<Matcher<?>> matchers;
       private final Description mismatchDescription;
 
-      public Matching(Collection<Matcher<? super S>> matchers, Description mismatchDescription) {
-        this.matchers = new ArrayList<Matcher<? super S>>(matchers);
+      public Matching(Collection<Matcher<?>> matchers, Description mismatchDescription) {
+        this.matchers = new ArrayList<Matcher<?>>(matchers);
         this.mismatchDescription = mismatchDescription;
       }
 
-      public boolean matches(S item) {
+      public boolean matches(Object item) {
         return isNotSurplus(item) && isMatched(item);
       }
 
-      public boolean isFinished(Iterable<? extends S> items) {
+      public boolean isFinished(Iterable<?> items) {
         if (matchers.isEmpty()) {
           return true;
         }
@@ -61,7 +61,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
         return false;
       }
 
-      private boolean isNotSurplus(S item) {
+      private boolean isNotSurplus(Object item) {
         if (matchers.isEmpty()) {
           mismatchDescription.appendText("Not matched: ").appendValue(item);
           return false;
@@ -69,8 +69,8 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
         return true;
       }
 
-      private boolean isMatched(S item) {
-        for (Matcher<? super S>  matcher : matchers) {
+      private boolean isMatched(Object item) {
+        for (Matcher<?>  matcher : matchers) {
           if (matcher.matches(item)) {
             matchers.remove(matcher);
             return true;
@@ -97,9 +97,10 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
      */
+    @SuppressWarnings("unchecked")
     @Factory
-    public static <T> Matcher<Iterable<T>> containsInAnyOrder(Matcher<? super T>... itemMatchers) {
-        return containsInAnyOrder(Arrays.asList(itemMatchers));
+    public static <T, I extends Iterable<?>> Matcher<I> containsInAnyOrder(Matcher<? super T>... itemMatchers) {
+        return containsInAnyOrder(asList(itemMatchers));
     }
 
     /**
@@ -119,13 +120,13 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      *     the items that must equal the items provided by an examined {@link Iterable} in any order
      */
     @Factory
-    public static <T> Matcher<Iterable<T>> containsInAnyOrder(T... items) {
-        List<Matcher<? super T>> matchers = new ArrayList<Matcher<? super T>>();
-        for (T item : items) {
+    public static <T, I extends Iterable<?>> Matcher<I> containsInAnyOrder(T... items) {
+        List<Matcher<?>> matchers = new ArrayList<Matcher<?>>();
+        for (Object item : items) {
             matchers.add(equalTo(item));
         }
 
-        return new IsIterableContainingInAnyOrder<T>(matchers);
+        return new IsIterableContainingInAnyOrder<I>(matchers);
     }
 
     /**
@@ -145,8 +146,8 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<T>> containsInAnyOrder(Collection<Matcher<? super T>> itemMatchers) {
-        return new IsIterableContainingInAnyOrder<T>(itemMatchers);
+    public static <I extends Iterable<?>> Matcher<I> containsInAnyOrder(Collection<Matcher<?>> itemMatchers) {
+        return new IsIterableContainingInAnyOrder<I>(itemMatchers);
     }
 }
 

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -12,25 +12,25 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
+public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher<Iterable<T>> {
     private final Collection<Matcher<? super T>> matchers;
 
     public IsIterableContainingInAnyOrder(Collection<Matcher<? super T>> matchers) {
         this.matchers = matchers;
     }
-    
+
     @Override
-    protected boolean matchesSafely(Iterable<? extends T> items, Description mismatchDescription) {
+    protected boolean matchesSafely(Iterable<T> items, Description mismatchDescription) {
       Matching<T> matching = new Matching<T>(matchers, mismatchDescription);
       for (T item : items) {
         if (! matching.matches(item)) {
           return false;
         }
       }
-      
+
       return matching.isFinished(items);
     }
-    
+
     @Override
     public void describeTo(Description description) {
       description.appendText("iterable over ")
@@ -46,7 +46,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
         this.matchers = new ArrayList<Matcher<? super S>>(matchers);
         this.mismatchDescription = mismatchDescription;
       }
-      
+
       public boolean matches(S item) {
         return isNotSurplus(item) && isMatched(item);
       }
@@ -60,7 +60,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
           .appendText(" in ").appendValueList("[", ", ", "]", items);
         return false;
       }
-      
+
       private boolean isNotSurplus(S item) {
         if (matchers.isEmpty()) {
           mismatchDescription.appendText("Not matched: ").appendValue(item);
@@ -93,12 +93,12 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
-     * 
+     *
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(Matcher<? super T>... itemMatchers) {
+    public static <T> Matcher<Iterable<T>> containsInAnyOrder(Matcher<? super T>... itemMatchers) {
         return containsInAnyOrder(Arrays.asList(itemMatchers));
     }
 
@@ -114,17 +114,17 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder("bar", "foo"))</pre>
-     * 
+     *
      * @param items
      *     the items that must equal the items provided by an examined {@link Iterable} in any order
      */
     @Factory
-    public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(T... items) {
+    public static <T> Matcher<Iterable<T>> containsInAnyOrder(T... items) {
         List<Matcher<? super T>> matchers = new ArrayList<Matcher<? super T>>();
         for (T item : items) {
             matchers.add(equalTo(item));
         }
-        
+
         return new IsIterableContainingInAnyOrder<T>(matchers);
     }
 
@@ -140,12 +140,12 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
-     * 
+     *
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
      */
     @Factory
-    public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(Collection<Matcher<? super T>> itemMatchers) {
+    public static <T> Matcher<Iterable<T>> containsInAnyOrder(Collection<Matcher<? super T>> itemMatchers) {
         return new IsIterableContainingInAnyOrder<T>(itemMatchers);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<Iterable<? extends E>> {
+public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<Iterable<E>> {
     private final List<Matcher<? super E>> matchers;
 
     public IsIterableContainingInOrder(List<Matcher<? super E>> matchers) {
@@ -19,7 +19,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<? extends E> iterable, Description mismatchDescription) {
+    protected boolean matchesSafely(Iterable<E> iterable, Description mismatchDescription) {
         MatchSeries<E> matchSeries = new MatchSeries<E>(matchers, mismatchDescription);
         for (E item : iterable) {
             if (!matchSeries.matches(item)) {
@@ -92,12 +92,12 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), contains("foo", "bar"))</pre>
-     * 
+     *
      * @param items
      *     the items that must equal the items provided by an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> contains(E... items) {
+    public static <E> Matcher<Iterable<E>> contains(E... items) {
         List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
         for (E item : items) {
             matchers.add(equalTo(item));
@@ -113,14 +113,14 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo"), contains(equalTo("foo")))</pre>
-     * 
+     *
      * @param itemMatcher
      *     the matcher that must be satisfied by the single item provided by an
      *     examined {@link Iterable}
      */
     @SuppressWarnings("unchecked")
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> contains(final Matcher<? super E> itemMatcher) {
+    public static <E> Matcher<Iterable<E>> contains(final Matcher<? super E> itemMatcher) {
         return contains(new ArrayList<Matcher<? super E>>(asList(itemMatcher)));
     }
 
@@ -132,12 +132,12 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), contains(equalTo("foo"), equalTo("bar")))</pre>
-     * 
+     *
      * @param itemMatchers
      *     the matchers that must be satisfied by the items provided by an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> contains(Matcher<? super E>... itemMatchers) {
+    public static <E> Matcher<Iterable<E>> contains(Matcher<? super E>... itemMatchers) {
         return contains(asList(itemMatchers));
     }
 
@@ -149,13 +149,13 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * <p/>
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), contains(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
-     * 
+     *
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by the corresponding item provided by
      *     an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> contains(List<Matcher<? super E>> itemMatchers) {
+    public static <E> Matcher<Iterable<E>> contains(List<Matcher<? super E>> itemMatchers) {
         return new IsIterableContainingInOrder<E>(itemMatchers);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -11,17 +11,17 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<Iterable<E>> {
-    private final List<Matcher<? super E>> matchers;
+public class IsIterableContainingInOrder<I extends Iterable<?>> extends TypeSafeDiagnosingMatcher<I> {
+    private final List<Matcher<?>> matchers;
 
-    public IsIterableContainingInOrder(List<Matcher<? super E>> matchers) {
+    public IsIterableContainingInOrder(List<Matcher<?>> matchers) {
         this.matchers = matchers;
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<E> iterable, Description mismatchDescription) {
-        MatchSeries<E> matchSeries = new MatchSeries<E>(matchers, mismatchDescription);
-        for (E item : iterable) {
+    protected boolean matchesSafely(I iterable, Description mismatchDescription) {
+        MatchSeries matchSeries = new MatchSeries(matchers, mismatchDescription);
+        for (Object item : iterable) {
             if (!matchSeries.matches(item)) {
                 return false;
             }
@@ -35,12 +35,12 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
         description.appendText("iterable containing ").appendList("[", ", ", "]", matchers);
     }
 
-    private static class MatchSeries<F> {
-        public final List<Matcher<? super F>> matchers;
+    private static class MatchSeries {
+        public final List<Matcher<?>> matchers;
         private final Description mismatchDescription;
         public int nextMatchIx = 0;
 
-        public MatchSeries(List<Matcher<? super F>> matchers, Description mismatchDescription) {
+        public MatchSeries(List<Matcher<?>> matchers, Description mismatchDescription) {
             this.mismatchDescription = mismatchDescription;
             if (matchers.isEmpty()) {
                 throw new IllegalArgumentException("Should specify at least one expected element");
@@ -48,7 +48,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
             this.matchers = matchers;
         }
 
-        public boolean matches(F item) {
+        public boolean matches(Object item) {
             return isNotSurplus(item) && isMatched(item);
         }
 
@@ -60,8 +60,8 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
             return true;
         }
 
-        private boolean isMatched(F item) {
-            Matcher<? super F> matcher = matchers.get(nextMatchIx);
+        private boolean isMatched(Object item) {
+            Matcher<?> matcher = matchers.get(nextMatchIx);
             if (!matcher.matches(item)) {
                 describeMismatch(matcher, item);
                 return false;
@@ -70,7 +70,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
             return true;
         }
 
-        private boolean isNotSurplus(F item) {
+        private boolean isNotSurplus(Object item) {
             if (matchers.size() <= nextMatchIx) {
                 mismatchDescription.appendText("Not matched: ").appendValue(item);
                 return false;
@@ -78,7 +78,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
             return true;
         }
 
-        private void describeMismatch(Matcher<? super F> matcher, F item) {
+        private void describeMismatch(Matcher<?> matcher, Object item) {
             mismatchDescription.appendText("item " + nextMatchIx + ": ");
             matcher.describeMismatch(item, mismatchDescription);
         }
@@ -97,9 +97,9 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      *     the items that must equal the items provided by an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<E>> contains(E... items) {
-        List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
-        for (E item : items) {
+    public static <I extends Iterable<?>> Matcher<I> contains(Object... items) {
+        List<Matcher<?>> matchers = new ArrayList<Matcher<?>>();
+        for (Object item : items) {
             matchers.add(equalTo(item));
         }
 
@@ -120,8 +120,8 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      */
     @SuppressWarnings("unchecked")
     @Factory
-    public static <E> Matcher<Iterable<E>> contains(final Matcher<? super E> itemMatcher) {
-        return contains(new ArrayList<Matcher<? super E>>(asList(itemMatcher)));
+    public static <I extends Iterable<?>> Matcher<I> contains(final Matcher<?> itemMatcher) {
+        return contains(new ArrayList<Matcher<?>>(asList(itemMatcher)));
     }
 
     /**
@@ -137,7 +137,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      *     the matchers that must be satisfied by the items provided by an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<E>> contains(Matcher<? super E>... itemMatchers) {
+    public static <I extends Iterable<?>> Matcher<I> contains(Matcher<?>... itemMatchers) {
         return contains(asList(itemMatchers));
     }
 
@@ -155,7 +155,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      *     an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<E>> contains(List<Matcher<? super E>> itemMatchers) {
-        return new IsIterableContainingInOrder<E>(itemMatchers);
+    public static <I extends Iterable<?>> Matcher<I> contains(List<Matcher<?>> itemMatchers) {
+        return new IsIterableContainingInOrder<I>(itemMatchers);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -8,7 +8,7 @@ import org.hamcrest.Factory;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> {
+public class IsIterableWithSize<I extends Iterable<?>> extends FeatureMatcher<I, Integer> {
 
     public IsIterableWithSize(Matcher<? super Integer> sizeMatcher) {
         super(sizeMatcher, "an iterable with size", "iterable size");
@@ -16,9 +16,9 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
     
 
     @Override
-    protected Integer featureValueOf(Iterable<E> actual) {
+    protected Integer featureValueOf(I actual) {
       int size = 0;
-      for (Iterator<E> iterator = actual.iterator(); iterator.hasNext(); iterator.next()) {
+      for (Iterator<?> iterator = actual.iterator(); iterator.hasNext(); iterator.next()) {
         size++;
       }
       return size;
@@ -36,8 +36,8 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      *     a matcher for the number of items that should be yielded by an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<E>> iterableWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsIterableWithSize<E>(sizeMatcher);
+    public static <I extends Iterable<?>> Matcher<I> iterableWithSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsIterableWithSize<I>(sizeMatcher);
     }
 
     /**
@@ -52,7 +52,7 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      *     the number of items that should be yielded by an examined {@link Iterable}
      */
     @Factory
-    public static <E> Matcher<Iterable<E>> iterableWithSize(int size) {
+    public static <I extends Iterable<?>> Matcher<I> iterableWithSize(int size) {
         return iterableWithSize(equalTo(size));
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -11,18 +11,18 @@ import java.util.Map.Entry;
 import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
-    private final Matcher<? super K> keyMatcher;
-    private final Matcher<? super V> valueMatcher;
+public class IsMapContaining<M extends Map<?, ?>> extends TypeSafeMatcher<M> {
+    private final Matcher<?> keyMatcher;
+    private final Matcher<?> valueMatcher;
 
-    public IsMapContaining(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
+    public IsMapContaining(Matcher<?> keyMatcher, Matcher<?> valueMatcher) {
         this.keyMatcher = keyMatcher;
         this.valueMatcher = valueMatcher;
     }
 
     @Override
-    public boolean matchesSafely(Map<K, V> map) {
-        for (Entry<? extends K, ? extends V> entry : map.entrySet()) {
+    public boolean matchesSafely(M map) {
+        for (Entry<?, ?> entry : map.entrySet()) {
             if (keyMatcher.matches(entry.getKey()) && valueMatcher.matches(entry.getValue())) {
                 return true;
             }
@@ -31,7 +31,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
     }
 
     @Override
-    public void describeMismatchSafely(Map<K, V> map, Description mismatchDescription) {
+    public void describeMismatchSafely(M map, Description mismatchDescription) {
       mismatchDescription.appendText("map was ").appendValueList("[", ", ", "]", map.entrySet());
     }
 
@@ -58,8 +58,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
      *     the value matcher that, in combination with the keyMatcher, must be satisfied by at least one entry
      */
     @Factory
-    public static <K,V> Matcher<Map<K, V>> hasEntry(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
-        return new IsMapContaining<K,V>(keyMatcher, valueMatcher);
+    public static <K, V, M extends Map<?,?>> Matcher<M> hasEntry(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
+        return new IsMapContaining<M>(keyMatcher, valueMatcher);
     }
 
     /**
@@ -76,8 +76,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
      *     the value that, in combination with the key, must be describe at least one entry
      */
     @Factory
-    public static <K, V> Matcher<Map<K, V>> hasEntry(K key, V value) {
-        return new IsMapContaining<K,V>(equalTo(key), equalTo(value));
+    public static <K, V, M extends Map<?,?>> Matcher<M> hasEntry(K key, V value) {
+        return hasEntry(equalTo(key), equalTo(value));
     }
 
     /**
@@ -91,8 +91,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
      *     the matcher that must be satisfied by at least one key
      */
     @Factory
-    public static <K, V> Matcher<Map<K, V>> hasKey(Matcher<? super K> keyMatcher) {
-        return new IsMapContaining<K, V>(keyMatcher, anything());
+    public static <K, M extends Map<?,?>> Matcher<M> hasKey(Matcher<? super K> keyMatcher) {
+        return hasEntry(keyMatcher, anything());
     }
 
     /**
@@ -106,8 +106,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
      *     the key that satisfying maps must contain
      */
     @Factory
-    public static <K, V> Matcher<Map<K, V>> hasKey(K key) {
-        return new IsMapContaining<K, V>(equalTo(key), anything());
+    public static <K, M extends Map<?,?>> Matcher<M> hasKey(K key) {
+        return hasKey(equalTo(key));
     }
 
     /**
@@ -121,8 +121,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
      *     the matcher that must be satisfied by at least one value
      */
     @Factory
-    public static <K, V> Matcher<Map<K, V>> hasValue(Matcher<? super V> valueMatcher) {
-        return new IsMapContaining<K, V>(anything(), valueMatcher);
+    public static <V, M extends Map<?,?>> Matcher<M> hasValue(Matcher<? super V> valueMatcher) {
+        return hasEntry(anything(), valueMatcher);
     }
 
     /**
@@ -136,7 +136,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
      *     the value that satisfying maps must contain
      */
     @Factory
-    public static <K, V> Matcher<Map<K, V>> hasValue(V value) {
-        return new IsMapContaining<K, V>(anything(), equalTo(value));
+    public static <V, M extends Map<?,?>> Matcher<M> hasValue(V value) {
+        return hasValue(equalTo(value));
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -11,7 +11,7 @@ import java.util.Map.Entry;
 import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? extends V>> {
+public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<K, V>> {
     private final Matcher<? super K> keyMatcher;
     private final Matcher<? super V> valueMatcher;
 
@@ -21,7 +21,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
     }
 
     @Override
-    public boolean matchesSafely(Map<? extends K, ? extends V> map) {
+    public boolean matchesSafely(Map<K, V> map) {
         for (Entry<? extends K, ? extends V> entry : map.entrySet()) {
             if (keyMatcher.matches(entry.getKey()) && valueMatcher.matches(entry.getValue())) {
                 return true;
@@ -31,7 +31,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
     }
 
     @Override
-    public void describeMismatchSafely(Map<? extends K, ? extends V> map, Description mismatchDescription) {
+    public void describeMismatchSafely(Map<K, V> map, Description mismatchDescription) {
       mismatchDescription.appendText("map was ").appendValueList("[", ", ", "]", map.entrySet());
     }
 
@@ -51,14 +51,14 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * <p/>
      * For example:
      * <pre>assertThat(myMap, hasEntry(equalTo("bar"), equalTo("foo")))</pre>
-     * 
+     *
      * @param keyMatcher
      *     the key matcher that, in combination with the valueMatcher, must be satisfied by at least one entry
      * @param valueMatcher
      *     the value matcher that, in combination with the keyMatcher, must be satisfied by at least one entry
      */
     @Factory
-    public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
+    public static <K,V> Matcher<Map<K, V>> hasEntry(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
         return new IsMapContaining<K,V>(keyMatcher, valueMatcher);
     }
 
@@ -69,30 +69,30 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * <p/>
      * For example:
      * <pre>assertThat(myMap, hasEntry("bar", "foo"))</pre>
-     *  
+     *
      * @param key
      *     the key that, in combination with the value, must be describe at least one entry
      * @param value
      *     the value that, in combination with the key, must be describe at least one entry
      */
     @Factory
-    public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(K key, V value) {
+    public static <K, V> Matcher<Map<K, V>> hasEntry(K key, V value) {
         return new IsMapContaining<K,V>(equalTo(key), equalTo(value));
     }
-    
+
     /**
      * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
      * at least one key that satisfies the specified matcher.
      * <p/>
      * For example:
      * <pre>assertThat(myMap, hasKey(equalTo("bar")))</pre>
-     * 
+     *
      * @param keyMatcher
      *     the matcher that must be satisfied by at least one key
      */
     @Factory
-    public static <K> Matcher<Map<? extends K, ?>> hasKey(Matcher<? super K> keyMatcher) {
-        return new IsMapContaining<K,Object>(keyMatcher, anything());
+    public static <K, V> Matcher<Map<K, V>> hasKey(Matcher<? super K> keyMatcher) {
+        return new IsMapContaining<K, V>(keyMatcher, anything());
     }
 
     /**
@@ -101,13 +101,13 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * <p/>
      * For example:
      * <pre>assertThat(myMap, hasKey("bar"))</pre>
-     * 
+     *
      * @param key
      *     the key that satisfying maps must contain
      */
     @Factory
-    public static <K> Matcher<Map<? extends K, ?>> hasKey(K key) {
-        return new IsMapContaining<K,Object>(equalTo(key), anything());
+    public static <K, V> Matcher<Map<K, V>> hasKey(K key) {
+        return new IsMapContaining<K, V>(equalTo(key), anything());
     }
 
     /**
@@ -116,13 +116,13 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * <p/>
      * For example:
      * <pre>assertThat(myMap, hasValue(equalTo("foo")))</pre>
-     * 
+     *
      * @param valueMatcher
      *     the matcher that must be satisfied by at least one value
      */
     @Factory
-    public static <V> Matcher<Map<?, ? extends V>> hasValue(Matcher<? super V> valueMatcher) {
-        return new IsMapContaining<Object,V>(anything(), valueMatcher);
+    public static <K, V> Matcher<Map<K, V>> hasValue(Matcher<? super V> valueMatcher) {
+        return new IsMapContaining<K, V>(anything(), valueMatcher);
     }
 
     /**
@@ -131,12 +131,12 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * <p/>
      * For example:
      * <pre>assertThat(myMap, hasValue("foo"))</pre>
-     * 
+     *
      * @param value
      *     the value that satisfying maps must contain
      */
     @Factory
-    public static <V> Matcher<Map<?, ? extends V>> hasValue(V value) {
-        return new IsMapContaining<Object,V>(anything(), equalTo(value));
+    public static <K, V> Matcher<Map<K, V>> hasValue(V value) {
+        return new IsMapContaining<K, V>(anything(), equalTo(value));
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -11,7 +11,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * Matches if map size satisfies a nested matcher.
  */
-public final class IsMapWithSize<K, V, M extends Map<K, V>> extends FeatureMatcher<M, Integer> {
+public final class IsMapWithSize<M extends Map<?, ?>> extends FeatureMatcher<M, Integer> {
     public IsMapWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a map with size", "map size");
     }
@@ -32,8 +32,8 @@ public final class IsMapWithSize<K, V, M extends Map<K, V>> extends FeatureMatch
      *     a matcher for the size of an examined {@link java.util.Map}
      */
     @Factory
-    public static <K, V, M extends Map<K, V>> Matcher<M> aMapWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsMapWithSize<K, V, M>(sizeMatcher);
+    public static <M extends Map<?, ?>> Matcher<M> aMapWithSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsMapWithSize<M>(sizeMatcher);
     }
 
     /**
@@ -47,9 +47,8 @@ public final class IsMapWithSize<K, V, M extends Map<K, V>> extends FeatureMatch
      *     the expected size of an examined {@link java.util.Map}
      */
     @Factory
-    public static <K, V, M extends Map<K, V>> Matcher<M> aMapWithSize(int size) {
-        Matcher<? super Integer> matcher = equalTo(size);
-        return IsMapWithSize.<K, V, M>aMapWithSize(matcher);
+    public static <M extends Map<?, ?>> Matcher<M> aMapWithSize(int size) {
+        return aMapWithSize(equalTo(size));
     }
 
     /**
@@ -61,7 +60,7 @@ public final class IsMapWithSize<K, V, M extends Map<K, V>> extends FeatureMatch
      *
      */
     @Factory
-    public static <K, V, M extends Map<K, V>> Matcher<M> anEmptyMap() {
-        return IsMapWithSize.<K, V, M>aMapWithSize(equalTo(0));
+    public static <M extends Map<?, ?>> Matcher<M> anEmptyMap() {
+        return aMapWithSize(equalTo(0));
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -11,13 +11,13 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * Matches if map size satisfies a nested matcher.
  */
-public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ? extends V>, Integer> {
+public final class IsMapWithSize<K, V, M extends Map<K, V>> extends FeatureMatcher<M, Integer> {
     public IsMapWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a map with size", "map size");
     }
 
     @Override
-    protected Integer featureValueOf(Map<? extends K, ? extends V> actual) {
+    protected Integer featureValueOf(M actual) {
       return actual.size();
     }
 
@@ -27,13 +27,13 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * <p/>
      * For example:
      * <pre>assertThat(myMap, is(aMapWithSize(equalTo(2))))</pre>
-     * 
+     *
      * @param sizeMatcher
      *     a matcher for the size of an examined {@link java.util.Map}
      */
     @Factory
-    public static <K, V> Matcher<Map<? extends K, ? extends V>> aMapWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsMapWithSize<K, V>(sizeMatcher);
+    public static <K, V, M extends Map<K, V>> Matcher<M> aMapWithSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsMapWithSize<K, V, M>(sizeMatcher);
     }
 
     /**
@@ -42,26 +42,26 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * <p/>
      * For example:
      * <pre>assertThat(myMap, is(aMapWithSize(2)))</pre>
-     * 
+     *
      * @param size
      *     the expected size of an examined {@link java.util.Map}
      */
     @Factory
-    public static <K, V> Matcher<Map<? extends K, ? extends V>> aMapWithSize(int size) {
+    public static <K, V, M extends Map<K, V>> Matcher<M> aMapWithSize(int size) {
         Matcher<? super Integer> matcher = equalTo(size);
-        return IsMapWithSize.<K, V>aMapWithSize(matcher);
+        return IsMapWithSize.<K, V, M>aMapWithSize(matcher);
     }
-    
+
     /**
      * Creates a matcher for {@link java.util.Map}s that matches when the <code>size()</code> method returns
      * zero.
      * <p/>
      * For example:
      * <pre>assertThat(myMap, is(anEmptyMap()))</pre>
-     * 
+     *
      */
     @Factory
-    public static <K, V> Matcher<Map<? extends K, ? extends V>> anEmptyMap() {
-        return IsMapWithSize.<K, V>aMapWithSize(equalTo(0));
+    public static <K, V, M extends Map<K, V>> Matcher<M> anEmptyMap() {
+        return IsMapWithSize.<K, V, M>aMapWithSize(equalTo(0));
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -5,7 +5,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Factory;
 import org.hamcrest.TypeSafeMatcher;
 
-public class IsCompatibleType<T> extends TypeSafeMatcher<Class<T>> {
+public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
     private final Class<T> type;
 
     public IsCompatibleType(Class<T> type) {
@@ -13,12 +13,12 @@ public class IsCompatibleType<T> extends TypeSafeMatcher<Class<T>> {
     }
 
     @Override
-    public boolean matchesSafely(Class<T> cls) {
+    public boolean matchesSafely(Class<?> cls) {
         return type.isAssignableFrom(cls);
     }
 
     @Override
-    public void describeMismatchSafely(Class<T> cls, Description mismatchDescription) {
+    public void describeMismatchSafely(Class<?> cls, Description mismatchDescription) {
       mismatchDescription.appendValue(cls.getName());
     }
 
@@ -38,7 +38,7 @@ public class IsCompatibleType<T> extends TypeSafeMatcher<Class<T>> {
      *     the base class to examine classes against
      */
     @Factory
-    public static <T> Matcher<Class<T>> typeCompatibleWith(Class<T> baseType) {
+    public static <T> Matcher<Class<?>> typeCompatibleWith(Class<T> baseType) {
         return new IsCompatibleType<T>(baseType);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -5,40 +5,40 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Factory;
 import org.hamcrest.TypeSafeMatcher;
 
-public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
+public class IsCompatibleType<T> extends TypeSafeMatcher<Class<T>> {
     private final Class<T> type;
-    
+
     public IsCompatibleType(Class<T> type) {
         this.type = type;
     }
-    
+
     @Override
-    public boolean matchesSafely(Class<?> cls) {
+    public boolean matchesSafely(Class<T> cls) {
         return type.isAssignableFrom(cls);
     }
-    
+
     @Override
-    public void describeMismatchSafely(Class<?> cls, Description mismatchDescription) {
+    public void describeMismatchSafely(Class<T> cls, Description mismatchDescription) {
       mismatchDescription.appendValue(cls.getName());
     }
-    
+
     @Override
     public void describeTo(Description description) {
         description.appendText("type < ").appendText(type.getName());
     }
-    
+
     /**
      * Creates a matcher of {@link Class} that matches when the specified baseType is
      * assignable from the examined class.
      * <p/>
      * For example:
      * <pre>assertThat(Integer.class, typeCompatibleWith(Number.class))</pre>
-     * 
+     *
      * @param baseType
      *     the base class to examine classes against
      */
     @Factory
-    public static <T> Matcher<Class<?>> typeCompatibleWith(Class<T> baseType) {
+    public static <T> Matcher<Class<T>> typeCompatibleWith(Class<T> baseType) {
         return new IsCompatibleType<T>(baseType);
     }
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -13,7 +13,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 /**
  * Tests if the value is an event announced by a specific object.
  */
-public class IsEventFrom<T extends EventObject> extends TypeSafeDiagnosingMatcher<T> {
+public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
     private final Class<?> eventClass;
     private final Object source;
 
@@ -62,8 +62,8 @@ public class IsEventFrom<T extends EventObject> extends TypeSafeDiagnosingMatche
      *     the source of the event
      */
     @Factory
-    public static <T extends EventObject> Matcher<T> eventFrom(Class<T> eventClass, Object source) {
-        return new IsEventFrom<T>(eventClass, source);
+    public static <T extends EventObject> Matcher<EventObject> eventFrom(Class<T> eventClass, Object source) {
+        return new IsEventFrom(eventClass, source);
     }
 
     /**

--- a/hamcrest-library/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -13,7 +13,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 /**
  * Tests if the value is an event announced by a specific object.
  */
-public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
+public class IsEventFrom<T extends EventObject> extends TypeSafeDiagnosingMatcher<T> {
     private final Class<?> eventClass;
     private final Object source;
 
@@ -28,7 +28,7 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
           mismatchDescription.appendText("item type was " + item.getClass().getName());
           return false;
         }
-        
+
         if (!eventHasSameSource(item)) {
           mismatchDescription.appendText("source was ").appendValue(item.getSource());
           return false;
@@ -36,7 +36,7 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
         return true;
     }
 
-    
+
     private boolean eventHasSameSource(EventObject ev) {
         return ev.getSource() == source;
     }
@@ -55,15 +55,15 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
      * </p>
      * For example:
      * <pre>assertThat(myEvent, is(eventFrom(PropertyChangeEvent.class, myBean)))</pre>
-     * 
+     *
      * @param eventClass
      *     the class of the event to match on
      * @param source
      *     the source of the event
      */
     @Factory
-    public static Matcher<EventObject> eventFrom(Class<? extends EventObject> eventClass, Object source) {
-        return new IsEventFrom(eventClass, source);
+    public static <T extends EventObject> Matcher<T> eventFrom(Class<T> eventClass, Object source) {
+        return new IsEventFrom<T>(eventClass, source);
     }
 
     /**
@@ -72,7 +72,7 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
      * </p>
      * For example:
      * <pre>assertThat(myEvent, is(eventFrom(myBean)))</pre>
-     * 
+     *
      * @param source
      *     the source of the event
      */

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/AbstractMatcherTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/AbstractMatcherTest.java
@@ -5,12 +5,12 @@ package org.hamcrest;
 import junit.framework.TestCase;
 import org.junit.Assert;
 
-public abstract class AbstractMatcherTest extends TestCase {
+public abstract class AbstractMatcherTest<T> extends TestCase {
 
   /**
    * Create an instance of the Matcher so some generic safety-net tests can be run on it.
    */
-  protected abstract Matcher<?> createMatcher();
+  protected abstract Matcher<T> createMatcher();
 
   public static <T> void assertMatches(String message, Matcher<? super T> matcher, T arg) {
     if (!matcher.matches(arg)) {
@@ -18,18 +18,18 @@ public abstract class AbstractMatcherTest extends TestCase {
     }
   }
 
-  public static <T> void assertDoesNotMatch(String message, Matcher<? super T> c, T arg) {
-    Assert.assertFalse(message, c.matches(arg));
+  public static <T> void assertDoesNotMatch(String message, Matcher<? super T> matcher, T arg) {
+    Assert.assertFalse(message, matcher.matches(arg));
   }
 
-  public static void assertDescription(String expected, Matcher<?> matcher) {
+  public static <T> void assertDescription(String expected, Matcher<? super T> matcher) {
     Description description = new StringDescription();
     description.appendDescriptionOf(matcher);
     Assert.assertEquals("Expected description", expected, description.toString().trim());
   }
 
   public static <T> void assertMismatchDescription(String expected, Matcher<? super T> matcher, T arg) {
-    Assert.assertFalse("Precondtion: Matcher should not match item.", matcher.matches(arg));
+    Assert.assertFalse("Precondition: Matcher should not match item.", matcher.matches(arg));
     Assert.assertEquals("Expected mismatch description", expected, mismatchDescription(matcher, arg));
   }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/CustomTypeSafeMatcherTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/CustomTypeSafeMatcherTest.java
@@ -1,6 +1,6 @@
 package org.hamcrest;
 
-public class CustomTypeSafeMatcherTest extends AbstractMatcherTest {
+public class CustomTypeSafeMatcherTest extends AbstractMatcherTest<String> {
     private static final String STATIC_DESCRIPTION = "I match non empty strings";
     private Matcher<String> customMatcher;
 
@@ -28,7 +28,7 @@ public class CustomTypeSafeMatcherTest extends AbstractMatcherTest {
     }
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return customMatcher;
     }
 }

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyTest.java
@@ -15,13 +15,13 @@ import org.hamcrest.Matcher;
  * @author Steve Freeman
  * @since 1.1.0
  */
-public class HasPropertyTest extends AbstractMatcherTest {
+public class HasPropertyTest extends AbstractMatcherTest<Object> {
 
     private final HasPropertyWithValueTest.BeanWithoutInfo bean
             = new HasPropertyWithValueTest.BeanWithoutInfo("a bean");
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Object> createMatcher() {
         return hasProperty("irrelevant");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -23,14 +23,14 @@ import org.hamcrest.core.IsEqual;
  * @author Steve Freeman
  * @since 1.1.0
  */
-public class HasPropertyWithValueTest extends AbstractMatcherTest {
+public class HasPropertyWithValueTest extends AbstractMatcherTest<Object> {
   private final BeanWithoutInfo shouldMatch = new BeanWithoutInfo("is expected");
   private final BeanWithoutInfo shouldNotMatch = new BeanWithoutInfo("not expected");
 
   private final BeanWithInfo beanWithInfo = new BeanWithInfo("with info");
 
   @Override
-  protected Matcher<?> createMatcher() {
+  protected Matcher<Object> createMatcher() {
     return hasProperty("irrelevant", anything());
   }
 
@@ -63,7 +63,7 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
   public void testMatchesPropertyAndValue() {
     assertMatches("property with value", hasProperty( "property", anything()), beanWithInfo);
   }
-  
+
   public void testDoesNotWriteMismatchIfPropertyMatches() {
     Description description = new StringDescription();
     hasProperty( "property", anything()).describeMismatch(beanWithInfo, description);
@@ -129,8 +129,8 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
     @Override
     public PropertyDescriptor[] getPropertyDescriptors() {
       try {
-        return new PropertyDescriptor[] { 
-            new PropertyDescriptor("property", BeanWithInfo.class, "property", null) 
+        return new PropertyDescriptor[] {
+            new PropertyDescriptor("property", BeanWithInfo.class, "property", null)
           };
       } catch (IntrospectionException e) {
         throw new RuntimeException("Introspection exception: " + e.getMessage());

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -7,14 +7,14 @@ import static org.hamcrest.beans.SamePropertyValuesAs.samePropertyValuesAs;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class SamePropertyValuesAsTest extends AbstractMatcherTest {
+public class SamePropertyValuesAsTest extends AbstractMatcherTest<SamePropertyValuesAsTest.ExampleBean> {
   private static final Value aValue = new Value("expected");
   private static final ExampleBean expectedBean = new ExampleBean("same", 1, aValue);
   private static final ExampleBean actualBean = new ExampleBean("same", 1, aValue);
   
   
   @Override
-  protected Matcher<?> createMatcher() {
+  protected Matcher<ExampleBean> createMatcher() {
     return samePropertyValuesAs(expectedBean);
   }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -6,15 +6,13 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
+public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest<Number[]> {
 
-    @SuppressWarnings("unchecked")
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Number[]> createMatcher() {
         return arrayContainingInAnyOrder(equalTo(1), equalTo(2));
     }
 
-    @SuppressWarnings("unchecked")
     public void testHasAReadableDescription() {
         assertDescription("[<1>, <2>] in any order", arrayContainingInAnyOrder(equalTo(1), equalTo(2)));
         assertDescription("[<1>, <2>] in any order", arrayContainingInAnyOrder(1, 2));
@@ -26,7 +24,6 @@ public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
       assertMatches("single", arrayContainingInAnyOrder(1), new Integer[] {1});
     }
 
-    @SuppressWarnings("unchecked")
     public void testAppliesMatchersInAnyOrder() {
       assertMatches("in order", arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
       assertMatches("out of order", arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {3, 2, 1});

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
@@ -6,15 +6,13 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
+public class IsArrayContainingInOrderTest extends AbstractMatcherTest<Number[]> {
 
-    @SuppressWarnings("unchecked")
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Number[]> createMatcher() {
         return arrayContaining(equalTo(1), equalTo(2));
     }
 
-    @SuppressWarnings("unchecked")
     public void testHasAReadableDescription() {
         assertDescription("[<1>, <2>]", arrayContaining(equalTo(1), equalTo(2)));
     }
@@ -24,7 +22,6 @@ public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
       assertMatches("single", arrayContaining(1), new Integer[] {1});
     }
 
-    @SuppressWarnings("unchecked")
     public void testAppliesMatchersInOrder() {
       assertMatches("in order", arrayContaining(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
       assertMatches("single", arrayContaining(equalTo(1)), new Integer[] {1});

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayContainingTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayContainingTest.java
@@ -4,10 +4,10 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
 
-public class IsArrayContainingTest extends AbstractMatcherTest {
+public class IsArrayContainingTest extends AbstractMatcherTest<String[]> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String[]> createMatcher() {
         return hasItemInArray("irrelevant");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayTest.java
@@ -9,10 +9,10 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
 @SuppressWarnings("unchecked")
-public class IsArrayTest extends AbstractMatcherTest {
+public class IsArrayTest extends AbstractMatcherTest<String[]> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String[]> createMatcher() {
         return array(equalTo("irrelevant"));
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayWithSizeTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsArrayWithSizeTest.java
@@ -7,10 +7,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsArrayWithSizeTest extends AbstractMatcherTest {
+public class IsArrayWithSizeTest extends AbstractMatcherTest<Number[]> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Number[]> createMatcher() {
         return arrayWithSize(equalTo(2));
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionContainingTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionContainingTest.java
@@ -24,18 +24,18 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
     }
 
     public void testMatchesACollectionThatContainsAnElementMatchingTheGivenMatcher() {
-        Matcher<Iterable<? super String>> itemMatcher = hasItem(equalTo("a"));
+        Matcher<Iterable<String>> itemMatcher = hasItem(equalTo("a"));
         
         assertMatches("should match list that contains 'a'",
                 itemMatcher, asList("a", "b", "c"));
     }
 
     public void testDoesNotMatchCollectionThatDoesntContainAnElementMatchingTheGivenMatcher() {
-        final Matcher<Iterable<? super String>> matcher1 = hasItem(mismatchable("a"));
+        final Matcher<Iterable<String>> matcher1 = hasItem(mismatchable("a"));
         assertMismatchDescription("was a collection that did not contain mismatchable: a -- mismatches were: [mismatched: b, mismatched: c]",
                                   matcher1, asList("b", "c"));
         
-        final Matcher<Iterable<? super String>> matcher2 = hasItem(equalTo("a"));
+        final Matcher<Iterable<String>> matcher2 = hasItem(equalTo("a"));
         assertMismatchDescription("was an empty collection", matcher2, new ArrayList<String>());
     }
 
@@ -52,7 +52,7 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
       final Set<Number> s = new HashSet<Number>();
       s.add(Integer.valueOf(2));
       assertThat(s, new IsCollectionContaining<Number>(new IsEqual<Number>(Integer.valueOf(2))));
-      assertThat(s, IsCollectionContaining.hasItem(Integer.valueOf(2)));
+      assertThat(s, IsCollectionContaining.hasItem((Number) Integer.valueOf(2)));
     }
 
     @SuppressWarnings("unchecked")

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionContainingTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionContainingTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,9 +18,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
 
-public class IsCollectionContainingTest extends AbstractMatcherTest {
+public class IsCollectionContainingTest extends AbstractMatcherTest<Iterable<String>> {
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Iterable<String>> createMatcher() {
         return hasItem(equalTo("irrelevant"));
     }
 
@@ -51,11 +52,10 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
     {
       final Set<Number> s = new HashSet<Number>();
       s.add(Integer.valueOf(2));
-      assertThat(s, new IsCollectionContaining<Number>(new IsEqual<Number>(Integer.valueOf(2))));
+      assertThat(s, new IsCollectionContaining<Collection<Number>>(new IsEqual<Number>(Integer.valueOf(2))));
       assertThat(s, IsCollectionContaining.hasItem((Number) Integer.valueOf(2)));
     }
 
-    @SuppressWarnings("unchecked")
     public void testMatchesAllItemsInCollection() {
         final Matcher<Iterable<String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("should match list containing all items",

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
@@ -6,12 +6,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Collection;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 
 public class IsCollectionWithSizeTest extends AbstractMatcherTest {
 
@@ -69,7 +71,7 @@ public class IsCollectionWithSizeTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("a collection with size <3>", hasSize(equalTo(3)));
     }
-    
+
     public void testCompilesWithATypedCollection() {
       // To prove Issue 43
       ArrayList<String> arrayList = new ArrayList<String>();

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
@@ -6,19 +6,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Collection;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 
-public class IsCollectionWithSizeTest extends AbstractMatcherTest {
+public class IsCollectionWithSizeTest extends AbstractMatcherTest<Collection<String>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Collection<String>> createMatcher() {
         return hasSize(7);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsEmptyCollectionTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsEmptyCollectionTest.java
@@ -10,10 +10,10 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 
-public class IsEmptyCollectionTest extends AbstractMatcherTest {
+public class IsEmptyCollectionTest extends AbstractMatcherTest<Collection<String>> {
 
     @Override
-    protected Matcher<Collection<?>> createMatcher() {
+    protected Matcher<Collection<String>> createMatcher() {
         return empty();
     }
 
@@ -39,7 +39,7 @@ public class IsEmptyCollectionTest extends AbstractMatcherTest {
         return new ArrayList<String>(asList("one", "three"));
     }
 
-    private static Collection<Integer> emptyCollection() {
-        return new ArrayList<Integer>();
+    private static Collection<String> emptyCollection() {
+        return new ArrayList<String>();
     }
 }

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsEmptyIterableTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsEmptyIterableTest.java
@@ -9,10 +9,10 @@ import org.hamcrest.Matcher;
 import static java.util.Arrays.asList;
 import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
 
-public class IsEmptyIterableTest extends AbstractMatcherTest {
+public class IsEmptyIterableTest extends AbstractMatcherTest<Iterable<String>> {
 
     @Override
-    protected Matcher<Iterable<?>> createMatcher() {
+    protected Matcher<Iterable<String>> createMatcher() {
         return emptyIterable();
     }
 
@@ -38,7 +38,7 @@ public class IsEmptyIterableTest extends AbstractMatcherTest {
         return new ArrayList<String>(asList("one", "three"));
     }
 
-    private static Collection<Integer> emptyCollection() {
-        return new ArrayList<Integer>();
+    private static Collection<String> emptyCollection() {
+        return new ArrayList<String>();
     }
 }

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsInTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsInTest.java
@@ -7,11 +7,11 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
-public class IsInTest extends AbstractMatcherTest {
+public class IsInTest extends AbstractMatcherTest<String> {
     String[] elements = {"a", "b", "c"};
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return new IsIn<String>(elements);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
@@ -1,20 +1,16 @@
 package org.hamcrest.collection;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
-import org.hamcrest.collection.IsIterableContainingInOrderTest.WithValue;
 
-import java.util.Collections;
-
-import static java.util.Arrays.asList;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.hamcrest.collection.IsIterableContainingInOrderTest.make;
-import static org.hamcrest.collection.IsIterableContainingInOrderTest.value;
-
-public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
+public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest<Iterable<Number>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Iterable<Number>> createMatcher() {
         return containsInAnyOrder(1, 2);
     }   
 
@@ -23,7 +19,7 @@ public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
     }
 
     public void testDoesNotMatchEmpty() {
-        assertMismatchDescription("No item matches: <1>, <2> in []", containsInAnyOrder(1, 2), Collections.<Integer>emptyList());
+        assertMismatchDescription("No item matches: <1>, <2> in []", containsInAnyOrder(1, 2), emptyList());
     }
     
     public void testMatchesIterableOutOfOrder() {
@@ -38,10 +34,8 @@ public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
         assertMismatchDescription("Not matched: <4>", containsInAnyOrder(1, 2, 3), asList(1, 2, 4));
     }
 
-    @SuppressWarnings("unchecked")
     public void testDoesNotMatchIfThereAreMoreElementsThanMatchers() {
-        Matcher<Iterable<? extends WithValue>> helpTheCompilerOut = containsInAnyOrder(value(1), value(3));
-        assertMismatchDescription("Not matched: <WithValue 2>", helpTheCompilerOut, asList(make(1), make(2), make(3)));
+        assertMismatchDescription("Not matched: <2>", containsInAnyOrder(1, 3), asList(1, 2, 3));
     }
     
     public void testDoesNotMatchIfThereAreMoreMatchersThanElements() {

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
@@ -11,13 +11,12 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@SuppressWarnings("unchecked")
-public class IsIterableContainingInOrderTest extends AbstractMatcherTest {
+public class IsIterableContainingInOrderTest extends AbstractMatcherTest<Iterable<Integer>> {
     // temporary hack until the Java type system works
-    private final Matcher<Iterable<? extends WithValue>> contains123 = contains(value(1), value(2), value(3));
+    private final Matcher<Iterable<WithValue>> contains123 = contains(value(1), value(2), value(3));
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Iterable<Integer>> createMatcher() {
         return contains(1, 2);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsIterableWithSizeTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsIterableWithSizeTest.java
@@ -7,10 +7,10 @@ import java.util.Collections;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsIterableWithSizeTest extends AbstractMatcherTest {
+public class IsIterableWithSizeTest extends AbstractMatcherTest<Iterable<Number>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Iterable<Number>> createMatcher() {
         return iterableWithSize(7);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -10,10 +10,10 @@ import java.util.TreeMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 
-public class IsMapContainingKeyTest extends AbstractMatcherTest {
+public class IsMapContainingKeyTest extends AbstractMatcherTest<Map<String,String>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Map<String,String>> createMatcher() {
         return hasKey("foo");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapContainingTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapContainingTest.java
@@ -10,11 +10,11 @@ import org.hamcrest.Matcher;
 import java.util.Map;
 import java.util.TreeMap;
 
-public class IsMapContainingTest extends AbstractMatcherTest {
+public class IsMapContainingTest extends AbstractMatcherTest<Map<String,String>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
-        return IsMapContaining.hasEntry("irrelevant", "irrelevant");
+    protected Matcher<Map<String,String>> createMatcher() {
+        return hasEntry("irrelevant", "irrelevant");
     }
 
     public void testMatchesMapContainingMatchingKeyAndValue() {

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -10,11 +10,11 @@ import java.util.TreeMap;
 
 import static org.hamcrest.collection.IsMapContaining.hasValue;
 
-public class IsMapContainingValueTest extends AbstractMatcherTest {
+public class IsMapContainingValueTest extends AbstractMatcherTest<Map<String, String>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
-        return hasValue("foo");
+    protected Matcher<Map<String, String>> createMatcher() {
+        return IsMapContaining.hasValue("foo");
     }
 
     public void testHasReadableDescription() {

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapWithSizeTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/collection/IsMapWithSizeTest.java
@@ -10,10 +10,10 @@ import org.hamcrest.MatcherAssert;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public final class IsMapWithSizeTest extends AbstractMatcherTest {
+public final class IsMapWithSizeTest extends AbstractMatcherTest<Map<String,String>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Map<String,String>> createMatcher() {
         return aMapWithSize(7);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/AllOfTest.java
@@ -13,12 +13,12 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
-public class AllOfTest extends AbstractMatcherTest {
+public class AllOfTest extends AbstractMatcherTest<String> {
 
     @Override
     @SuppressWarnings("unchecked")
-    protected Matcher<?> createMatcher() {
-        return allOf(IsEqual.<Object>equalTo("irrelevant"));
+    protected Matcher<String> createMatcher() {
+        return allOf(equalTo("irrelevant"));
     }
     
     public void testEvaluatesToTheTheLogicalConjunctionOfTwoOtherMatchers() {

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/AnyOfTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/AnyOfTest.java
@@ -10,12 +10,12 @@ import static org.hamcrest.core.IsNot.not;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class AnyOfTest extends AbstractMatcherTest {
+public class AnyOfTest extends AbstractMatcherTest<String> {
 
     @Override
     @SuppressWarnings("unchecked")
-    protected Matcher<?> createMatcher() {
-        return anyOf(IsEqual.<Object>equalTo("irrelevant"));
+    protected Matcher<String> createMatcher() {
+        return anyOf(equalTo("irrelevant"));
     }
 
     public void testEvaluatesToTheTheLogicalDisjunctionOfTwoOtherMatchers() {

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/DescribedAsTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/DescribedAsTest.java
@@ -11,22 +11,22 @@ import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 
-public class DescribedAsTest extends AbstractMatcherTest {
+public class DescribedAsTest extends AbstractMatcherTest<Object> {
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Object> createMatcher() {
         return describedAs("irrelevant", anything());
     }
 
     public void testOverridesDescriptionOfOtherMatcherWithThatPassedToConstructor() {
-        Matcher<?> m1 = describedAs("m1 description", anything());
-        Matcher<?> m2 = describedAs("m2 description", not(anything()));
+        Matcher<Object> m1 = describedAs("m1 description", anything());
+        Matcher<Object> m2 = describedAs("m2 description", not(anything()));
 
         assertDescription("m1 description", m1);
         assertDescription("m2 description", m2);
     }
 
     public void testAppendsValuesToDescription() {
-        Matcher<?> m = describedAs("value 1 = %0, value 2 = %1",
+        Matcher<Object> m = describedAs("value 1 = %0, value 2 = %1",
                 anything(), 33, 97);
 
         assertDescription("value 1 = <33>, value 2 = <97>", m);

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/EveryTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/EveryTest.java
@@ -22,7 +22,7 @@ public class EveryTest {
     }
 
     @Test public void describesItself() {
-        final Every<String> each=  new Every<String>(containsString("a"));
+        final Every<Iterable<String>> each= new Every<Iterable<String>>(containsString("a"));
         assertEquals("every item is a string containing \"a\"", each.toString());
         
         StringDescription description = new StringDescription(); 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsAnythingTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsAnythingTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.core.IsAnything.anything;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsAnythingTest extends AbstractMatcherTest {
+public class IsAnythingTest extends AbstractMatcherTest<Object> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Object> createMatcher() {
         return anything();
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsEqualTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsEqualTest.java
@@ -10,10 +10,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 
 
-public class IsEqualTest extends AbstractMatcherTest {
+public class IsEqualTest extends AbstractMatcherTest<String> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return equalTo("irrelevant");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsInstanceOfTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsInstanceOfTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.*;
 import static org.hamcrest.core.IsNot.not;
 
-public class IsInstanceOfTest extends AbstractMatcherTest {
+public class IsInstanceOfTest extends AbstractMatcherTest<Class<Number>> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Class<Number>> createMatcher() {
         return instanceOf(Number.class);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNotTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNotTest.java
@@ -9,9 +9,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 
-public class IsNotTest extends AbstractMatcherTest {
+public class IsNotTest extends AbstractMatcherTest<String> {
   @Override
-  protected Matcher<?> createMatcher() {
+  protected Matcher<String> createMatcher() {
     return not("something");
   }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNullTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNullTest.java
@@ -13,11 +13,11 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 
-public class IsNullTest extends AbstractMatcherTest {
+public class IsNullTest extends AbstractMatcherTest<Object> {
     private static final BigDecimal ANY_NON_NULL_ARGUMENT = new BigDecimal(66);
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Object> createMatcher() {
         return nullValue();
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsSameTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsSameTest.java
@@ -10,10 +10,10 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
-public class IsSameTest extends AbstractMatcherTest {
+public class IsSameTest extends AbstractMatcherTest<String> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return sameInstance("irrelevant");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/core/IsTest.java
@@ -6,10 +6,10 @@ import static org.hamcrest.core.Is.isA;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsTest extends AbstractMatcherTest {
+public class IsTest extends AbstractMatcherTest<String> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return is("something");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/io/FileMatchersTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/io/FileMatchersTest.java
@@ -8,7 +8,7 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
-public class FileMatchersTest extends AbstractMatcherTest {
+public class FileMatchersTest extends AbstractMatcherTest<File> {
 
     private File directory;
     private File file;
@@ -96,7 +96,7 @@ public class FileMatchersTest extends AbstractMatcherTest {
     }
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<File> createMatcher() {
         return FileMatchers.aFileWithSize(1L);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/number/BigDecimalCloseToTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/number/BigDecimalCloseToTest.java
@@ -7,11 +7,11 @@ import java.math.BigDecimal;
 
 import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
 
-public class BigDecimalCloseToTest  extends AbstractMatcherTest {
+public class BigDecimalCloseToTest  extends AbstractMatcherTest<BigDecimal> {
   private final Matcher<BigDecimal> matcher = closeTo(new BigDecimal("1.0"), new BigDecimal("0.5"));
 
   @Override
-  protected Matcher<?> createMatcher() {
+  protected Matcher<BigDecimal> createMatcher() {
     BigDecimal irrelevant = new BigDecimal("0.01");
     return closeTo(irrelevant, irrelevant);
   }

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/number/IsCloseToTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/number/IsCloseToTest.java
@@ -7,11 +7,11 @@ import org.hamcrest.Matcher;
 
 import static org.hamcrest.number.IsCloseTo.closeTo;
 
-public class IsCloseToTest extends AbstractMatcherTest {
+public class IsCloseToTest extends AbstractMatcherTest<Double> {
   private final Matcher<Double> matcher = closeTo(1.0d, 0.5d);
 
   @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Double> createMatcher() {
         final double irrelevant = 0.1;
         return closeTo(irrelevant, irrelevant);
     }

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/number/OrderingComparisonTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/number/OrderingComparisonTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.number.OrderingComparison.*;
 
-public class OrderingComparisonTest extends AbstractMatcherTest {
+public class OrderingComparisonTest extends AbstractMatcherTest<Integer> {
 
     @Override
     protected Matcher<Integer> createMatcher() {

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/object/HasToStringTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/object/HasToStringTest.java
@@ -9,7 +9,7 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
-public class HasToStringTest extends AbstractMatcherTest {
+public class HasToStringTest extends AbstractMatcherTest<Object> {
     private static final String TO_STRING_RESULT = "toString result";
     private static final Object ARG = new Object() {
         @Override
@@ -19,7 +19,7 @@ public class HasToStringTest extends AbstractMatcherTest {
     };
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Object> createMatcher() {
         return hasToString(equalTo("irrelevant"));
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/object/IsCompatibleTypeTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/object/IsCompatibleTypeTest.java
@@ -5,7 +5,7 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 
-public class IsCompatibleTypeTest extends AbstractMatcherTest {
+public class IsCompatibleTypeTest extends AbstractMatcherTest<Class<?>> {
     public static class BaseClass {
     }
 
@@ -22,7 +22,7 @@ public class IsCompatibleTypeTest extends AbstractMatcherTest {
     }
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Class<?>> createMatcher() {
         return typeCompatibleWith(BaseClass.class);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/object/IsEventFromTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/object/IsEventFromTest.java
@@ -11,10 +11,10 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 
-public class IsEventFromTest extends AbstractMatcherTest {
+public class IsEventFromTest extends AbstractMatcherTest<EventObject> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<EventObject> createMatcher() {
         return eventFrom(null);
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEmptyStringTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEmptyStringTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.text.IsEmptyString.emptyString;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsEmptyStringTest extends AbstractMatcherTest {
+public class IsEmptyStringTest extends AbstractMatcherTest<String> {
 
   @Override
-  protected Matcher<?> createMatcher() {
+  protected Matcher<String> createMatcher() {
     return emptyOrNullString();
   }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
-public class IsEqualIgnoringCaseTest extends AbstractMatcherTest {
+public class IsEqualIgnoringCaseTest extends AbstractMatcherTest<String> {
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return equalToIgnoringCase("irrelevant");
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpaceTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpaceTest.java
@@ -8,12 +8,12 @@ import static org.hamcrest.text.IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSp
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsEqualIgnoringWhiteSpaceTest extends AbstractMatcherTest {
+public class IsEqualIgnoringWhiteSpaceTest extends AbstractMatcherTest<String> {
 
     private final Matcher<String> matcher = equalToIgnoringWhiteSpace("Hello World   how\n are we? ");
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return matcher;
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -6,11 +6,11 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 
-public class StringContainsInOrderTest extends AbstractMatcherTest {
+public class StringContainsInOrderTest extends AbstractMatcherTest<String> {
     StringContainsInOrder m = new StringContainsInOrder(asList("a", "b", "c"));
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return m;
     }
     

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringContainsTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringContainsTest.java
@@ -8,12 +8,12 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 
-public class StringContainsTest extends AbstractMatcherTest {
+public class StringContainsTest extends AbstractMatcherTest<String> {
     static final String EXCERPT = "EXCERPT";
     Matcher<String> stringContains = containsString(EXCERPT);
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return stringContains;
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringEndsWithTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringEndsWithTest.java
@@ -8,12 +8,12 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 
-public class StringEndsWithTest extends AbstractMatcherTest {
+public class StringEndsWithTest extends AbstractMatcherTest<String> {
     static final String EXCERPT = "EXCERPT";
     Matcher<String> stringEndsWith = endsWith(EXCERPT);
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return stringEndsWith;
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringStartsWithTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/text/StringStartsWithTest.java
@@ -8,12 +8,12 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 
-public class StringStartsWithTest extends AbstractMatcherTest {
+public class StringStartsWithTest extends AbstractMatcherTest<String> {
     static final String EXCERPT = "EXCERPT";
     Matcher<String> stringStartsWith = startsWith(EXCERPT);
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<String> createMatcher() {
         return stringStartsWith;
     }
 

--- a/hamcrest-unit-test/src/main/java/org/hamcrest/xml/HasXPathTest.java
+++ b/hamcrest-unit-test/src/main/java/org/hamcrest/xml/HasXPathTest.java
@@ -17,11 +17,12 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 /**
  * @author Joe Walnes
  */
-public class HasXPathTest extends AbstractMatcherTest {
+public class HasXPathTest extends AbstractMatcherTest<Node> {
     private Document xml;
     private NamespaceContext ns;
 
@@ -61,7 +62,7 @@ public class HasXPathTest extends AbstractMatcherTest {
     }
 
     @Override
-    protected Matcher<?> createMatcher() {
+    protected Matcher<Node> createMatcher() {
         return hasXPath("//irrelevant");
     }
 


### PR DESCRIPTION
Currently, the Matchers.hasItem(s) factory methods accept one or more
Matcher<? super T> and return a Matcher< Iterable<? super T>>. The wildcard
in the return type makes it difficult to use hasItem matchers in assert
statements.

This commit modifies the factory method return type to simply
Matcher< Iterable<T\>\>.