### PR TITLE
New matcher HasSubsequence

### DIFF
--- a/hamcrest-library/matchers.xml
+++ b/hamcrest-library/matchers.xml
@@ -19,7 +19,7 @@
     <factory class="org.hamcrest.core.StringEndsWith"/>
 
     <!-- Collection -->
-    <factory class="org.hamcrest.collection.HasConsecutiveItems"/>
+    <factory class="org.hamcrest.collection.HasSubsequence"/>
     <factory class="org.hamcrest.collection.IsArray"/>
     <factory class="org.hamcrest.collection.IsArrayContaining"/>
     <factory class="org.hamcrest.collection.IsArrayContainingInOrder"/>

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/HasSubsequence.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/HasSubsequence.java
@@ -15,25 +15,25 @@ import java.util.Collection;
  * Matches if a collection contains another collection's items in
  * consecutive order anywhere inside it.
  */
-public class HasConsecutiveItems<T>
+public class HasSubsequence<T>
     extends TypeSafeDiagnosingMatcher<Collection<? extends T>> {
     private final List<Matcher<? super T>> matchers;
 
-    public HasConsecutiveItems(List<Matcher<? super T>> matchers) {
+    public HasSubsequence(List<Matcher<? super T>> matchers) {
         this.matchers = matchers;
     }
 
     @Override
     public boolean matchesSafely(
-            Collection<? extends T> itemsToMatch,
+            Collection<? extends T> subsequenceToMatch,
             Description mismatchDescription) {
-        List<? extends T> itemsToMatchList = new ArrayList<T>(itemsToMatch);
+        List<? extends T> subsequenceToMatchList = new ArrayList<T>(subsequenceToMatch);
 
-        for (int i = 0; i <= itemsToMatchList.size() - matchers.size(); i++) {
+        for (int i = 0; i <= subsequenceToMatchList.size() - matchers.size(); i++) {
             boolean allMatchersMatched = true;
             for (int j = 0; j < matchers.size(); j++) {
                 Matcher<? super T> matcher = matchers.get(j);
-                if (!matcher.matches(itemsToMatchList.get(i + j))) {
+                if (!matcher.matches(subsequenceToMatchList.get(i + j))) {
                     allMatchersMatched = false;
                     break;
                 }
@@ -44,42 +44,42 @@ public class HasConsecutiveItems<T>
         }
 
         mismatchDescription
-                .appendText("could not find items inside collection ")
-                .appendValueList("[", ", ", "]", itemsToMatch);
+                .appendText("could not find subsequence inside collection ")
+                .appendValueList("[", ", ", "]", subsequenceToMatch);
         return false;
     }
 
     @Override
     public void describeTo(Description description) {
         description
-                .appendText("collection contains consecutive items matching ")
+                .appendText("collection contains subsequence matching ")
                 .appendList("[", ", ", "]", matchers);
     }
 
     @Factory
-    public static <T> Matcher<Collection<? extends T>> hasConsecutiveItems(
+    public static <T> Matcher<Collection<? extends T>> hasSubsequence(
             List<Matcher<? super T>> matchers) {
-        return new HasConsecutiveItems<T>(matchers);
+        return new HasSubsequence<T>(matchers);
     }
 
     @Factory
-    public static <T> Matcher<Collection<? extends T>> hasConsecutiveItems(
+    public static <T> Matcher<Collection<? extends T>> hasSubsequence(
             Matcher<? super T>... matchers) {
-        return hasConsecutiveItems(Arrays.asList(matchers));
+        return hasSubsequence(Arrays.asList(matchers));
     }
 
     @Factory
-    public static <T> Matcher<Collection<? extends T>> hasConsecutiveItems(
+    public static <T> Matcher<Collection<? extends T>> hasSubsequence(
             Iterable<? extends T> items) {
         List<Matcher<? super T>> matchers = new ArrayList<Matcher<? super T>>();
         for (Object item : items) {
             matchers.add(equalTo(item));
         }
-        return new HasConsecutiveItems<T>(matchers);
+        return new HasSubsequence<T>(matchers);
     }
 
     @Factory
-    public static <T> Matcher<Collection<? extends T>> hasConsecutiveItems(T... elements) {
-        return hasConsecutiveItems(Arrays.asList(elements));
+    public static <T> Matcher<Collection<? extends T>> hasSubsequence(T... elements) {
+        return hasSubsequence(Arrays.asList(elements));
     }
 }

--- a/hamcrest-library/src/test/java/org/hamcrest/collection/HasSubsequenceTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/collection/HasSubsequenceTest.java
@@ -9,61 +9,61 @@ import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.collection.HasConsecutiveItems.hasConsecutiveItems;
+import static org.hamcrest.collection.HasSubsequence.hasSubsequence;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @SuppressWarnings("unchecked")
-public class HasConsecutiveItemsTest extends AbstractMatcherTest {
-    private final Matcher<Collection<? extends WithValue>> contains123 = hasConsecutiveItems(value(1), value(2), value(3));
+public class HasSubsequenceTest extends AbstractMatcherTest {
+    private final Matcher<Collection<? extends WithValue>> contains123 = hasSubsequence(value(1), value(2), value(3));
 
     @Override
     protected Matcher<?> createMatcher() {
-        return hasConsecutiveItems(1, 2);
+        return hasSubsequence(1, 2);
     }
 
     public void testMatchingSingleItemCollection() throws Exception {
-        assertMatches("Single item iterable", hasConsecutiveItems(1), asList(1));
+        assertMatches("Single item iterable", hasSubsequence(1), asList(1));
     }
 
     public void testMatchingMultipleItemCollection() throws Exception {
-        assertMatches("Multiple item iterable", hasConsecutiveItems(1, 2, 3), asList(1, 2, 3));
+        assertMatches("Multiple item iterable", hasSubsequence(1, 2, 3), asList(1, 2, 3));
     }
 
     public void testMatchesWithMoreElementsThanExpectedAtBeginning() throws Exception {
-        assertMatches("More elements at beginning", hasConsecutiveItems(2, 3, 4), asList(1, 2, 3, 4));
+        assertMatches("More elements at beginning", hasSubsequence(2, 3, 4), asList(1, 2, 3, 4));
     }
 
     public void testMatchesWithMoreElementsThanExpectedAtEnd() throws Exception {
-        assertMatches("More elements at end", hasConsecutiveItems(1, 2, 3), asList(1, 2, 3, 4));
+        assertMatches("More elements at end", hasSubsequence(1, 2, 3), asList(1, 2, 3, 4));
     }
 
     public void testDoesNotMatchWithMoreElementsThanExpectedInBetween() throws Exception {
-        assertMismatchDescription("could not find items inside collection [<1>, <2>, <3>]", hasConsecutiveItems(1, 3), asList(1, 2, 3));
+        assertMismatchDescription("could not find subsequence inside collection [<1>, <2>, <3>]", hasSubsequence(1, 3), asList(1, 2, 3));
     }
 
     public void testMatchesSubSection() throws Exception {
-        assertMatches("Sub section of iterable", hasConsecutiveItems(2, 3), asList(1, 2, 3, 4));
+        assertMatches("Sub section of iterable", hasSubsequence(2, 3), asList(1, 2, 3, 4));
     }
 
     public void testDoesNotMatchWithFewerElementsThanExpected() throws Exception {
         List<WithValue> valueList = asList(make(1), make(2));
-        assertMismatchDescription("could not find items inside collection [<WithValue 1>, <WithValue 2>]", contains123, valueList);
+        assertMismatchDescription("could not find subsequence inside collection [<WithValue 1>, <WithValue 2>]", contains123, valueList);
     }
 
     public void testDoesNotMatchIfSingleItemNotFound() throws Exception {
-        assertMismatchDescription("could not find items inside collection [<WithValue 3>]", hasConsecutiveItems(value(4)), asList(make(3)));
+        assertMismatchDescription("could not find subsequence inside collection [<WithValue 3>]", hasSubsequence(value(4)), asList(make(3)));
     }
 
     public void testDoesNotMatchIfOneOfMultipleItemsNotFound() throws Exception {
-        assertMismatchDescription("could not find items inside collection [<WithValue 1>, <WithValue 2>, <WithValue 4>]", contains123, asList(make(1), make(2), make(4)));
+        assertMismatchDescription("could not find subsequence inside collection [<WithValue 1>, <WithValue 2>, <WithValue 4>]", contains123, asList(make(1), make(2), make(4)));
     }
 
     public void testDoesNotMatchEmptyCollection() throws Exception {
-        assertMismatchDescription("could not find items inside collection []", hasConsecutiveItems(value(4)), new ArrayList<WithValue>());
+        assertMismatchDescription("could not find subsequence inside collection []", hasSubsequence(value(4)), new ArrayList<WithValue>());
     }
 
     public void testHasAReadableDescription() {
-        assertDescription("collection contains consecutive items matching [<1>, <2>]", hasConsecutiveItems(1, 2));
+        assertDescription("collection contains subsequence matching [<1>, <2>]", hasSubsequence(1, 2));
     }
 
     public static class WithValue {


### PR DESCRIPTION
When implementing a library to test compiler command-line arguments in the form:

`-x foo -y -z bar`

I found I needed a Hamcrest matcher which would look for a consecutive
sequence of items anywhere inside a collection of items.

I was surprised that Hamcrest had matchers which:

1) Match if a collection includes a single item anywhere (`hasItem`)
2) Match if a collection includes multiple items anywhere (`hasItems`)
3) Match if a collection includes multiple items in order anywhere, consecutive or not (`containsInRelativeOrder`)
4) Match if a collection exactly matches another collection in order (`contains`)
5) Match if a collection exactly matches another collection in any order (`containsInAnyOrder`)

but not for a consecutive sequence of items anywhere inside the collection.

This implements such a matcher (`hasSubsequence`) and adds tests. I borrowed the tests from `containsInRelativeOrder`,
so let me know if there are better tests I should include. I wasn't sure about the `WithValue` stuff
so I just copy-pasted it from that test.
