### PR TITLE
Added returns(), alias to is()

### DIFF
--- a/hamcrest-core/core-matchers.xml
+++ b/hamcrest-core/core-matchers.xml
@@ -14,6 +14,7 @@
     <factory class="org.hamcrest.core.IsNot"/>
     <factory class="org.hamcrest.core.IsNull"/>
     <factory class="org.hamcrest.core.IsSame"/>
+    <factory class="org.hamcrest.core.Returns"/>
     <factory class="org.hamcrest.core.StringContains"/>
     <factory class="org.hamcrest.core.StringStartsWith"/>
     <factory class="org.hamcrest.core.StringEndsWith"/>

--- a/hamcrest-core/src/main/java/org/hamcrest/core/Returns.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/Returns.java
@@ -1,0 +1,44 @@
+package org.hamcrest.core;
+
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+
+/**
+ * Aliases for is() to allow for more expressive tests of
+ * method return values.
+ * 
+ * For example: assertThat(object.calculateValue(), returns(5))
+ *
+ */
+public class Returns {
+
+	/**
+	 * An alias to <code>is(Matcher&lt;T&gt; matcher)</code> to allow for more readable
+	 * expressions and concise code when testing method return values.
+	 * <p/>
+	 * For example:
+	 * <pre>assertThat(object.calculateValue(), returns(greaterThan(5)));</pre>
+	 * instead of:
+	 * <pre>int actualValue = object.calculateValue();</pre>
+	 * <pre>assertThat(actualValue, is(greaterThan(5)));</pre>
+	 */
+	@Factory
+    public static <T> Matcher<T> returns(Matcher<T> matcher) {
+        return Is.is(matcher);
+    }
+	
+	/**
+	 * An alias to <code>is(T operand)</code> to allow for more readable
+	 * expressions and concise code when testing method return values.
+	 * <p/>
+	 * For example:
+	 * <pre>assertThat(object.getValue(), returns(5));</pre>
+	 * instead of:
+	 * <pre>int actualValue = object.getValue();</pre>
+	 * <pre>assertThat(actualValue, is(5));</pre>
+	 */
+	@Factory
+    public static <T> Matcher<T> returns(T operand) {
+        return Is.is(operand);
+    }
+}

--- a/hamcrest-library/matchers.xml
+++ b/hamcrest-library/matchers.xml
@@ -14,6 +14,7 @@
     <factory class="org.hamcrest.core.IsNot"/>
     <factory class="org.hamcrest.core.IsNull"/>
     <factory class="org.hamcrest.core.IsSame"/>
+    <factory class="org.hamcrest.core.Returns"/>
     <factory class="org.hamcrest.core.StringContains"/>
     <factory class="org.hamcrest.core.StringStartsWith"/>
     <factory class="org.hamcrest.core.StringEndsWith"/>


### PR DESCRIPTION
Created an alias to is() called returns() which allows for more concise and readable tests in the case of testing the return value of a method.

Example:
assertThat(object.calculateValue(), returns(5))

instead of:
int actualValue = object.calculateValue()
assertThat(actualValue, is(5))

which also reads more as natural language than:
assertThat(object.calculateValue(), is(5))
