### PR TITLE
Added xml() method to allow converting various sources of XML into Node

### DIFF
--- a/hamcrest-library/matchers.xml
+++ b/hamcrest-library/matchers.xml
@@ -60,5 +60,6 @@
 
     <!-- XML -->
     <factory class="org.hamcrest.xml.HasXPath"/>
+    <factory class="org.hamcrest.xml.Xml"/>
 
 </matchers>

--- a/hamcrest-library/src/main/java/org/hamcrest/xml/Xml.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/xml/Xml.java
@@ -1,0 +1,225 @@
+package org.hamcrest.xml;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsNull;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+
+public class Xml extends BaseMatcher<Object> {
+
+	private Matcher<Node> matcherParam;
+	private Matcher<?> delegateMatcher;
+	
+	
+	private Xml(Matcher<Node> matcherParam) {
+		this.matcherParam = matcherParam;
+	}
+	
+	private void populateDelegateMatcher(Object item) {
+		if (null == this.delegateMatcher) {
+			this.delegateMatcher = getDelegateMatcher(item);
+		}
+	}
+	
+	private Matcher<?> getDelegateMatcher(Object item) {
+		Matcher<?> delegateMatcher = null;
+		
+		if (item instanceof File) {
+			delegateMatcher = new FileXmlSourceMatcher(this.matcherParam);
+		} else if (item instanceof String) {
+			delegateMatcher = new StringXmlSourceMatcher(this.matcherParam);
+		} else if (item instanceof InputStream) {
+			delegateMatcher = new InputStreamXmlSourceMatcher(this.matcherParam);
+		} else if (null == item) {
+			delegateMatcher = IsNull.notNullValue();
+		} else {
+			delegateMatcher = new UnknownXmlSourceMatcher(this.matcherParam);
+		}
+		
+		return delegateMatcher;
+	}
+	
+	@Override
+	public boolean matches(Object item) {
+		populateDelegateMatcher(item);
+		return this.delegateMatcher.matches(item);
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		this.delegateMatcher.describeTo(description);
+	}
+
+	@Override
+	public void describeMismatch(Object item, Description description) {
+		populateDelegateMatcher(item);
+		this.delegateMatcher.describeMismatch(item, description);
+	}
+
+	@Factory
+	public static Matcher<Object> xml(Matcher<Node> matcher) {
+		return new Xml(matcher);
+	}
+	
+	private abstract class AbstractXmlSourceMatcher<T> extends TypeSafeMatcher<T> {
+		
+		private Matcher<Node> matcher;
+		
+		public AbstractXmlSourceMatcher(Matcher<Node> matcher) {
+			this.matcher = matcher;
+		}
+
+		@Override
+		final public void describeTo(Description description) {
+			this.matcher.describeTo(description);
+		}
+		
+		@Override
+		abstract protected void describeMismatchSafely(T item, Description mismatchDescription);
+		
+		@Override
+		abstract protected boolean matchesSafely(T item);
+
+		protected DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
+			return DocumentBuilderFactory.newInstance().newDocumentBuilder();
+		}
+		
+		protected boolean matches(Node node) {
+			return this.matcher.matches(node);
+		}
+	}
+	
+	private class FileXmlSourceMatcher extends AbstractXmlSourceMatcher<File> {
+		
+		public FileXmlSourceMatcher(Matcher<Node> matcher) {
+			super(matcher);
+		}
+		
+		@Override
+		protected void describeMismatchSafely(File item, Description mismatchDescription) {
+			mismatchDescription.appendText("a match was not found");
+		}
+
+		@Override
+		protected boolean matchesSafely(File item) {
+			boolean matches = false;
+			
+			try {
+				Node node = getDocumentBuilder().parse(item);
+				matches = super.matches(node);
+			} catch (ParserConfigurationException e) {
+				e.printStackTrace();
+			} catch (SAXException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			return matches;
+		}
+	}
+	
+	private class StringXmlSourceMatcher extends AbstractXmlSourceMatcher<String> {
+		
+		public StringXmlSourceMatcher(Matcher<Node> matcher) {
+			super(matcher);
+		}
+		
+		@Override
+		protected void describeMismatchSafely(String item, Description mismatchDescription) {
+			mismatchDescription.appendText("a match was not found");
+		}
+
+		@Override
+		protected boolean matchesSafely(String item) {
+			boolean matches = false;
+			
+			try {
+				Node node = getDocumentBuilder().parse(new ByteArrayInputStream(item.getBytes()));
+				matches = super.matches(node);
+			} catch (ParserConfigurationException e) {
+				e.printStackTrace();
+			} catch (SAXException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			return matches;
+		}
+	}
+	
+	private class InputStreamXmlSourceMatcher extends AbstractXmlSourceMatcher<InputStream> {
+		
+		public InputStreamXmlSourceMatcher(Matcher<Node> matcher) {
+			super(matcher);
+		}
+		
+		@Override
+		protected void describeMismatchSafely(InputStream item, Description mismatchDescription) {
+			mismatchDescription.appendText("a match was not found");
+		}
+
+		@Override
+		protected boolean matchesSafely(InputStream item) {
+			boolean matches = false;
+			
+			try {
+				Node node = getDocumentBuilder().parse(item);
+				matches = super.matches(node);
+			} catch (ParserConfigurationException e) {
+				e.printStackTrace();
+			} catch (SAXException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			return matches;
+		}
+	}
+	
+	private class UnknownXmlSourceMatcher extends AbstractXmlSourceMatcher<Object> {
+		
+		public UnknownXmlSourceMatcher(Matcher<Node> matcher) {
+			super(matcher);
+		}
+		
+		@Override
+		protected void describeMismatchSafely(Object item, Description mismatchDescription) {
+			mismatchDescription.appendText("a match was not found");
+		}
+
+		@Override
+		protected boolean matchesSafely(Object item) {
+			boolean matches = false;
+			
+			try {
+				Node node = getDocumentBuilder().parse(new ByteArrayInputStream(item.toString().getBytes()));
+				matches = super.matches(node);
+			} catch (ParserConfigurationException e) {
+				e.printStackTrace();
+			} catch (SAXException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+			return matches;
+		}
+	}
+}

--- a/hamcrest-library/src/test/java/org/hamcrest/xml/XmlTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/xml/XmlTest.java
@@ -1,0 +1,119 @@
+package org.hamcrest.xml;
+
+import static org.hamcrest.AbstractMatcherTest.assertDoesNotMatch;
+import static org.hamcrest.AbstractMatcherTest.assertMatches;
+import static org.hamcrest.xml.HasXPath.hasXPath;
+import static org.hamcrest.xml.Xml.xml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class XmlTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+	
+	private final String VALID_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><elementRoot><otherElement /><elementSub>TextValue</elementSub></elementRoot>";
+	private final String INVALID_XML = "ASDF12345";
+	
+	@Test
+	public void matchesValidFile() throws IOException {
+		File file = getFileWithContent(VALID_XML);
+		
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertMatches(matcher, file);
+	}
+	
+	@Test
+	public void doesNotMatchInvalidFile() throws IOException {
+		File file = getFileWithContent(INVALID_XML);
+		
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertDoesNotMatch(matcher, file);
+	}
+	
+	@Test
+	public void matchesValidInputStream() throws IOException {
+		File file = getFileWithContent(VALID_XML);
+		
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertMatches(matcher, new FileInputStream(file));
+	}
+	
+	@Test
+	public void doesNotMatchInputStream() throws IOException {
+		File file = getFileWithContent(INVALID_XML);
+		
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertDoesNotMatch(matcher, new FileInputStream(file));
+	}
+	
+	@Test
+	public void matchesValidString() throws IOException, InterruptedException {
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertMatches(matcher, VALID_XML);
+	}
+	
+	@Test
+	public void doesNotMatchInvalidString() throws IOException {
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertDoesNotMatch(matcher, INVALID_XML);
+	}
+
+	@Test
+	public void doesNotMatchNull() {
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertDoesNotMatch(matcher, null);
+	}
+	
+	@Test
+	public void matchesValidToStringOnUnknownXmlSource() {
+		Object unknown = new Object() {
+			@Override
+			public String toString() {
+				return VALID_XML;
+			}
+		};
+		
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertMatches(matcher, unknown);
+	}
+	
+	@Test
+	public void doesNotMatchInvalidToStringOnUnknownXmlSource() {
+		Object unknown = new Object() {
+			@Override
+			public String toString() {
+				return INVALID_XML;
+			}
+		};
+		
+		Matcher<Object> matcher = xml(hasXPath("/elementRoot/elementSub"));
+		
+		assertDoesNotMatch(matcher, unknown);
+	}
+	
+	private File getFileWithContent(String content) throws IOException {
+		File file = tempFolder.newFile();
+		FileOutputStream out = new FileOutputStream(file);
+		out.write(content.getBytes());
+		out.close();
+		
+		return file;
+	}
+}


### PR DESCRIPTION
Allows arbitrary sources of XML to be be compatible with the `HasXPath` matcher by converting to `Node`. Currently handles `File`, `String` and `InputStream` conversions. For any class it does not recognize, it will call `toString()`.

Unit tests complete for multiple scenarios.
##### Examples

``` Java
/* Converts File to Node */
File file = new File("file.xml");
assertThat(file, xml(hasXPath("/elementOne/elementTwo"));
```

``` Java
/* Converts String to Node */
String xmlString = "<elementOne><elementTwo>Text</elementTwo></elementOne>";
assertThat(xmlString, xml(hasXPath("/elementOne/elementTwo"));
```

``` Java
/* As a last resort will call toString() on anything it does not recognize */
StringBuffer buffer = new StringBuffer();
buffer.append("<elementOne><elementTwo>");
buffer.append("Text");
buffer.append("</elementTwo></elementOne>");

assertThat(buffer, xml(hasXPath("/elementOne/elementTwo"));
```
##### Additional Improvements / TODO
- JavaDoc (I can take care of that this weekend, currently very late here)
- Some discussion on how best to handle exceptions related to parsing the XML
- Potential minor refactoring for reduction of repeat code
- Allow `Node` instances to pass through as-is
- Add more detailed messages for mismatches potentially different for each source type
- The name of the xml() method is also not being proposed as the only possible name, this can be easily refactored if a better name is suggested
