### PR TITLE
add Matcher#and, a fluent way to build AllOf

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/BaseMatcher.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/BaseMatcher.java
@@ -1,5 +1,7 @@
 package org.hamcrest;
 
+import org.hamcrest.core.AllOf;
+
 /**
  * BaseClass for all Matcher implementations.
  *
@@ -14,6 +16,14 @@ public abstract class BaseMatcher<T> implements Matcher<T> {
     @Deprecated
     public final void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
         // See Matcher interface for an explanation of this method.
+    }
+
+    /**
+     * @see AllOf#allOf(Matcher[])
+     */
+    @Override
+    public Matcher<T> and(Matcher<? super T> otherMatcher) {
+        return AllOf.<T>allOf(this, otherMatcher);
     }
 
     @Override

--- a/hamcrest-core/src/main/java/org/hamcrest/Matcher.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/Matcher.java
@@ -35,6 +35,15 @@ public interface Matcher<T> extends SelfDescribing {
     boolean matches(Object item);
     
     /**
+     * Creates a new Matcher that matches when both this and the given
+     * matcher match.
+     *
+     * @param otherMatcher
+     * @return a Matcher matching when both this and the given matcher match
+     */
+    Matcher<T> and(Matcher<? super T> otherMatcher);
+
+    /**
      * Generate a description of why the matcher has not accepted the item.
      * The description will be part of a larger description of why a matching
      * failed, so it should be concise. 

--- a/hamcrest-core/src/test/java/org/hamcrest/BaseMatcherTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/BaseMatcherTest.java
@@ -1,26 +1,46 @@
 package org.hamcrest;
 
+import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public final class BaseMatcherTest {
 
     @Test
     public void
     describesItselfWithToStringMethod() {
-        Matcher<Object> someMatcher = new BaseMatcher<Object>() {
-            @Override
-            public boolean matches(Object item) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("SOME DESCRIPTION");
-            }
-        };
+        Matcher<Object> someMatcher = new ConcreteBaseMacther<Object>("SOME DESCRIPTION");
 
         assertEquals("SOME DESCRIPTION", someMatcher.toString());
+    }
+    
+    @Test
+    public void and() {
+        Matcher<Object> first = new ConcreteBaseMacther<Object>("SOME MATCHER");
+        Matcher<Object> second = new ConcreteBaseMacther<Object>("SOME OTHER MATCHER");
+        Matcher<Object> actualAnd = first.and(second);
+        Matcher<Object> expectedAnd = AllOf.<Object>allOf(first, second);
+        assertEquals(expectedAnd.toString(), actualAnd.toString());
+    }
+
+    private static class ConcreteBaseMacther<T> extends BaseMatcher<T> {
+
+        private String string;
+
+        public ConcreteBaseMacther(String string) {
+            this.string = string;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText(string);
+        }
     }
 }


### PR DESCRIPTION
Example of usage:

```
assertThat(alphabet, startsWith("a").and(endsWith("z"));
```

If you like the idea I will also add Matcher#or.
Then should we deprecate CombinableMatcher?