### PR TITLE
Fix StringContainsInOrder to detect if a repeated pattern is missing

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInOrder.java
@@ -22,6 +22,7 @@ public class StringContainsInOrder extends TypeSafeMatcher<String> {
             if (fromIndex == -1) {
                 return false;
             }
+            fromIndex++;
         }
         
         return true;

--- a/hamcrest-library/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -7,7 +7,7 @@ import static java.util.Arrays.asList;
 
 
 public class StringContainsInOrderTest extends AbstractMatcherTest {
-    StringContainsInOrder m = new StringContainsInOrder(asList("a", "b", "c"));
+    StringContainsInOrder m = new StringContainsInOrder(asList("a", "b", "c", "c"));
 
     @Override
     protected Matcher<?> createMatcher() {
@@ -15,9 +15,10 @@ public class StringContainsInOrderTest extends AbstractMatcherTest {
     }
     
     public void testMatchesOnlyIfStringContainsGivenSubstringsInTheSameOrder() {
-        assertMatches("substrings in order", m, "abc");
-        assertMatches("substrings separated", m, "1a2b3c4");
+        assertMatches("substrings in order", m, "abcc");
+        assertMatches("substrings separated", m, "1a2b3c4c5");
         
+        assertDoesNotMatch("substrings in order missing a repeated pattern", m, "abc");
         assertDoesNotMatch("substrings out of order", m, "cab");
         assertDoesNotMatch("no substrings in string", m, "xyz");
         assertDoesNotMatch("substring missing", m, "ac");
@@ -25,6 +26,6 @@ public class StringContainsInOrderTest extends AbstractMatcherTest {
     }
     
     public void testHasAReadableDescription() {
-        assertDescription("a string containing \"a\", \"b\", \"c\" in order", m);
+        assertDescription("a string containing \"a\", \"b\", \"c\", \"c\" in order", m);
     }
 }


### PR DESCRIPTION
Eg: StringContainsInOrder(asList("abc", "abc")) should fail when matching "---abc---"

For now matchesSafely does not increment 'fromIndex', the next call to indexOf does not return -1; so it does not fail.