### PR TITLE
Improve generics on some collection matchers. 

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -739,7 +739,7 @@ public class Matchers {
    * @param sizeMatcher
    *     a matcher for the length of an examined array
    */
-  public static <E> org.hamcrest.Matcher<E[]> arrayWithSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
+  public static org.hamcrest.Matcher<Object[]> arrayWithSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
     return org.hamcrest.collection.IsArrayWithSize.arrayWithSize(sizeMatcher);
   }
 
@@ -752,7 +752,7 @@ public class Matchers {
    * @param size
    *     the length that an examined array must have for a positive match
    */
-  public static <E> org.hamcrest.Matcher<E[]> arrayWithSize(int size) {
+  public static org.hamcrest.Matcher<Object[]> arrayWithSize(int size) {
     return org.hamcrest.collection.IsArrayWithSize.arrayWithSize(size);
   }
 
@@ -762,7 +762,7 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new String[0], emptyArray())</pre>
    */
-  public static <E> org.hamcrest.Matcher<E[]> emptyArray() {
+  public static org.hamcrest.Matcher<Object[]> emptyArray() {
     return org.hamcrest.collection.IsArrayWithSize.emptyArray();
   }
 
@@ -775,7 +775,7 @@ public class Matchers {
    * @param sizeMatcher
    *     a matcher for the size of an examined {@link java.util.Map}
    */
-  public static <K, V> org.hamcrest.Matcher<java.util.Map<? extends K,? extends V>> aMapWithSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
+  public static org.hamcrest.Matcher<java.util.Map<?, ?>> aMapWithSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
     return org.hamcrest.collection.IsMapWithSize.aMapWithSize(sizeMatcher);
   }
 
@@ -788,7 +788,7 @@ public class Matchers {
    * @param size
    *     the expected size of an examined {@link java.util.Map}
    */
-  public static <K, V> org.hamcrest.Matcher<java.util.Map<? extends K,? extends V>> aMapWithSize(int size) {
+  public static org.hamcrest.Matcher<java.util.Map<?, ?>> aMapWithSize(int size) {
     return org.hamcrest.collection.IsMapWithSize.aMapWithSize(size);
   }
 
@@ -798,7 +798,7 @@ public class Matchers {
    * For example:
    * <pre>assertThat(myMap, is(anEmptyMap()))</pre>
    */
-  public static <K, V> org.hamcrest.Matcher<java.util.Map<? extends K,? extends V>> anEmptyMap() {
+  public static org.hamcrest.Matcher<java.util.Map<?, ?>> anEmptyMap() {
     return org.hamcrest.collection.IsMapWithSize.anEmptyMap();
   }
 
@@ -811,7 +811,7 @@ public class Matchers {
    * @param sizeMatcher
    *     a matcher for the size of an examined {@link java.util.Collection}
    */
-  public static <E> org.hamcrest.Matcher<java.util.Collection<? extends E>> hasSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
+  public static org.hamcrest.Matcher<java.util.Collection<?>> hasSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
     return org.hamcrest.collection.IsCollectionWithSize.hasSize(sizeMatcher);
   }
 
@@ -824,7 +824,7 @@ public class Matchers {
    * @param size
    *     the expected size of an examined {@link java.util.Collection}
    */
-  public static <E> org.hamcrest.Matcher<java.util.Collection<? extends E>> hasSize(int size) {
+  public static org.hamcrest.Matcher<java.util.Collection<?>> hasSize(int size) {
     return org.hamcrest.collection.IsCollectionWithSize.hasSize(size);
   }
 
@@ -834,7 +834,7 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new ArrayList&lt;String&gt;(), is(empty()))</pre>
    */
-  public static <E> org.hamcrest.Matcher<java.util.Collection<? extends E>> empty() {
+  public static org.hamcrest.Matcher<java.util.Collection<?>> empty() {
     return org.hamcrest.collection.IsEmptyCollection.empty();
   }
 
@@ -846,8 +846,11 @@ public class Matchers {
    * 
    * @param unusedToForceReturnType
    *     the type of the collection's content
+   *
+   * @deprecated This method is superfluous. Use {@link #empty()} instead.
    */
-  public static <E> org.hamcrest.Matcher<java.util.Collection<E>> emptyCollectionOf(java.lang.Class<E> unusedToForceReturnType) {
+  @Deprecated
+  public static org.hamcrest.Matcher<java.util.Collection<?>> emptyCollectionOf(java.lang.Class<?> unusedToForceReturnType) {
     return org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf(unusedToForceReturnType);
   }
 
@@ -856,7 +859,7 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterable()))</pre>
    */
-  public static <E> org.hamcrest.Matcher<java.lang.Iterable<? extends E>> emptyIterable() {
+  public static org.hamcrest.Matcher<java.lang.Iterable<?>> emptyIterable() {
     return org.hamcrest.collection.IsEmptyIterable.emptyIterable();
   }
 
@@ -867,8 +870,11 @@ public class Matchers {
    * 
    * @param unusedToForceReturnType
    *     the type of the iterable's content
+   *
+   * @deprecated This method is superfluous. Use {@link #emptyIterable()} instead.
    */
-  public static <E> org.hamcrest.Matcher<java.lang.Iterable<E>> emptyIterableOf(java.lang.Class<E> unusedToForceReturnType) {
+  @Deprecated
+  public static org.hamcrest.Matcher<java.lang.Iterable<?>> emptyIterableOf(java.lang.Class<?> unusedToForceReturnType) {
     return org.hamcrest.collection.IsEmptyIterable.emptyIterableOf(unusedToForceReturnType);
   }
 
@@ -1062,7 +1068,7 @@ public class Matchers {
    * @param sizeMatcher
    *     a matcher for the number of items that should be yielded by an examined {@link Iterable}
    */
-  public static <E> org.hamcrest.Matcher<java.lang.Iterable<E>> iterableWithSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
+  public static org.hamcrest.Matcher<java.lang.Iterable<?>> iterableWithSize(org.hamcrest.Matcher<? super java.lang.Integer> sizeMatcher) {
     return org.hamcrest.collection.IsIterableWithSize.iterableWithSize(sizeMatcher);
   }
 
@@ -1076,7 +1082,7 @@ public class Matchers {
    * @param size
    *     the number of items that should be yielded by an examined {@link Iterable}
    */
-  public static <E> org.hamcrest.Matcher<java.lang.Iterable<E>> iterableWithSize(int size) {
+  public static org.hamcrest.Matcher<java.lang.Iterable<?>> iterableWithSize(int size) {
     return org.hamcrest.collection.IsIterableWithSize.iterableWithSize(size);
   }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
@@ -9,13 +9,13 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * Matches if array size satisfies a nested matcher.
  */
-public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
+public class IsArrayWithSize extends FeatureMatcher<Object[], Integer> {
     public IsArrayWithSize(Matcher<? super Integer> sizeMatcher) {
         super(sizeMatcher, "an array with size","array size");
     }
 
     @Override
-    protected Integer featureValueOf(E[] actual) {
+    protected Integer featureValueOf(Object[] actual) {
       return actual.length;
     }
 
@@ -28,8 +28,8 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
      * @param sizeMatcher
      *     a matcher for the length of an examined array
      */
-    public static <E> Matcher<E[]> arrayWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsArrayWithSize<>(sizeMatcher);
+    public static Matcher<Object[]> arrayWithSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsArrayWithSize(sizeMatcher);
     }
 
     /**
@@ -41,7 +41,7 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
      * @param size
      *     the length that an examined array must have for a positive match
      */
-    public static <E> Matcher<E[]> arrayWithSize(int size) {
+    public static Matcher<Object[]> arrayWithSize(int size) {
         return arrayWithSize(equalTo(size));
     }
 
@@ -52,7 +52,7 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
      * <pre>assertThat(new String[0], emptyArray())</pre>
      * 
      */
-    public static <E> Matcher<E[]> emptyArray() {
-        return describedAs("an empty array", IsArrayWithSize.<E>arrayWithSize(0));
+    public static Matcher<Object[]> emptyArray() {
+        return describedAs("an empty array", arrayWithSize(0));
     }
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -2,49 +2,49 @@ package org.hamcrest.collection;
 
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
+import org.hamcrest.core.IsEqual;
 
 import java.util.Collection;
-
-import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Matches if collection size satisfies a nested matcher.
  */
-public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends E>, Integer> {
+public class IsCollectionWithSize extends FeatureMatcher<Collection<?>, Integer> {
     public IsCollectionWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a collection with size", "collection size");
     }
 
     @Override
-    protected Integer featureValueOf(Collection<? extends E> actual) {
+    protected Integer featureValueOf(Collection<?> actual) {
       return actual.size();
     }
 
     /**
      * Creates a matcher for {@link java.util.Collection}s that matches when the <code>size()</code> method returns
      * a value that satisfies the specified matcher.
+     *
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(equalTo(2)))</pre>
      * 
      * @param sizeMatcher
      *     a matcher for the size of an examined {@link java.util.Collection}
      */
-    public static <E> Matcher<Collection<? extends E>> hasSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsCollectionWithSize<E>(sizeMatcher);
+    public static Matcher<Collection<?>> hasSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsCollectionWithSize(sizeMatcher);
     }
 
     /**
      * Creates a matcher for {@link java.util.Collection}s that matches when the <code>size()</code> method returns
      * a value equal to the specified <code>size</code>.
+     *
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(2))</pre>
      * 
      * @param size
      *     the expected size of an examined {@link java.util.Collection}
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <E> Matcher<Collection<? extends E>> hasSize(int size) {
-        return (Matcher)IsCollectionWithSize.hasSize(equalTo(size));
+    public static Matcher<Collection<?>> hasSize(int size) {
+       return hasSize(IsEqual.equalTo(size));
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -9,15 +9,15 @@ import java.util.Collection;
 /**
  * Tests if collection is empty.
  */
-public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E>> {
+public class IsEmptyCollection extends TypeSafeMatcher<Collection<?>> {
 
     @Override
-    public boolean matchesSafely(Collection<? extends E> item) {
+    public boolean matchesSafely(Collection<?> item) {
         return item.isEmpty();
     }
 
     @Override
-    public void describeMismatchSafely(Collection<? extends E> item, Description mismatchDescription) {
+    public void describeMismatchSafely(Collection<?> item, Description mismatchDescription) {
       mismatchDescription.appendValue(item);
     }
 
@@ -33,8 +33,8 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(empty()))</pre>
      * 
      */
-    public static <E> Matcher<Collection<? extends E>> empty() {
-        return new IsEmptyCollection<E>();
+    public static Matcher<Collection<?>> empty() {
+        return new IsEmptyCollection();
     }
 
     /**
@@ -45,9 +45,12 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * 
      * @param unusedToForceReturnType
      *     the type of the collection's content
+     *
+     * @deprecated This method is superfluous. Use {@link #empty()} instead.
      */
-    @SuppressWarnings({"unchecked", "UnusedParameters"})
-    public static <E> Matcher<Collection<E>> emptyCollectionOf(Class<E> unusedToForceReturnType) {
-      return (Matcher)empty();
+    @Deprecated
+    @SuppressWarnings({"UnusedParameters"})
+    public static Matcher<Collection<?>> emptyCollectionOf(Class<?> unusedToForceReturnType) {
+      return empty();
     }
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
@@ -7,14 +7,14 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Tests if collection is empty.
  */
-public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
+public class IsEmptyIterable extends TypeSafeMatcher<Iterable<?>> {
 
     @Override
-    public boolean matchesSafely(Iterable<? extends E> iterable) {
+    public boolean matchesSafely(Iterable<?> iterable) {
         return !iterable.iterator().hasNext();
     }
     @Override
-    public void describeMismatchSafely(Iterable<? extends E> iter, Description mismatchDescription) {
+    public void describeMismatchSafely(Iterable<?> iter, Description mismatchDescription) {
         mismatchDescription.appendValueList("[", ",", "]", iter);
     }
 
@@ -29,8 +29,8 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterable()))</pre>
      * 
      */
-    public static <E> Matcher<Iterable<? extends E>> emptyIterable() {
-        return new IsEmptyIterable<E>();
+    public static Matcher<Iterable<?>> emptyIterable() {
+        return new IsEmptyIterable();
     }
 
     /**
@@ -40,9 +40,12 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * 
      * @param unusedToForceReturnType
      *     the type of the iterable's content
+     *
+     * @deprecated This method is superfluous. Use {@link #emptyIterable()}.
      */
-    @SuppressWarnings({"unchecked", "UnusedParameters"})
-    public static <E> Matcher<Iterable<E>> emptyIterableOf(Class<E> unusedToForceReturnType) {
-      return (Matcher)emptyIterable();
+    @Deprecated
+    @SuppressWarnings({"UnusedParameters"})
+    public static Matcher<Iterable<?>> emptyIterableOf(Class<?> unusedToForceReturnType) {
+      return emptyIterable();
     }
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> {
+public class IsIterableWithSize extends FeatureMatcher<Iterable<?>, Integer> {
 
     public IsIterableWithSize(Matcher<? super Integer> sizeMatcher) {
         super(sizeMatcher, "an iterable with size", "iterable size");
@@ -15,9 +15,9 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
     
 
     @Override
-    protected Integer featureValueOf(Iterable<E> actual) {
+    protected Integer featureValueOf(Iterable<?> actual) {
       int size = 0;
-      for (Iterator<E> iterator = actual.iterator(); iterator.hasNext(); iterator.next()) {
+      for (Iterator<?> iterator = actual.iterator(); iterator.hasNext(); iterator.next()) {
         size++;
       }
       return size;
@@ -33,8 +33,8 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      * @param sizeMatcher
      *     a matcher for the number of items that should be yielded by an examined {@link Iterable}
      */
-    public static <E> Matcher<Iterable<E>> iterableWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsIterableWithSize<E>(sizeMatcher);
+    public static Matcher<Iterable<?>> iterableWithSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsIterableWithSize(sizeMatcher);
     }
 
     /**
@@ -47,7 +47,7 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      * @param size
      *     the number of items that should be yielded by an examined {@link Iterable}
      */
-    public static <E> Matcher<Iterable<E>> iterableWithSize(int size) {
+    public static Matcher<Iterable<?>> iterableWithSize(int size) {
         return iterableWithSize(equalTo(size));
     }
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -10,14 +10,14 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * Matches if map size satisfies a nested matcher.
  */
-public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ? extends V>, Integer> {
+public final class IsMapWithSize extends FeatureMatcher<Map<?, ?>, Integer> {
     @SuppressWarnings("WeakerAccess")
     public IsMapWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a map with size", "map size");
     }
 
     @Override
-    protected Integer featureValueOf(Map<? extends K, ? extends V> actual) {
+    protected Integer featureValueOf(Map<?, ?> actual) {
       return actual.size();
     }
 
@@ -30,8 +30,8 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * @param sizeMatcher
      *     a matcher for the size of an examined {@link java.util.Map}
      */
-    public static <K, V> Matcher<Map<? extends K, ? extends V>> aMapWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsMapWithSize<>(sizeMatcher);
+    public static Matcher<Map<?, ?>> aMapWithSize(Matcher<? super Integer> sizeMatcher) {
+        return new IsMapWithSize(sizeMatcher);
     }
 
     /**
@@ -43,8 +43,8 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * @param size
      *     the expected size of an examined {@link java.util.Map}
      */
-    public static <K, V> Matcher<Map<? extends K, ? extends V>> aMapWithSize(int size) {
-        return IsMapWithSize.aMapWithSize(equalTo(size));
+    public static Matcher<Map<?, ?>> aMapWithSize(int size) {
+        return aMapWithSize(equalTo(size));
     }
     
     /**
@@ -54,7 +54,7 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * <pre>assertThat(myMap, is(anEmptyMap()))</pre>
      * 
      */
-    public static <K, V> Matcher<Map<? extends K, ? extends V>> anEmptyMap() {
-        return IsMapWithSize.aMapWithSize(equalTo(0));
+    public static Matcher<Map<?, ?>> anEmptyMap() {
+        return aMapWithSize(equalTo(0));
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
@@ -28,12 +28,6 @@ public class IsEmptyCollectionTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("an empty collection", createMatcher());
     }
-
-    public void testCompiles() {
-        needs(IsEmptyCollection.emptyCollectionOf(String.class));
-    }
-
-    private void needs(@SuppressWarnings("unused") Matcher<Collection<String>> bar) { }
     
     private static Collection<String> collectionOfValues() {
         return new ArrayList<String>(asList("one", "three"));

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
@@ -28,12 +28,6 @@ public class IsEmptyIterableTest extends AbstractMatcherTest {
         assertDescription("an empty iterable", createMatcher());
     }
 
-    public void testCompiles() {
-        needs(IsEmptyIterable.emptyIterableOf(String.class));
-    }
-
-    private void needs(@SuppressWarnings("unused") Matcher<Iterable<String>> bar) { }
-
     private static Collection<String> collectionOfValues() {
         return new ArrayList<String>(asList("one", "three"));
     }


### PR DESCRIPTION
The following classes are no longer parameterized as they don't care what is in
the collection they match:
- IsCollectionWithSize
- IsIterableWithSize
- IsMapWithSize
- IsEmptyCollection
- IsEmptyIterable
