### PR TITLE
HasPropertyWithValue reports actual exception thrown by bean method

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static org.hamcrest.Condition.matched;
@@ -104,9 +105,12 @@ public class HasPropertyWithValue<T> extends TypeSafeDiagnosingMatcher<T> {
             public Condition<Object> apply(Method readMethod, Description mismatch) {
                 try {
                     return matched(readMethod.invoke(bean, NO_ARGUMENTS), mismatch);
-                } catch (Exception e) {
-                    mismatch.appendText(e.getMessage());
+                } catch (InvocationTargetException e) {
+                    final Throwable cause = e.getTargetException();
+                    mismatch.appendText(cause.getClass().getSimpleName() + " was thrown with message \"" + cause.getMessage() + "\"");
                     return notMatched();
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("We shouldn't get an IllegalAccessException, since we already verified the method is readable", e);
                 }
             }
         };

--- a/hamcrest-library/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -73,6 +73,10 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
     assertMismatchDescription("No property \"honk\"", hasProperty( "honk", anything()), shouldNotMatch);
   }
 
+  public void testExceptionsInBeanMethodsShouldBeReportedCorrectly() {
+    assertMismatchDescription("IllegalStateException was thrown with message \"getFoo() is not implemented correctly\"", hasProperty("foo", equalTo("bar")), new BuggyBean());
+  }
+
   public void testCanAccessAnAnonymousInnerClass() {
     class X implements IX {
       @Override
@@ -134,6 +138,12 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
       } catch (IntrospectionException e) {
         throw new RuntimeException("Introspection exception: " + e.getMessage());
       }
+    }
+  }
+
+  public static class BuggyBean {
+    public String getFoo() {
+      throw new IllegalStateException("getFoo() is not implemented correctly");
     }
   }
 }


### PR DESCRIPTION
When readMethod.invoke() was throwing an InvocationTargetException (i.e when the readMethod's execution was throwing an exception), the actual exception and message were lost (e.getMessage() of the InvocationTargetException is null).
With this patch, we report the actual exception's type and message.