### PR TITLE
add BaseMatcher#equals

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/BaseMatcher.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/BaseMatcher.java
@@ -21,6 +21,18 @@ public abstract class BaseMatcher<T> implements Matcher<T> {
         description.appendText("was ").appendValue(item);
     }
 
+    /**
+     * @return true if the given object is a BaseMatcher
+     * and its String representation is equal to this one.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == null || !(obj instanceof BaseMatcher)) {
+            return false;
+        }
+        return toString().equals(obj.toString());
+    }
+
     @Override
     public String toString() {
         return StringDescription.toString(this);

--- a/hamcrest-core/src/test/java/org/hamcrest/BaseMatcherTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/BaseMatcherTest.java
@@ -3,24 +3,58 @@ package org.hamcrest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public final class BaseMatcherTest {
 
     @Test
     public void
     describesItselfWithToStringMethod() {
-        Matcher<Object> someMatcher = new BaseMatcher<Object>() {
-            @Override
-            public boolean matches(Object item) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("SOME DESCRIPTION");
-            }
-        };
+        Matcher<Object> someMatcher = new ConcreteBaseMacther<Object>("SOME DESCRIPTION");
 
         assertEquals("SOME DESCRIPTION", someMatcher.toString());
+    }
+
+    @Test
+    public void equals_givenNullOtherMatcher() {
+        Matcher<Object> out = new ConcreteBaseMacther<Object>("OBJECT UNDER TEST");
+        boolean actual = out.equals(null);
+        assertFalse(actual);
+    }
+
+    @Test
+    public void equals_givenMatcherWithDifferentDescription() {
+        Matcher<Object> out = new ConcreteBaseMacther<Object>("OBJECT UNDER TEST");
+        Matcher<Object> otherMatcher = new ConcreteBaseMacther<Object>("OTHER MATCHER");
+        boolean actual = out.equals(otherMatcher);
+        assertFalse(actual);
+    }
+
+    @Test
+    public void equals_givenMatcherWithSameDescription() {
+        Matcher<Object> out = new ConcreteBaseMacther<Object>("OBJECT UNDER TEST");
+        Matcher<Object> otherMatcher = new ConcreteBaseMacther<Object>("OBJECT UNDER TEST");
+        boolean actual = out.equals(otherMatcher);
+        assertTrue(actual);
+    }
+
+    private static class ConcreteBaseMacther<T> extends BaseMatcher<T> {
+
+        private String string;
+
+        public ConcreteBaseMacther(String string) {
+            this.string = string;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText(string);
+        }
     }
 }


### PR DESCRIPTION
This implementation is quite naive and relies on toString:

```
return toString().equals(obj.toString());
```

Considering that toString in turn relies on Description, which is pretty accurate and usually includes all of the variables (actual and expected), it should be actually quite good despite naive.