### PR TITLE
Change generic signature of OrderingComparison to accept Comparable<? super T>

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/number/OrderingComparison.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/number/OrderingComparison.java
@@ -9,7 +9,7 @@ import org.hamcrest.TypeSafeMatcher;
 
 import static java.lang.Integer.signum;
 
-public class OrderingComparison<T extends Comparable<T>> extends TypeSafeMatcher<T> {
+public class OrderingComparison<T extends Comparable<? super T>> extends TypeSafeMatcher<T> {
     private static final int LESS_THAN = -1;
     private static final int GREATER_THAN = 1;
     private static final int EQUAL = 0;
@@ -67,7 +67,7 @@ public class OrderingComparison<T extends Comparable<T>> extends TypeSafeMatcher
      * 
      */
     @Factory
-    public static <T extends Comparable<T>> Matcher<T> comparesEqualTo(T value) {
+    public static <T extends Comparable<? super T>> Matcher<T> comparesEqualTo(T value) {
         return new OrderingComparison<T>(value, EQUAL, EQUAL);
     }
 
@@ -85,7 +85,7 @@ public class OrderingComparison<T extends Comparable<T>> extends TypeSafeMatcher
      * 
      */
     @Factory
-    public static <T extends Comparable<T>> Matcher<T> greaterThan(T value) {
+    public static <T extends Comparable<? super T>> Matcher<T> greaterThan(T value) {
         return new OrderingComparison<T>(value, GREATER_THAN, GREATER_THAN);
     }
 
@@ -103,7 +103,7 @@ public class OrderingComparison<T extends Comparable<T>> extends TypeSafeMatcher
      * 
      */
     @Factory
-    public static <T extends Comparable<T>> Matcher<T> greaterThanOrEqualTo(T value) {
+    public static <T extends Comparable<? super T>> Matcher<T> greaterThanOrEqualTo(T value) {
         return new OrderingComparison<T>(value, EQUAL, GREATER_THAN);
     }
 
@@ -121,7 +121,7 @@ public class OrderingComparison<T extends Comparable<T>> extends TypeSafeMatcher
      * 
      */
     @Factory
-    public static <T extends Comparable<T>> Matcher<T> lessThan(T value) {
+    public static <T extends Comparable<? super T>> Matcher<T> lessThan(T value) {
         return new OrderingComparison<T>(value, LESS_THAN, LESS_THAN);
     }
 
@@ -139,7 +139,7 @@ public class OrderingComparison<T extends Comparable<T>> extends TypeSafeMatcher
      * 
      */
     @Factory
-    public static <T extends Comparable<T>> Matcher<T> lessThanOrEqualTo(T value) {
+    public static <T extends Comparable<? super T>> Matcher<T> lessThanOrEqualTo(T value) {
         return new OrderingComparison<T>(value, LESS_THAN, EQUAL);
     }
 }

--- a/hamcrest-library/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
@@ -68,8 +68,12 @@ public class OrderingComparisonTest extends AbstractMatcherTest {
     public void testComparesCustomTypesWhoseCompareToReturnsValuesGreaterThatOne() {
         assertThat(new CustomInt(5), lessThan(new CustomInt(10)));
     }
+    
+    public void testComparesCustomTypesWhichExtendComparableClasses() {
+        assertThat(new CustomExtendedInt(5), lessThan(new CustomExtendedInt(10)));
+    }
 
-    private static final class CustomInt implements Comparable<CustomInt> {
+    private static class CustomInt implements Comparable<CustomInt> {
         private final int value;
         public CustomInt(int value) {
             this.value = value;
@@ -77,6 +81,12 @@ public class OrderingComparisonTest extends AbstractMatcherTest {
 
         public int compareTo(CustomInt other) {
             return value - other.value;
+        }
+    }
+
+    private static class CustomExtendedInt extends CustomInt {
+        public CustomExtendedInt(int value) {
+            super(value);
         }
     }
 }


### PR DESCRIPTION
Currently to use `OrderingComparison` with classes which extend other comparable classes (or in general, classes which are comparable to one of their supertypes), the argument needs to be explicitly cast to the supertype, e.g.

```
ConcreteType myObj1, myObj2;
assertThat(myObj1, greaterThan((AbstractType)myObj2);
```

This patch changes the generic signature of `OrderingComparison` to accept `T extends Comparable<? super T>`, which should be compatible with existing uses but also allow more valid cases to compile.
