### PR TITLE
Add a cleanup method to handle wrong conversion of type like java.util.Map.Entry

### DIFF
--- a/hamcrest-core/core-matchers.xml
+++ b/hamcrest-core/core-matchers.xml
@@ -17,5 +17,6 @@
     <factory class="org.hamcrest.core.StringContains"/>
     <factory class="org.hamcrest.core.StringStartsWith"/>
     <factory class="org.hamcrest.core.StringEndsWith"/>
+    <factory class="org.hamcrest.core.StringMatching"/>
 
 </matchers>

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringMatching.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringMatching.java
@@ -3,44 +3,61 @@
  */
 package org.hamcrest.core;
 
+import java.util.regex.Pattern;
+
+import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * @author borettim
  * 
  */
-public class StringMatching extends SubstringMatcher {
+public class StringMatching extends TypeSafeDiagnosingMatcher<String> {
 
-	protected StringMatching(String substring) {
-		super(substring);
+	protected StringMatching(Pattern pattern) {
+		this.pattern = pattern;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.hamcrest.core.SubstringMatcher#evalSubstringOf(java.lang.String)
-	 */
+	private Pattern pattern;
+
 	@Override
-	protected boolean evalSubstringOf(String s) {
-		return s.matches(substring);
+	public void describeTo(Description description) {
+		description.appendText("a string matching the pattern ").appendValue(pattern);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.hamcrest.core.SubstringMatcher#relationship()
-	 */
 	@Override
-	protected String relationship() {
-		return "matching the regex";
+	protected boolean matchesSafely(String item, Description mismatchDescription) {
+		if (!pattern.matcher(item).matches()) {
+			mismatchDescription.appendText("but the string ").appendValue(item)
+					.appendText(" was not matching ").appendValue(pattern);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Validate a string with a {@link java.util.regex.Pattern}.
+	 * 
+	 * <pre>
+	 * assertThat(&quot;abc&quot;, matchesRegex(Pattern.compile(&quot;&circ;[a-z]$&quot;));
+	 * </pre>
+	 * 
+	 * @param pattern
+	 *            the pattern to be used.
+	 * @return The matcher.
+	 */
+	@Factory
+	public static Matcher<String> matchesRegex(Pattern pattern) {
+		return new StringMatching(pattern);
 	}
 
 	/**
 	 * Validate a string with a regex.
 	 * 
 	 * <pre>
-	 * assertThat("abc",matches("^[a-z]+$"));
+	 * assertThat(&quot;abc&quot;, matchesRegex(&quot;&circ;[a-z]+$&quot;));
 	 * </pre>
 	 * 
 	 * @param regex
@@ -48,8 +65,7 @@ public class StringMatching extends SubstringMatcher {
 	 * @return The matcher.
 	 */
 	@Factory
-	public static Matcher<String> matches(String regex) {
-		return new StringMatching(regex);
+	public static Matcher<String> matchesRegex(String regex) {
+		return matchesRegex(Pattern.compile(regex));
 	}
-
 }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringMatching.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringMatching.java
@@ -1,0 +1,55 @@
+/**
+ * 
+ */
+package org.hamcrest.core;
+
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+
+/**
+ * @author borettim
+ * 
+ */
+public class StringMatching extends SubstringMatcher {
+
+	protected StringMatching(String substring) {
+		super(substring);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.hamcrest.core.SubstringMatcher#evalSubstringOf(java.lang.String)
+	 */
+	@Override
+	protected boolean evalSubstringOf(String s) {
+		return s.matches(substring);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.hamcrest.core.SubstringMatcher#relationship()
+	 */
+	@Override
+	protected String relationship() {
+		return "matching the regex";
+	}
+
+	/**
+	 * Validate a string with a regex.
+	 * 
+	 * <pre>
+	 * assertThat("abc",matches("^[a-z]+$"));
+	 * </pre>
+	 * 
+	 * @param regex
+	 *            The regex to be used for the validation.
+	 * @return The matcher.
+	 */
+	@Factory
+	public static Matcher<String> matches(String regex) {
+		return new StringMatching(regex);
+	}
+
+}

--- a/hamcrest-core/src/test/java/org/hamcrest/core/StringMatchingTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/StringMatchingTest.java
@@ -1,0 +1,25 @@
+package org.hamcrest.core;
+
+import static org.hamcrest.AbstractMatcherTest.assertDoesNotMatch;
+import static org.hamcrest.AbstractMatcherTest.assertMatches;
+import static org.hamcrest.core.StringMatching.matches;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+public class StringMatchingTest {
+
+	@Test
+	public void testMatchingRegex() {
+		Matcher matcher = matches("^[0-9]+$");
+		assertMatches(matcher, "12");
+		assertDoesNotMatch(matcher, new Object());
+	}
+	
+	@Test
+	public void testNotMatchingRegex() {
+		Matcher matcher = matches("^[0-9]+$");
+		assertDoesNotMatch(matcher, "a");
+	}
+
+}

--- a/hamcrest-core/src/test/java/org/hamcrest/core/StringMatchingTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/StringMatchingTest.java
@@ -2,7 +2,7 @@ package org.hamcrest.core;
 
 import static org.hamcrest.AbstractMatcherTest.assertDoesNotMatch;
 import static org.hamcrest.AbstractMatcherTest.assertMatches;
-import static org.hamcrest.core.StringMatching.matches;
+import static org.hamcrest.core.StringMatching.matchesRegex;
 
 import org.hamcrest.Matcher;
 import org.junit.Test;
@@ -11,14 +11,14 @@ public class StringMatchingTest {
 
 	@Test
 	public void testMatchingRegex() {
-		Matcher matcher = matches("^[0-9]+$");
+		Matcher matcher = matchesRegex("^[0-9]+$");
 		assertMatches(matcher, "12");
 		assertDoesNotMatch(matcher, new Object());
 	}
 	
 	@Test
 	public void testNotMatchingRegex() {
-		Matcher matcher = matches("^[0-9]+$");
+		Matcher matcher = matchesRegex("^[0-9]+$");
 		assertDoesNotMatch(matcher, "a");
 	}
 

--- a/hamcrest-generator/src/main/java/org/hamcrest/generator/ReflectiveFactoryReader.java
+++ b/hamcrest-generator/src/main/java/org/hamcrest/generator/ReflectiveFactoryReader.java
@@ -8,167 +8,199 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
- * Reads a list of Hamcrest factory methods from a class, using standard Java reflection.
- * <h3>Usage</h3>
+ * Reads a list of Hamcrest factory methods from a class, using standard Java
+ * reflection. <h3>Usage</h3>
+ * 
  * <pre>
  * for (FactoryMethod method : new ReflectiveFactoryReader(MyMatchers.class)) {
  *   ...
  * }
  * </pre>
- * <p>All methods matching signature '@Factory public static Matcher<blah> blah(blah)' will be
- * treated as factory methods. To change this behavior, override {@link #isFactoryMethod(Method)}.
- * <p>Caveat: Reflection is hassle-free, but unfortunately cannot expose method parameter names or JavaDoc
- * comments, making the sugar slightly more obscure.
- *
+ * <p>
+ * All methods matching signature '@Factory public static Matcher<blah>
+ * blah(blah)' will be treated as factory methods. To change this behavior,
+ * override {@link #isFactoryMethod(Method)}.
+ * <p>
+ * Caveat: Reflection is hassle-free, but unfortunately cannot expose method
+ * parameter names or JavaDoc comments, making the sugar slightly more obscure.
+ * 
  * @author Joe Walnes
  * @see SugarGenerator
  * @see FactoryMethod
  */
 public class ReflectiveFactoryReader implements Iterable<FactoryMethod> {
 
-    private final Class<?> cls;
+	private final Class<?> cls;
 
-    private final ClassLoader classLoader;
+	private final ClassLoader classLoader;
 
-    public ReflectiveFactoryReader(Class<?> cls) {
-        this.cls = cls;
-        this.classLoader = cls.getClassLoader();
-    }
+	public ReflectiveFactoryReader(Class<?> cls) {
+		this.cls = cls;
+		this.classLoader = cls.getClassLoader();
+	}
 
-    @Override
-    public Iterator<FactoryMethod> iterator() {
-        return new Iterator<FactoryMethod>() {
+	@Override
+	public Iterator<FactoryMethod> iterator() {
+		return new Iterator<FactoryMethod>() {
 
-            private int currentMethod = -1;
-            private Method[] allMethods = cls.getMethods();
+			private int currentMethod = -1;
+			private Method[] allMethods = cls.getMethods();
 
-            @Override
-            public boolean hasNext() {
-                while (true) {
-                    currentMethod++;
-                    if (currentMethod >= allMethods.length) {
-                        return false;
-                    } else if (isFactoryMethod(allMethods[currentMethod])) {
-                        return true;
-                    } // else carry on looping and try the next one.
-                }
-            }
+			@Override
+			public boolean hasNext() {
+				while (true) {
+					currentMethod++;
+					if (currentMethod >= allMethods.length) {
+						return false;
+					} else if (isFactoryMethod(allMethods[currentMethod])) {
+						return true;
+					} // else carry on looping and try the next one.
+				}
+			}
 
-            @Override
-            public FactoryMethod next() {
-                if (outsideArrayBounds()) {
-                  throw new IllegalStateException("next() called without hasNext() check.");
-                }
-                return buildFactoryMethod(allMethods[currentMethod]);
-            }
+			@Override
+			public FactoryMethod next() {
+				if (outsideArrayBounds()) {
+					throw new IllegalStateException(
+							"next() called without hasNext() check.");
+				}
+				return buildFactoryMethod(allMethods[currentMethod]);
+			}
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
+			@Override
+			public void remove() {
+				throw new UnsupportedOperationException();
+			}
 
-            private boolean outsideArrayBounds() {
-              return currentMethod < 0 || allMethods.length <= currentMethod;
-            }
-        };
-    }
+			private boolean outsideArrayBounds() {
+				return currentMethod < 0 || allMethods.length <= currentMethod;
+			}
+		};
+	}
 
-    /**
-     * Determine whether a particular method is classified as a matcher factory method.
-     * <p/>
-     * <p>The rules for determining this are:
-     * 1. The method must be public static.
-     * 2. It must have a return type of org.hamcrest.Matcher (or something that extends this).
-     * 3. It must be marked with the org.hamcrest.Factory annotation.
-     * <p/>
-     * <p>To use another set of rules, override this method.
-     */
-    protected boolean isFactoryMethod(Method javaMethod) {
-        return isStatic(javaMethod.getModifiers())
-                && isPublic(javaMethod.getModifiers())
-                && hasFactoryAnnotation(javaMethod)
-                && !Void.TYPE.equals(javaMethod.getReturnType());
-    }
+	/**
+	 * Determine whether a particular method is classified as a matcher factory
+	 * method.
+	 * <p/>
+	 * <p>
+	 * The rules for determining this are: 1. The method must be public static.
+	 * 2. It must have a return type of org.hamcrest.Matcher (or something that
+	 * extends this). 3. It must be marked with the org.hamcrest.Factory
+	 * annotation.
+	 * <p/>
+	 * <p>
+	 * To use another set of rules, override this method.
+	 */
+	protected boolean isFactoryMethod(Method javaMethod) {
+		return isStatic(javaMethod.getModifiers())
+				&& isPublic(javaMethod.getModifiers())
+				&& hasFactoryAnnotation(javaMethod)
+				&& !Void.TYPE.equals(javaMethod.getReturnType());
+	}
 
-    @SuppressWarnings("unchecked")
-    private boolean hasFactoryAnnotation(Method javaMethod) {
-      // We dynamically load the Factory class, to avoid a compile time
-      // dependency on org.hamcrest.Factory. This gets around
-      // a circular bootstrap issue (because generator is required to
-      // compile core).
-      try {
-        final Class<?> factoryClass = classLoader.loadClass("org.hamcrest.Factory");
-        if (!Annotation.class.isAssignableFrom(factoryClass)) {
-          throw new RuntimeException("Not an annotation class: " + factoryClass.getCanonicalName());
-        }
-        return javaMethod.getAnnotation((Class<? extends Annotation>)factoryClass) != null;        
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException("Cannot load hamcrest core", e);
-      }
-    }
-    
-    private static FactoryMethod buildFactoryMethod(Method javaMethod) {
-        FactoryMethod result = new FactoryMethod(
-                classToString(javaMethod.getDeclaringClass()),
-                javaMethod.getName(), 
-                classToString(javaMethod.getReturnType()));
+	@SuppressWarnings("unchecked")
+	private boolean hasFactoryAnnotation(Method javaMethod) {
+		// We dynamically load the Factory class, to avoid a compile time
+		// dependency on org.hamcrest.Factory. This gets around
+		// a circular bootstrap issue (because generator is required to
+		// compile core).
+		try {
+			final Class<?> factoryClass = classLoader
+					.loadClass("org.hamcrest.Factory");
+			if (!Annotation.class.isAssignableFrom(factoryClass)) {
+				throw new RuntimeException("Not an annotation class: "
+						+ factoryClass.getCanonicalName());
+			}
+			return javaMethod
+					.getAnnotation((Class<? extends Annotation>) factoryClass) != null;
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Cannot load hamcrest core", e);
+		}
+	}
 
-        for (TypeVariable<Method> typeVariable : javaMethod.getTypeParameters()) {
-            boolean hasBound = false;
-            StringBuilder s = new StringBuilder(typeVariable.getName());
-            for (Type bound : typeVariable.getBounds()) {
-                if (bound != Object.class) {
-                    if (hasBound) {
-                        s.append(" & ");
-                    } else {
-                        s.append(" extends ");
-                        hasBound = true;
-                    }
-                    s.append(typeToString(bound));
-                }
-            }
-            result.addGenericTypeParameter(s.toString());
-        }
-        Type returnType = javaMethod.getGenericReturnType();
-        if (returnType instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) returnType;
-            Type generifiedType = parameterizedType.getActualTypeArguments()[0];
-            result.setGenerifiedType(typeToString(generifiedType));
-        }
+	private static FactoryMethod buildFactoryMethod(Method javaMethod) {
+		FactoryMethod result = new FactoryMethod(
+				classToString(javaMethod.getDeclaringClass()),
+				javaMethod.getName(), classToString(javaMethod.getReturnType()));
 
-        int paramNumber = 0;
-        for (Type paramType : javaMethod.getGenericParameterTypes()) {
-            String type = typeToString(paramType);
-            // Special case for var args methods.... String[] -> String...
-            if (javaMethod.isVarArgs()
-                    && paramNumber == javaMethod.getParameterTypes().length - 1) {
-                type = type.replaceFirst("\\[\\]$", "...");
-            }
-            result.addParameter(type, "param" + (++paramNumber));
-        }
+		for (TypeVariable<Method> typeVariable : javaMethod.getTypeParameters()) {
+			boolean hasBound = false;
+			StringBuilder s = new StringBuilder(typeVariable.getName());
+			for (Type bound : typeVariable.getBounds()) {
+				if (bound != Object.class) {
+					if (hasBound) {
+						s.append(" & ");
+					} else {
+						s.append(" extends ");
+						hasBound = true;
+					}
+					s.append(typeToString(bound));
+				}
+			}
+			result.addGenericTypeParameter(s.toString());
+		}
+		Type returnType = javaMethod.getGenericReturnType();
+		if (returnType instanceof ParameterizedType) {
+			ParameterizedType parameterizedType = (ParameterizedType) returnType;
+			Type generifiedType = parameterizedType.getActualTypeArguments()[0];
+			result.setGenerifiedType(typeToString(generifiedType));
+		}
 
-        for (Class<?> exception : javaMethod.getExceptionTypes()) {
-            result.addException(typeToString(exception));
-        }
+		int paramNumber = 0;
+		for (Type paramType : javaMethod.getGenericParameterTypes()) {
+			String type = typeToString(paramType);
+			// Special case for var args methods.... String[] -> String...
+			if (javaMethod.isVarArgs()
+					&& paramNumber == javaMethod.getParameterTypes().length - 1) {
+				type = type.replaceFirst("\\[\\]$", "...");
+			}
+			result.addParameter(type, "param" + (++paramNumber));
+		}
 
-        return result;
-    }
+		for (Class<?> exception : javaMethod.getExceptionTypes()) {
+			result.addException(typeToString(exception));
+		}
 
-    /*
-     * Get String representation of Type (e.g. java.lang.String or Map&lt;Stuff,? extends Cheese&gt;).
-     * <p/>
-     * Annoyingly this method wouldn't be needed if java.lang.reflect.Type.toString() behaved consistently
-     * across implementations. Rock on Liskov.
-     */
-    private static String typeToString(Type type) {
-        return type instanceof Class<?> ?  classToString((Class<?>) type): type.toString();
-    }
+		return result;
+	}
 
-    private static String classToString(Class<?> cls) {
-      final String name = cls.isArray() ? cls.getComponentType().getName() + "[]" : cls.getName();
-      return name.replace('$', '.');
-    }
+	/*
+	 * Get String representation of Type (e.g. java.lang.String or
+	 * Map&lt;Stuff,? extends Cheese&gt;). <p/> Annoyingly this method wouldn't
+	 * be needed if java.lang.reflect.Type.toString() behaved consistently
+	 * across implementations. Rock on Liskov.
+	 */
+	private static String typeToString(Type type) {
+		return type instanceof Class<?> ? classToString((Class<?>) type)
+				: cleanup(type.toString());
+	}
+
+	/**
+	 * Add a method to cleanup the type string. for instance :
+	 * 
+	 * <pre>
+	 * Map.Entry&lt;K, V>
+	 * </pre>
+	 * produce by default something like 
+	 * <pre>
+	 * java.util.Map.java.util.Map$Entry<K, V>
+	 * </pre>
+	 * The purpose of this method is to cleanup this mess.
+	 * 
+	 * @param input The input string
+	 * @return The cleaned string.
+	 */
+	private static String cleanup(String input) {
+		return input.replaceFirst("^(.+)\\.\\1\\$", "$1.");
+	}
+
+	private static String classToString(Class<?> cls) {
+		final String name = cls.isArray() ? cls.getComponentType().getName()
+				+ "[]" : cls.getName();
+		return name.replace('$', '.');
+	}
 
 }

--- a/hamcrest-generator/src/test/java/org/hamcrest/generator/ReflectiveFactoryReaderTest.java
+++ b/hamcrest-generator/src/test/java/org/hamcrest/generator/ReflectiveFactoryReaderTest.java
@@ -154,7 +154,21 @@ public final class ReflectiveFactoryReaderTest {
         public static Matcher<String> withGenerifiedParam(Collection<? extends Comparable<String>> things, Set<String[]>[] x) {
             return null;
         }
+        
+        @Factory
+        public static Matcher<String> withInnerClass(Map.Entry<String, Integer> x) {
+        	return null;
+        }
 
+    }
+    
+    @Test public void
+    readsInnterClass() {
+        FactoryMethod method = readMethod(ParameterizedMatchers.class, "withInnerClass");
+        List<FactoryMethod.Parameter> params = method.getParameters();
+        assertEquals(1, params.size());
+
+        assertEquals("java.util.Map.Entry<java.lang.String, java.lang.Integer>", params.get(0).getType());
     }
 
     @Test public void

--- a/hamcrest-library/matchers.xml
+++ b/hamcrest-library/matchers.xml
@@ -17,6 +17,7 @@
     <factory class="org.hamcrest.core.StringContains"/>
     <factory class="org.hamcrest.core.StringStartsWith"/>
     <factory class="org.hamcrest.core.StringEndsWith"/>
+    <factory class="org.hamcrest.core.StringMatching"/>
 
     <!-- Collection -->
     <factory class="org.hamcrest.collection.IsArray"/>


### PR DESCRIPTION
Outside of the code format, this change is related to the method :

private static String typeToString(Type type). The returned string, for the Type case, is passed thru a new cleanup method that correct wrong output with parameter of the type :
java.util.Map.Entry<K,V> (without the fix, produce java.util.Map.java.util.Map$Entry<K,V>) which is not valid in java.

The file use a regex to do the correction :
```java
private static String cleanup(String input) {
  return input.replaceFirst("^(.+)\\.\\1\\$", "$1.");
}
```