### PR TITLE
    Mismatch description for AllOf made consistent with other matchers

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/core/AllOf.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/AllOf.java
@@ -25,8 +25,7 @@ public class AllOf<T> extends DiagnosingMatcher<T> {
     public boolean matches(Object o, Description mismatch) {
         for (Matcher<? super T> matcher : matchers) {
             if (!matcher.matches(o)) {
-                mismatch.appendDescriptionOf(matcher).appendText(" ");
-                matcher.describeMismatch(o, mismatch);
+            	matcher.describeMismatch(o, mismatch);
               return false;
             }
         }

--- a/hamcrest-core/src/test/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/AllOfTest.java
@@ -65,6 +65,6 @@ public final class AllOfTest {
 
     @Test public void
     hasAMismatchDescriptionDescribingTheFirstFailingMatch() {
-        assertMismatchDescription("\"good\" was \"bad\"", allOf(equalTo("bad"), equalTo("good")), "bad");
+        assertMismatchDescription("was \"bad\"", allOf(equalTo("bad"), equalTo("good")), "bad");
     }
 }

--- a/hamcrest-core/src/test/java/org/hamcrest/core/CombinableTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/CombinableTest.java
@@ -42,7 +42,7 @@ public final class CombinableTest {
     @Test public void
     bothDescribesItself() {
         assertDescription("(not <3> and not <4>)", NOT_3_AND_NOT_4);
-        assertMismatchDescription("not <3> was <3>", NOT_3_AND_NOT_4, 3);
+        assertMismatchDescription("was <3>", NOT_3_AND_NOT_4, 3);
     }
 
     @Test public void

--- a/hamcrest-core/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -87,7 +87,7 @@ public final class IsCollectionContainingTest {
     reportsMismatchWithAReadableDescriptionForMultipleItems() {
         final Matcher<Iterable<Integer>> matcher = hasItems(3, 4);
         
-        assertMismatchDescription("a collection containing <4> mismatches were: [was <1>, was <2>, was <3>]",
+        assertMismatchDescription("mismatches were: [was <1>, was <2>, was <3>]",
                                   matcher, asList(1, 2, 3));
     }
 


### PR DESCRIPTION
```
Mismatch description for AllOf made consistent with other matchers

Example:
is(2) against 3, would give a description of: was <3>
allOf(is(greaterThan(2)), is(equalTo(4))) against 3, normally gives a
mismatchDescription consisting of the description followed by the
mismatched value, as in:
(is a value greater than <2> and is <4>) was <3>
It now only resturns the actual mismatch as for most other matchers:
was <3>
```
