### PR TITLE
Improve Every mismatch descriptions (Issue 91)

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/internal/SelfDescribingText.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/internal/SelfDescribingText.java
@@ -1,0 +1,18 @@
+package org.hamcrest.internal;
+
+import org.hamcrest.Description;
+import org.hamcrest.SelfDescribing;
+
+public class SelfDescribingText implements SelfDescribing {
+
+    private final String text;
+
+    public SelfDescribingText(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(text);
+    }
+}

--- a/hamcrest-core/src/test/java/org/hamcrest/core/EveryTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/EveryTest.java
@@ -1,18 +1,13 @@
 package org.hamcrest.core;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.AbstractMatcherTest.assertDescription;
-import static org.hamcrest.AbstractMatcherTest.assertDoesNotMatch;
-import static org.hamcrest.AbstractMatcherTest.assertMatches;
-import static org.hamcrest.AbstractMatcherTest.assertMismatchDescription;
-import static org.hamcrest.AbstractMatcherTest.assertNullSafe;
-import static org.hamcrest.AbstractMatcherTest.assertUnknownTypeSafe;
-import static org.hamcrest.core.StringContains.containsString;
+import org.hamcrest.Matcher;
+import org.junit.Test;
 
 import java.util.ArrayList;
 
-import org.hamcrest.Matcher;
-import org.junit.Test;
+import static java.util.Arrays.asList;
+import static org.hamcrest.AbstractMatcherTest.*;
+import static org.hamcrest.core.StringContains.containsString;
 
 public final class EveryTest {
 
@@ -37,12 +32,18 @@ public final class EveryTest {
 
     @Test public void
     describesItself() {
-        assertDescription("every item is a string containing \"a\"", matcher);
+        assertDescription("a collection in which every item is a string containing \"a\"", matcher);
     }
 
     @Test public void
     describesAMismatch() {
         assertMismatchDescription("an item was \"BXB\"", matcher, asList("BXB"));
+    }
+
+    @Test public void
+    describesLotsOfMismatches() {
+        assertMismatchDescription("a collection with <2> mismatches: [was \"b\", was \"bit\"]",
+                matcher, asList("b", "a", "bat", "bit", "bar"));
     }
 }
 


### PR DESCRIPTION
 * Every now diagnoses *all* mismatches, in a (fairly) friendly way.
 * Extra test case added to illustrate this
 * Self description tweaked to be slightly more consistent with others.
 * Uses a newly added SelfDescribingText class.