### PR TITLE
Fixed multiple identical substring matching in StringContainsInOrder

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInOrder.java
@@ -20,7 +20,7 @@ public class StringContainsInOrder extends TypeSafeMatcher<String> {
         
         for (String substring : substrings) {
             fromIndex = s.indexOf(substring, fromIndex);
-            if (fromIndex == -1) {
+            if (fromIndex++ == -1) {
                 return false;
             }
         }

--- a/hamcrest-library/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -7,7 +7,7 @@ import org.hamcrest.Matcher;
 
 
 public class StringContainsInOrderTest extends AbstractMatcherTest {
-    StringContainsInOrder m = new StringContainsInOrder(asList("a", "b", "c"));
+    StringContainsInOrder m = new StringContainsInOrder(asList("a", "b", "c", "c"));
 
     @Override
     protected Matcher<?> createMatcher() {
@@ -15,16 +15,18 @@ public class StringContainsInOrderTest extends AbstractMatcherTest {
     }
     
     public void testMatchesOnlyIfStringContainsGivenSubstringsInTheSameOrder() {
-        assertMatches("substrings in order", m, "abc");
-        assertMatches("substrings separated", m, "1a2b3c4");
+        assertMatches("all substrings adjacent in order", m, "abcc");
+        assertMatches("all substrings separated in order", m, "1a2b3c4c5");
         
-        assertDoesNotMatch("substrings out of order", m, "cab");
-        assertDoesNotMatch("no substrings in string", m, "xyz");
-        assertDoesNotMatch("substring missing", m, "ac");
+        assertDoesNotMatch("cumulative substring length longer than string", m, "abc");
+        assertDoesNotMatch("substrings out of order", m, "cabc");
+        assertDoesNotMatch("no substrings in string", m, "wxyz");
+        assertDoesNotMatch("substring not occurring", m, "axcc");
+        assertDoesNotMatch("substring missing", m, "acc");
         assertDoesNotMatch("empty string", m, "");
     }
     
     public void testHasAReadableDescription() {
-        assertDescription("a string containing \"a\", \"b\", \"c\" in order", m);
+        assertDescription("a string containing \"a\", \"b\", \"c\", \"c\" in order", m);
     }
 }


### PR DESCRIPTION
StringContainsInOrder instances might expect multiple occurrences of identical substrings in the string to be matched. However, since this matcher requires all substrings to be _in order_, they must match **distinct** occurrences. This behavior is imposed with this fix.

Example:
`StringContainsInOrder m1 = new StringContainsInOrder(asList("a", "b", "c"));`
`StringContainsInOrder m2 = new StringContainsInOrder(asList("a", "b", "c", "c"));`
The matcher `m1` is expected to match `"abc"`, however `m2` is not. Unless this fix is pulled, both `m1` and `m2` matches `"abc"`.
