### PR TITLE
Add a Matcher which allows the use of lamdas to test the field of an object

### DIFF
--- a/hamcrest-library/matchers.xml
+++ b/hamcrest-library/matchers.xml
@@ -52,6 +52,7 @@
     <factory class="org.hamcrest.object.HasToString"/>
     <factory class="org.hamcrest.object.IsCompatibleType"/>
     <factory class="org.hamcrest.object.IsEventFrom"/>
+    <factory class="org.hamcrest.object.HasField"/>
 
     <!-- Beans -->
     <factory class="org.hamcrest.beans.HasProperty"/>

--- a/hamcrest-library/src/main/java/org/hamcrest/object/FieldExtractor.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/object/FieldExtractor.java
@@ -1,0 +1,9 @@
+package org.hamcrest.object;
+
+/**
+ * An interface used to extract a field from an object for the {@linkplain HasField} Matcher.
+ */
+// @FunctionalInterface
+public interface FieldExtractor<T, U> {
+    U apply(T t);
+}

--- a/hamcrest-library/src/main/java/org/hamcrest/object/HasField.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/object/HasField.java
@@ -1,0 +1,43 @@
+package org.hamcrest.object;
+
+import org.hamcrest.Factory;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+/**
+ * A Matcher that asserts that an object field matches the given matcher.
+ * The property is extracted from the object using a {@linkplain FieldExtractor}.
+ * The idea for this is to use a lamda to easily extract the property from the bean.
+ */
+public class HasField<T, U> extends FeatureMatcher<T, U> {
+
+    private final FieldExtractor<T, U> field;
+
+    public HasField(final String fieldName, final FieldExtractor<T, U> field, final Matcher<U> valueMatcher) {
+        super(valueMatcher, "field " + fieldName + " is", fieldName);
+        this.field = field;
+    }
+
+    @Override
+    protected U featureValueOf(final T actual) {
+        return field.apply(actual);
+    }
+
+    /**
+     * Creates a matcher that matches when the examined object has a field
+     * with the specified name whose value satisfies the specified matcher.
+     * <p/>
+     * For example, in Java 8:
+     * <pre>assertThat(myBean, hasField("foo", Bean::getFoo, equalTo("bar"))</pre>
+     *
+     * @param fieldName name or identifier of the field in the bean.
+     * @param field Object used to extract the field from the object
+     * @param fieldMatcher
+     *     a matcher for the value of the specified property of the examined bean
+     */
+    @Factory
+    public static <T, U> Matcher<T> hasField(final String fieldName, final FieldExtractor<T, U> field, final Matcher<U> fieldMatcher) {
+        return new HasField<T, U>(fieldName, field, fieldMatcher);
+    }
+
+}

--- a/hamcrest-library/src/test/java/org/hamcrest/object/HasFieldTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/object/HasFieldTest.java
@@ -1,0 +1,72 @@
+package org.hamcrest.object;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import static org.hamcrest.AbstractMatcherTest.assertDescription;
+import static org.hamcrest.AbstractMatcherTest.assertDoesNotMatch;
+import static org.hamcrest.AbstractMatcherTest.assertMatches;
+import static org.hamcrest.AbstractMatcherTest.assertMismatchDescription;
+import static org.hamcrest.AbstractMatcherTest.assertNullSafe;
+import static org.hamcrest.AbstractMatcherTest.assertUnknownTypeSafe;
+import static org.hamcrest.object.HasField.hasField;
+import static org.hamcrest.beans.HasProperty.hasProperty;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class HasFieldTest {
+
+    @Test
+    public void
+    copesWithNullsAndUnknownTypes() {
+        Matcher<Object> matcher = hasProperty("irrelevant");
+
+        assertNullSafe(matcher);
+        assertUnknownTypeSafe(matcher);
+    }
+
+    @Test
+    public void matchesWhenTheFieldMatches() {
+
+        final String value = "this is a value";
+
+        assertMatches(hasField("property", FIELD_EXTRACTOR, equalTo(value)), new Bean(value));
+    }
+
+    @Test
+    public void doesNotMatchTheFieldDoesNotMatch() {
+        assertDoesNotMatch(hasField("property", FIELD_EXTRACTOR, equalTo("one value")), new Bean("another value"));
+    }
+
+    @Test
+    public void describesItself() {
+
+        final String fieldName = "property";
+        final String fieldValue = "value";
+
+        assertDescription("field "+ fieldName +" is \""+ fieldValue +"\"", hasField(fieldName, FIELD_EXTRACTOR, equalTo(fieldValue)));
+    }
+
+    @Test
+    public void describesAMismatch() {
+        final String fieldName = "property";
+        final String fieldValue = "another value";
+        assertMismatchDescription(fieldName + " was \"" + fieldValue + "\"",
+                hasField("property", FIELD_EXTRACTOR, equalTo("value")), new Bean("another value"));
+    }
+
+    private static final FieldExtractor<Bean, String> FIELD_EXTRACTOR = new FieldExtractor<Bean, String>() {
+        @Override
+        public String apply(final Bean b) {
+            return b.property;
+        }
+    };
+
+    private static class Bean {
+        private final String property;
+
+        private Bean(final String property) {
+            this.property = property;
+        }
+    }
+
+}


### PR DESCRIPTION
The idea behind this matcher is to reduce the need to write custom matchers under Java 8 by being able to use a lambda to retrieve the field inside an object to match against