### PR TITLE
Apply the 'osgi' plugin, so the jar includes a bundle manifest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ jar {
         attributes 'Implementation-Title': 'hamcrest-all',
                 'Implementation-Vendor': 'hamcrest.org',
                 'Implementation-Version': version
+        instruction 'Import-Package', '*; resolution:=optional'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import static org.gradle.api.JavaVersion.VERSION_1_7
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'osgi'
 apply plugin: 'signing'
 
 sourceCompatibility = VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,10 @@ jar {
         attributes 'Implementation-Title': 'hamcrest-all',
                 'Implementation-Vendor': 'hamcrest.org',
                 'Implementation-Version': version
-        instruction 'Import-Package', '*; resolution:=optional'
+        instruction 'Import-Package', '''javax.xml.namespace; resolution:=optional,
+                                         javax.xml.xpath; resolution:=optional,
+                                         org.w3c.dom; resolution:=optional,
+                                         *'''
     }
 }
 


### PR DESCRIPTION
This fixes #11. The plugin automatically determines Import-Package and
Export-Package based on analysis of the classes, and also adds
Tool, Bundle-Name, Bundle-Version, Bundle-SymbolicName and
others.

The manifest after this change looks like:

    Manifest-Version: 1.0
    Export-Package: org.hamcrest;version="2.0.0.0";uses:="javax.xml.namesp
     ace,org.hamcrest.collection,org.hamcrest.core,org.hamcrest.internal,o
     rg.w3c.dom",org.hamcrest.beans;version="2.0.0.0";uses:="org.hamcrest"
     ,org.hamcrest.collection;version="2.0.0.0";uses:="org.hamcrest",org.h
     amcrest.comparator;version="2.0.0.0";uses:="org.hamcrest",org.hamcres
     t.core;version="2.0.0.0";uses:="org.hamcrest",org.hamcrest.internal;v
     ersion="2.0.0.0";uses:="org.hamcrest",org.hamcrest.io;version="2.0.0.
     0";uses:="org.hamcrest",org.hamcrest.number;version="2.0.0.0";uses:="
     org.hamcrest",org.hamcrest.object;version="2.0.0.0";uses:="org.hamcre
     st",org.hamcrest.text;version="2.0.0.0";uses:="org.hamcrest",org.hamc
     rest.xml;version="2.0.0.0";uses:="javax.xml.namespace,org.hamcrest,or
     g.w3c.dom"
    Implementation-Title: hamcrest-all
    Implementation-Version: 2.0.0.0
    Tool: Bnd-2.1.0.20130426-122213
    Bundle-Name: java-hamcrest
    Created-By: 1.7.0_25 (Oracle Corporation)
    Implementation-Vendor: hamcrest.org
    Bundle-Version: 2.0.0.0
    Bnd-LastModified: 1424961114000
    Bundle-ManifestVersion: 2
    Import-Package: javax.xml.namespace,javax.xml.xpath,org.w3c.dom
    Bundle-SymbolicName: org.hamcrest.java-hamcrest

which looks right.