### PR TITLE
Waiting Matcher

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1617,7 +1617,7 @@ public class Matchers {
    * @param timeoutMs       timeout in milliseconds
    * @param <T>             accepted value type of the original matcher
    * @return matcher which waits
-   * @see #stateMatches(org.hamcrest.concurrent.WaitFor.WaitForFunction, Matcher)
+   * @see #applying(org.hamcrest.function.Function, Matcher)
    * @see #waitFor(Matcher, long, java.util.concurrent.TimeUnit)
    */
   public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeoutMs) {
@@ -1634,7 +1634,7 @@ public class Matchers {
    * @param timeUnit        timeout unit
    * @param <T>             accepted value type of the original matcher
    * @return matcher which waits
-   * @see #stateMatches(org.hamcrest.concurrent.WaitFor.WaitForFunction, Matcher)
+   * @see #applying(org.hamcrest.function.Function, Matcher)
    * @see #waitFor(Matcher, long)
    */
   public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeout, java.util.concurrent.TimeUnit timeUnit) {
@@ -1646,18 +1646,17 @@ public class Matchers {
    * Applies a transformation to the value before comparing the transformed result with the given matcher.
    * </p>
    *
-   * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
-   *                      to the target value (typically its state)
-   * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
-   * @param <F>           type to input into assertion
-   * @param <T>           actual value type to compare
+   * @param function        the function to apply to convert the asserted value to the target value
+   * @param delegateMatcher matcher to apply to the transformed value; typically the state of the component under test
+   * @param <F>             type to input into assertion
+   * @param <T>             actual value type to compare
    * @return matcher which transforms input before comparison
    * @see #waitFor(Matcher, long, java.util.concurrent.TimeUnit)
    * @see #waitFor(Matcher, long)
    */
-  public static <F, T> Matcher<F> stateMatches(org.hamcrest.concurrent.WaitFor.WaitForFunction<F, T> stateFunction,
-                                               Matcher<? super T> stateMatcher) {
-    return org.hamcrest.concurrent.WaitFor.stateMatches(stateFunction, stateMatcher);
+  public static <F, T> Matcher<F> applying(org.hamcrest.function.Function<F, T> function,
+                                               Matcher<? super T> delegateMatcher) {
+    return org.hamcrest.function.ApplyingMatcher.applying(function, delegateMatcher);
   }
 
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1610,7 +1610,7 @@ public class Matchers {
 
   /**
    * Creates a matcher which waits for the embedded matcher to evaluate to true.
-   * It is required that the embedded matcher changes its state over time thus
+   * It is required that the embedded matcher checks a mutable aspect of the matched object thus
    * typical default matchers like {@code equalTo} won't work.
    *
    * @param originalMatcher the original matcher to wait to return true
@@ -1626,7 +1626,7 @@ public class Matchers {
 
   /**
    * Creates a matcher which waits for the embedded matcher to evaluate to true.
-   * It is required that the embedded matcher changes its state over time thus
+   * It is required that the embedded matcher checks a mutable aspect of the matched object thus
    * typical default matchers like {@code equalTo} won't work.
    *
    * @param originalMatcher the original matcher to wait to return true

--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1608,4 +1608,56 @@ public class Matchers {
     return org.hamcrest.xml.HasXPath.hasXPath(xPath, namespaceContext);
   }
 
+  /**
+   * Creates a matcher which waits for the embedded matcher to evaluate to true.
+   * It is required that the embedded matcher changes its state over time thus
+   * typical default matchers like {@code equalTo} won't work.
+   *
+   * @param originalMatcher the original matcher to wait to return true
+   * @param timeoutMs       timeout in milliseconds
+   * @param <T>             accepted value type of the original matcher
+   * @return matcher which waits
+   * @see #stateMatches(org.hamcrest.concurrent.WaitFor.WaitForFunction, Matcher)
+   * @see #waitFor(Matcher, long, java.util.concurrent.TimeUnit)
+   */
+  public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeoutMs) {
+    return org.hamcrest.concurrent.WaitFor.waitFor(originalMatcher, timeoutMs);
+  }
+
+  /**
+   * Creates a matcher which waits for the embedded matcher to evaluate to true.
+   * It is required that the embedded matcher changes its state over time thus
+   * typical default matchers like {@code equalTo} won't work.
+   *
+   * @param originalMatcher the original matcher to wait to return true
+   * @param timeout         timeout amount
+   * @param timeUnit        timeout unit
+   * @param <T>             accepted value type of the original matcher
+   * @return matcher which waits
+   * @see #stateMatches(org.hamcrest.concurrent.WaitFor.WaitForFunction, Matcher)
+   * @see #waitFor(Matcher, long)
+   */
+  public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeout, java.util.concurrent.TimeUnit timeUnit) {
+    return org.hamcrest.concurrent.WaitFor.waitFor(originalMatcher, timeout, timeUnit);
+  }
+
+  /**
+   * <p>
+   * Applies a transformation to the value before comparing the transformed result with the given matcher.
+   * </p>
+   *
+   * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
+   *                      to the target value (typically its state)
+   * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
+   * @param <F>           type to input into assertion
+   * @param <T>           actual value type to compare
+   * @return matcher which transforms input before comparison
+   * @see #waitFor(Matcher, long, java.util.concurrent.TimeUnit)
+   * @see #waitFor(Matcher, long)
+   */
+  public static <F, T> Matcher<F> stateMatches(org.hamcrest.concurrent.WaitFor.WaitForFunction<F, T> stateFunction,
+                                               Matcher<? super T> stateMatcher) {
+    return org.hamcrest.concurrent.WaitFor.stateMatches(stateFunction, stateMatcher);
+  }
+
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/concurrent/WaitFor.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/concurrent/WaitFor.java
@@ -58,268 +58,268 @@ import static java.util.Objects.requireNonNull;
  * @see <a href="http://minds.coremedia.com/2012/11/29/haste-makes-waste/">Haste makes waste | Minds</a>
  */
 public class WaitFor<T> extends TypeSafeMatcher<T> {
-  /**
-   * Initial delay to wait if we need to wait.
-   */
-  private static final long INITIAL_DELAY_MS = 10L;
-  /**
-   * Factor by which the polling factor decelerates.
-   */
-  private static final double DECELERATION_FACTOR = 1.1;
-  /**
-   * A grace period for the last poll.
-   */
-  private static final long SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS = 100L;
+    /**
+     * Initial delay to wait if we need to wait.
+     */
+    private static final long INITIAL_DELAY_MS = 10L;
+    /**
+     * Factor by which the polling factor decelerates.
+     */
+    private static final double DECELERATION_FACTOR = 1.1;
+    /**
+     * A grace period for the last poll.
+     */
+    private static final long SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS = 100L;
 
-  /**
-   * Original matcher who is required to changes its state while waiting.
-   */
-  private final Matcher<T> originalMatcher;
-  /**
-   * Amount of timeout.
-   *
-   * @see #timeUnit
-   */
-  private final long timeout;
-  /**
-   * Unit for timeout.
-   *
-   * @see #timeout
-   */
-  private final TimeUnit timeUnit;
+    /**
+     * Original matcher who is required to changes its state while waiting.
+     */
+    private final Matcher<T> originalMatcher;
+    /**
+     * Amount of timeout.
+     *
+     * @see #timeUnit
+     */
+    private final long timeout;
+    /**
+     * Unit for timeout.
+     *
+     * @see #timeout
+     */
+    private final TimeUnit timeUnit;
 
-  /**
-   * Constructor with original matcher and timeout. For convenience it is recommended to use the
-   * factory methods instead.
-   *
-   * @param originalMatcher matcher to wrap; must change its state over time
-   * @param timeout         amount of timeout
-   * @param timeUnit        unit of timeout
-   */
-  public WaitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
-    this.originalMatcher = requireNonNull(originalMatcher, "Original matcher must not be null.");
-    this.timeout = timeout;
-    this.timeUnit = requireNonNull(timeUnit, "Timeunit must not be null.");
-  }
-
-  @Override
-  protected boolean matchesSafely(T item) {
-    long timeoutMs = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
-    long deadlineTimeMs = nowMillis() + timeoutMs;
-    // At first, wait 10ms between checks.
-    long delay = INITIAL_DELAY_MS;
-
-    boolean result;
-    while (true) {
-      long beforeEvaluationTimeMs = nowMillis();
-      result = originalMatcher.matches(item);
-      long afterEvaluationTimeMs = nowMillis();
-      if (result || afterEvaluationTimeMs > deadlineTimeMs) {
-        break;
-      }
-      delay = sleepAndRecalculateDelay(delay, deadlineTimeMs, beforeEvaluationTimeMs, afterEvaluationTimeMs);
-    }
-    return result;
-  }
-
-  /**
-   * {@inheritDoc}
-   * <p>
-   * The description is the same as from the original matcher.
-   * </p>
-   */
-  @Override
-  public void describeTo(Description description) {
-    originalMatcher.describeTo(description);
-  }
-
-  /**
-   * <p>
-   * Describes the mismatch by falling back to the original matcher's mismatch description.
-   * </p>
-   * <dl>
-   * <dt><strong>Note:</strong></dt>
-   * <dd>
-   * <p>
-   * As the item tested here is expected to change over time it might result in a mismatch description
-   * which does not match the invalid state retrieved before. Thus you might want to store the state
-   * between comparison and failure.
-   * </p>
-   * </dd>
-   * </dl>
-   */
-  @Override
-  protected void describeMismatchSafely(T item, Description mismatchDescription) {
-    originalMatcher.describeMismatch(item, mismatchDescription);
-  }
-
-  /**
-   * <p>
-   * Decelerating wait. Decreases the polling interval over time to give the system under test a chance to
-   * actually reach the desired state.
-   * </p>
-   */
-  private long sleepAndRecalculateDelay(long previousDelay,
-                                        long deadlineTimeMs,
-                                        long beforeEvaluationTimeMs,
-                                        long afterEvaluationTimeMs) {
-    long newDelay = previousDelay;
-    // Leave at least as much time between two checks as the check itself took.
-    final long lastDuration = afterEvaluationTimeMs - beforeEvaluationTimeMs;
-    if (lastDuration > newDelay) {
-      newDelay = lastDuration;
+    /**
+     * Constructor with original matcher and timeout. For convenience it is recommended to use the
+     * factory methods instead.
+     *
+     * @param originalMatcher matcher to wrap; must change its state over time
+     * @param timeout         amount of timeout
+     * @param timeUnit        unit of timeout
+     */
+    public WaitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
+        this.originalMatcher = requireNonNull(originalMatcher, "Original matcher must not be null.");
+        this.timeout = timeout;
+        this.timeUnit = requireNonNull(timeUnit, "Timeunit must not be null.");
     }
 
-    // Wait, but not much longer than until the deadlineTimeMillis and at least a millisecond.
-    try {
-      sleep(Math.max(1, Math.min(newDelay, deadlineTimeMs + SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS - afterEvaluationTimeMs)));
-    } catch (InterruptedException e) {
-      throw new IllegalStateException("Unexpected interruption.", e);
+    @Override
+    protected boolean matchesSafely(T item) {
+        long timeoutMs = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
+        long deadlineTimeMs = nowMillis() + timeoutMs;
+        // At first, wait 10ms between checks.
+        long delay = INITIAL_DELAY_MS;
+
+        boolean result;
+        while (true) {
+            long beforeEvaluationTimeMs = nowMillis();
+            result = originalMatcher.matches(item);
+            long afterEvaluationTimeMs = nowMillis();
+            if (result || afterEvaluationTimeMs > deadlineTimeMs) {
+                break;
+            }
+            delay = sleepAndRecalculateDelay(delay, deadlineTimeMs, beforeEvaluationTimeMs, afterEvaluationTimeMs);
+        }
+        return result;
     }
 
-    // Make checks less and less frequently.
-    // Increase the wait period using the deceleration factor, but
-    // wait at least one millisecond longer next time.
-    newDelay = Math.max(newDelay + 1, (long) (newDelay * DECELERATION_FACTOR));
-    return newDelay;
-  }
-
-  /**
-   * Sleep the given number of milliseconds.
-   *
-   * @param millis how long to sleep
-   * @throws InterruptedException if the current thread has been interrupted
-   */
-  protected void sleep(long millis) throws InterruptedException {
-    Thread.sleep(millis);
-  }
-
-  /**
-   * Retrieve the current time in milliseconds. Especially allows to override this behavior for testing purpose.
-   *
-   * @return time in milliseconds
-   */
-  protected long nowMillis() {
-    return System.currentTimeMillis();
-  }
-
-  /**
-   * <p>
-   * A function which is used to transform a component under test {@code F} to a state {@code T} which changes over
-   * time.
-   * </p>
-   * <p>
-   * This is a convenience interface if you cannot use Java 8+ functions or use Guava's Function interface.
-   * </p>
-   *
-   * @param <F> type of value to transform; typically the component under test
-   * @param <T> type of the target value to transform to; typically a value which represents the state of the
-   *            component under test
-   */
-  public interface WaitForFunction<F, T> {
-    T apply(F input);
-  }
-
-  /**
-   * <p>
-   * Matcher to delegate the matching of a transformed value to another (a normal) matcher.
-   * </p>
-   * <dl>
-   * <dt><strong>Note:</strong></dt>
-   * <dd>
-   * In order not to report a different state on failure than used for comparison the previously
-   * retrieved state is stored per thread when matching is tried. As a consequence
-   * {@link #describeMismatchSafely(Object, Description)} ignores the item expecting that it did
-   * not change meanwhile.
-   * </dd>
-   * </dl>
-   *
-   * @param <F> type of the actual value in the assertion; typically the component under test
-   * @param <T> type of the actual value to compare; typically the state of the component under test
-   */
-  public static class DelegatingWaitMatcher<F, T> extends TypeSafeMatcher<F> {
-    private final ThreadLocal<T> lastValue = new ThreadLocal<>();
-    private final WaitForFunction<F, T> stateFunction;
-    private final Matcher<? super T> stateMatcher;
-
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The description is the same as from the original matcher.
+     * </p>
+     */
+    @Override
+    public void describeTo(Description description) {
+        originalMatcher.describeTo(description);
+    }
 
     /**
      * <p>
-     * Constructor.
+     * Describes the mismatch by falling back to the original matcher's mismatch description.
+     * </p>
+     * <dl>
+     * <dt><strong>Note:</strong></dt>
+     * <dd>
+     * <p>
+     * As the item tested here is expected to change over time it might result in a mismatch description
+     * which does not match the invalid state retrieved before. Thus you might want to store the state
+     * between comparison and failure.
+     * </p>
+     * </dd>
+     * </dl>
+     */
+    @Override
+    protected void describeMismatchSafely(T item, Description mismatchDescription) {
+        originalMatcher.describeMismatch(item, mismatchDescription);
+    }
+
+    /**
+     * <p>
+     * Decelerating wait. Decreases the polling interval over time to give the system under test a chance to
+     * actually reach the desired state.
+     * </p>
+     */
+    private long sleepAndRecalculateDelay(long previousDelay,
+                                          long deadlineTimeMs,
+                                          long beforeEvaluationTimeMs,
+                                          long afterEvaluationTimeMs) {
+        long newDelay = previousDelay;
+        // Leave at least as much time between two checks as the check itself took.
+        final long lastDuration = afterEvaluationTimeMs - beforeEvaluationTimeMs;
+        if (lastDuration > newDelay) {
+            newDelay = lastDuration;
+        }
+
+        // Wait, but not much longer than until the deadlineTimeMillis and at least a millisecond.
+        try {
+            sleep(Math.max(1, Math.min(newDelay, deadlineTimeMs + SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS - afterEvaluationTimeMs)));
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Unexpected interruption.", e);
+        }
+
+        // Make checks less and less frequently.
+        // Increase the wait period using the deceleration factor, but
+        // wait at least one millisecond longer next time.
+        newDelay = Math.max(newDelay + 1, (long) (newDelay * DECELERATION_FACTOR));
+        return newDelay;
+    }
+
+    /**
+     * Sleep the given number of milliseconds.
+     *
+     * @param millis how long to sleep
+     * @throws InterruptedException if the current thread has been interrupted
+     */
+    protected void sleep(long millis) throws InterruptedException {
+        Thread.sleep(millis);
+    }
+
+    /**
+     * Retrieve the current time in milliseconds. Especially allows to override this behavior for testing purpose.
+     *
+     * @return time in milliseconds
+     */
+    protected long nowMillis() {
+        return System.currentTimeMillis();
+    }
+
+    /**
+     * <p>
+     * A function which is used to transform a component under test {@code F} to a state {@code T} which changes over
+     * time.
+     * </p>
+     * <p>
+     * This is a convenience interface if you cannot use Java 8+ functions or use Guava's Function interface.
+     * </p>
+     *
+     * @param <F> type of value to transform; typically the component under test
+     * @param <T> type of the target value to transform to; typically a value which represents the state of the
+     *            component under test
+     */
+    public interface WaitForFunction<F, T> {
+        T apply(F input);
+    }
+
+    /**
+     * <p>
+     * Matcher to delegate the matching of a transformed value to another (a normal) matcher.
+     * </p>
+     * <dl>
+     * <dt><strong>Note:</strong></dt>
+     * <dd>
+     * In order not to report a different state on failure than used for comparison the previously
+     * retrieved state is stored per thread when matching is tried. As a consequence
+     * {@link #describeMismatchSafely(Object, Description)} ignores the item expecting that it did
+     * not change meanwhile.
+     * </dd>
+     * </dl>
+     *
+     * @param <F> type of the actual value in the assertion; typically the component under test
+     * @param <T> type of the actual value to compare; typically the state of the component under test
+     */
+    public static class DelegatingWaitMatcher<F, T> extends TypeSafeMatcher<F> {
+        private final ThreadLocal<T> lastValue = new ThreadLocal<>();
+        private final WaitForFunction<F, T> stateFunction;
+        private final Matcher<? super T> stateMatcher;
+
+
+        /**
+         * <p>
+         * Constructor.
+         * </p>
+         *
+         * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
+         *                      to the target value (typically its state)
+         * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
+         */
+        public DelegatingWaitMatcher(WaitForFunction<F, T> stateFunction, Matcher<? super T> stateMatcher) {
+            this.stateFunction = requireNonNull(stateFunction, "State function must not be null.");
+            this.stateMatcher = requireNonNull(stateMatcher, "Matcher for state value must not be null.");
+        }
+
+        @Override
+        protected boolean matchesSafely(F item) {
+            lastValue.set(stateFunction.apply(item));
+            return stateMatcher.matches(lastValue.get());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            stateMatcher.describeTo(description);
+        }
+
+        @Override
+        protected void describeMismatchSafely(F item, Description mismatchDescription) {
+            // Ignoring item, expecting that it did not change between call to describeMismatch and matches.
+            stateMatcher.describeMismatch(lastValue.get(), mismatchDescription);
+        }
+
+    }
+
+    /**
+     * Creates a matcher which waits for the embedded matcher to evaluate to true.
+     * It is required that the embedded matcher changes its state over time thus
+     * typical default matchers like {@code equalTo} won't work.
+     *
+     * @param originalMatcher the original matcher to wait to return true
+     * @param timeoutMs       timeout in milliseconds
+     * @param <T>             accepted value type of the original matcher
+     * @return matcher which waits
+     */
+    public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeoutMs) {
+        return waitFor(originalMatcher, timeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Creates a matcher which waits for the embedded matcher to evaluate to true.
+     * It is required that the embedded matcher changes its state over time thus
+     * typical default matchers like {@code equalTo} won't work.
+     *
+     * @param originalMatcher the original matcher to wait to return true
+     * @param timeout         timeout amount
+     * @param timeUnit        timeout unit
+     * @param <T>             accepted value type of the original matcher
+     * @return matcher which waits
+     */
+    public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
+        return new WaitFor<>(originalMatcher, timeout, timeUnit);
+    }
+
+    /**
+     * <p>
+     * Applies a transformation to the value before comparing the transformed result with the given matcher.
      * </p>
      *
      * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
      *                      to the target value (typically its state)
      * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
+     * @param <F>           type to input into assertion
+     * @param <T>           actual value type to compare
+     * @return matcher which transforms input before comparison
      */
-    public DelegatingWaitMatcher(WaitForFunction<F, T> stateFunction, Matcher<? super T> stateMatcher) {
-      this.stateFunction = requireNonNull(stateFunction, "State function must not be null.");
-      this.stateMatcher = requireNonNull(stateMatcher, "Matcher for state value must not be null.");
+    public static <F, T> Matcher<F> stateMatches(WaitForFunction<F, T> stateFunction,
+                                                 Matcher<? super T> stateMatcher) {
+        return new DelegatingWaitMatcher<>(stateFunction, stateMatcher);
     }
-
-    @Override
-    protected boolean matchesSafely(F item) {
-      lastValue.set(stateFunction.apply(item));
-      return stateMatcher.matches(lastValue.get());
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      stateMatcher.describeTo(description);
-    }
-
-    @Override
-    protected void describeMismatchSafely(F item, Description mismatchDescription) {
-      // Ignoring item, expecting that it did not change between call to describeMismatch and matches.
-      stateMatcher.describeMismatch(lastValue.get(), mismatchDescription);
-    }
-
-  }
-
-  /**
-   * Creates a matcher which waits for the embedded matcher to evaluate to true.
-   * It is required that the embedded matcher changes its state over time thus
-   * typical default matchers like {@code equalTo} won't work.
-   *
-   * @param originalMatcher the original matcher to wait to return true
-   * @param timeoutMs       timeout in milliseconds
-   * @param <T>             accepted value type of the original matcher
-   * @return matcher which waits
-   */
-  public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeoutMs) {
-    return waitFor(originalMatcher, timeoutMs, TimeUnit.MILLISECONDS);
-  }
-
-  /**
-   * Creates a matcher which waits for the embedded matcher to evaluate to true.
-   * It is required that the embedded matcher changes its state over time thus
-   * typical default matchers like {@code equalTo} won't work.
-   *
-   * @param originalMatcher the original matcher to wait to return true
-   * @param timeout         timeout amount
-   * @param timeUnit        timeout unit
-   * @param <T>             accepted value type of the original matcher
-   * @return matcher which waits
-   */
-  public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
-    return new WaitFor<>(originalMatcher, timeout, timeUnit);
-  }
-
-  /**
-   * <p>
-   * Applies a transformation to the value before comparing the transformed result with the given matcher.
-   * </p>
-   *
-   * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
-   *                      to the target value (typically its state)
-   * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
-   * @param <F>           type to input into assertion
-   * @param <T>           actual value type to compare
-   * @return matcher which transforms input before comparison
-   */
-  public static <F, T> Matcher<F> stateMatches(WaitForFunction<F, T> stateFunction,
-                                               Matcher<? super T> stateMatcher) {
-    return new DelegatingWaitMatcher<>(stateFunction, stateMatcher);
-  }
 
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/concurrent/WaitFor.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/concurrent/WaitFor.java
@@ -1,0 +1,325 @@
+package org.hamcrest.concurrent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * <p>
+ * Wait for the given matcher to evaluate to true. It is required that the embedded matcher changes its state over time.
+ * </p>
+ * <p>
+ * This matcher uses a decelerating wait approach, i. e. it tries to poll the state very often at the beginning
+ * of the wait period and slows down towards the end. As a result fast system under tests will finish very quickly
+ * while slower systems are given more time to actually reach the wanted state. If the state is reached directly
+ * the algorithm will not even wait at all.
+ * </p>
+ * <dl>
+ * <dt><strong>Convenience Function Included:</strong></dt>
+ * <dd>
+ * <p>
+ * Most of the time using this matcher you will have a component under test which changes its state over time. For
+ * the assertion you will need to retrieve the state of this component repeatedly until it meets your required
+ * conditions.
+ * </p>
+ * <p>
+ * Therefore this matcher comes with two inner classes ready to be filled with your state retrieving function
+ * and to compare the retrieved state with any normal matcher available in the library. If you rely on Guava or
+ * Java 8 you might as well use the functional interfaces they provide. So this is just for convenience if you happen
+ * not to have Guava and/or Java 8 at hand.
+ * </p>
+ * </dd>
+ * <dt><strong>Usage:</strong></dt>
+ * <dd>
+ * <p>
+ * Relying on the function mentioned above a typical usage might look like this:
+ * </p>
+ * <pre>{@code
+ * ComponentUnderTest cut = ...;
+ * State expectedState = ...;
+ * WaitForFunction<ComponentUnderTest,State> stateFunction = new WaitForFunction<>() { ... };
+ * assertThat(componentUnderTest, waitFor(stateMatches(stateFunction, equalTo(expectedState)), 2, SECONDS));
+ * }</pre>
+ * </dd>
+ * <dt><strong>Note:</strong></dt>
+ * <dd>
+ * Unlike other matchers it is not useful to combine this matcher with e. g. logical operations like for example
+ * <em>not</em>. Such logical operations need to be placed in the embedded matcher instead.
+ * </dd>
+ * </dl>
+ *
+ * @param <T> original type of the wrapped matcher
+ * @author Olaf Kummer
+ * @author Mark Michaelis
+ * @see <a href="http://minds.coremedia.com/2012/11/29/haste-makes-waste/">Haste makes waste | Minds</a>
+ */
+public class WaitFor<T> extends TypeSafeMatcher<T> {
+  /**
+   * Initial delay to wait if we need to wait.
+   */
+  private static final long INITIAL_DELAY_MS = 10L;
+  /**
+   * Factor by which the polling factor decelerates.
+   */
+  private static final double DECELERATION_FACTOR = 1.1;
+  /**
+   * A grace period for the last poll.
+   */
+  private static final long SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS = 100L;
+
+  /**
+   * Original matcher who is required to changes its state while waiting.
+   */
+  private final Matcher<T> originalMatcher;
+  /**
+   * Amount of timeout.
+   *
+   * @see #timeUnit
+   */
+  private final long timeout;
+  /**
+   * Unit for timeout.
+   *
+   * @see #timeout
+   */
+  private final TimeUnit timeUnit;
+
+  /**
+   * Constructor with original matcher and timeout. For convenience it is recommended to use the
+   * factory methods instead.
+   *
+   * @param originalMatcher matcher to wrap; must change its state over time
+   * @param timeout         amount of timeout
+   * @param timeUnit        unit of timeout
+   */
+  public WaitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
+    this.originalMatcher = requireNonNull(originalMatcher, "Original matcher must not be null.");
+    this.timeout = timeout;
+    this.timeUnit = requireNonNull(timeUnit, "Timeunit must not be null.");
+  }
+
+  @Override
+  protected boolean matchesSafely(T item) {
+    long timeoutMs = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
+    long deadlineTimeMs = nowMillis() + timeoutMs;
+    // At first, wait 10ms between checks.
+    long delay = INITIAL_DELAY_MS;
+
+    boolean result;
+    while (true) {
+      long beforeEvaluationTimeMs = nowMillis();
+      result = originalMatcher.matches(item);
+      long afterEvaluationTimeMs = nowMillis();
+      if (result || afterEvaluationTimeMs > deadlineTimeMs) {
+        break;
+      }
+      delay = sleepAndRecalculateDelay(delay, deadlineTimeMs, beforeEvaluationTimeMs, afterEvaluationTimeMs);
+    }
+    return result;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * The description is the same as from the original matcher.
+   * </p>
+   */
+  @Override
+  public void describeTo(Description description) {
+    originalMatcher.describeTo(description);
+  }
+
+  /**
+   * <p>
+   * Describes the mismatch by falling back to the original matcher's mismatch description.
+   * </p>
+   * <dl>
+   * <dt><strong>Note:</strong></dt>
+   * <dd>
+   * <p>
+   * As the item tested here is expected to change over time it might result in a mismatch description
+   * which does not match the invalid state retrieved before. Thus you might want to store the state
+   * between comparison and failure.
+   * </p>
+   * </dd>
+   * </dl>
+   */
+  @Override
+  protected void describeMismatchSafely(T item, Description mismatchDescription) {
+    originalMatcher.describeMismatch(item, mismatchDescription);
+  }
+
+  /**
+   * <p>
+   * Decelerating wait. Decreases the polling interval over time to give the system under test a chance to
+   * actually reach the desired state.
+   * </p>
+   */
+  private long sleepAndRecalculateDelay(long previousDelay,
+                                        long deadlineTimeMs,
+                                        long beforeEvaluationTimeMs,
+                                        long afterEvaluationTimeMs) {
+    long newDelay = previousDelay;
+    // Leave at least as much time between two checks as the check itself took.
+    final long lastDuration = afterEvaluationTimeMs - beforeEvaluationTimeMs;
+    if (lastDuration > newDelay) {
+      newDelay = lastDuration;
+    }
+
+    // Wait, but not much longer than until the deadlineTimeMillis and at least a millisecond.
+    try {
+      sleep(Math.max(1, Math.min(newDelay, deadlineTimeMs + SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS - afterEvaluationTimeMs)));
+    } catch (InterruptedException e) {
+      throw new IllegalStateException("Unexpected interruption.", e);
+    }
+
+    // Make checks less and less frequently.
+    // Increase the wait period using the deceleration factor, but
+    // wait at least one millisecond longer next time.
+    newDelay = Math.max(newDelay + 1, (long) (newDelay * DECELERATION_FACTOR));
+    return newDelay;
+  }
+
+  /**
+   * Sleep the given number of milliseconds.
+   *
+   * @param millis how long to sleep
+   * @throws InterruptedException if the current thread has been interrupted
+   */
+  protected void sleep(long millis) throws InterruptedException {
+    Thread.sleep(millis);
+  }
+
+  /**
+   * Retrieve the current time in milliseconds. Especially allows to override this behavior for testing purpose.
+   *
+   * @return time in milliseconds
+   */
+  protected long nowMillis() {
+    return System.currentTimeMillis();
+  }
+
+  /**
+   * <p>
+   * A function which is used to transform a component under test {@code F} to a state {@code T} which changes over
+   * time.
+   * </p>
+   * <p>
+   * This is a convenience interface if you cannot use Java 8+ functions or use Guava's Function interface.
+   * </p>
+   *
+   * @param <F> type of value to transform; typically the component under test
+   * @param <T> type of the target value to transform to; typically a value which represents the state of the
+   *            component under test
+   */
+  public interface WaitForFunction<F, T> {
+    T apply(F input);
+  }
+
+  /**
+   * <p>
+   * Matcher to delegate the matching of a transformed value to another (a normal) matcher.
+   * </p>
+   * <dl>
+   * <dt><strong>Note:</strong></dt>
+   * <dd>
+   * In order not to report a different state on failure than used for comparison the previously
+   * retrieved state is stored per thread when matching is tried. As a consequence
+   * {@link #describeMismatchSafely(Object, Description)} ignores the item expecting that it did
+   * not change meanwhile.
+   * </dd>
+   * </dl>
+   *
+   * @param <F> type of the actual value in the assertion; typically the component under test
+   * @param <T> type of the actual value to compare; typically the state of the component under test
+   */
+  public static class DelegatingWaitMatcher<F, T> extends TypeSafeMatcher<F> {
+    private final ThreadLocal<T> lastValue = new ThreadLocal<>();
+    private final WaitForFunction<F, T> stateFunction;
+    private final Matcher<? super T> stateMatcher;
+
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
+     *                      to the target value (typically its state)
+     * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
+     */
+    public DelegatingWaitMatcher(WaitForFunction<F, T> stateFunction, Matcher<? super T> stateMatcher) {
+      this.stateFunction = requireNonNull(stateFunction, "State function must not be null.");
+      this.stateMatcher = requireNonNull(stateMatcher, "Matcher for state value must not be null.");
+    }
+
+    @Override
+    protected boolean matchesSafely(F item) {
+      lastValue.set(stateFunction.apply(item));
+      return stateMatcher.matches(lastValue.get());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      stateMatcher.describeTo(description);
+    }
+
+    @Override
+    protected void describeMismatchSafely(F item, Description mismatchDescription) {
+      // Ignoring item, expecting that it did not change between call to describeMismatch and matches.
+      stateMatcher.describeMismatch(lastValue.get(), mismatchDescription);
+    }
+
+  }
+
+  /**
+   * Creates a matcher which waits for the embedded matcher to evaluate to true.
+   * It is required that the embedded matcher changes its state over time thus
+   * typical default matchers like {@code equalTo} won't work.
+   *
+   * @param originalMatcher the original matcher to wait to return true
+   * @param timeoutMs       timeout in milliseconds
+   * @param <T>             accepted value type of the original matcher
+   * @return matcher which waits
+   */
+  public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeoutMs) {
+    return waitFor(originalMatcher, timeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Creates a matcher which waits for the embedded matcher to evaluate to true.
+   * It is required that the embedded matcher changes its state over time thus
+   * typical default matchers like {@code equalTo} won't work.
+   *
+   * @param originalMatcher the original matcher to wait to return true
+   * @param timeout         timeout amount
+   * @param timeUnit        timeout unit
+   * @param <T>             accepted value type of the original matcher
+   * @return matcher which waits
+   */
+  public static <T> Matcher<T> waitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
+    return new WaitFor<>(originalMatcher, timeout, timeUnit);
+  }
+
+  /**
+   * <p>
+   * Applies a transformation to the value before comparing the transformed result with the given matcher.
+   * </p>
+   *
+   * @param stateFunction the function to apply to convert the asserted value (typically the component under test)
+   *                      to the target value (typically its state)
+   * @param stateMatcher  matcher to apply to the transformed value; typically the state of the component under test
+   * @param <F>           type to input into assertion
+   * @param <T>           actual value type to compare
+   * @return matcher which transforms input before comparison
+   */
+  public static <F, T> Matcher<F> stateMatches(WaitForFunction<F, T> stateFunction,
+                                               Matcher<? super T> stateMatcher) {
+    return new DelegatingWaitMatcher<>(stateFunction, stateMatcher);
+  }
+
+}

--- a/hamcrest-library/src/main/java/org/hamcrest/concurrent/WaitFor.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/concurrent/WaitFor.java
@@ -10,7 +10,8 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * <p>
- * Wait for the given matcher to evaluate to true. It is required that the embedded matcher changes its state over time.
+ * Wait for the given matcher to evaluate to true. It is required that the embedded matcher checks a mutable
+ * aspect of the matched object.
  * </p>
  * <p>
  * This matcher uses a decelerating wait approach, i. e. it tries to poll the state very often at the beginning
@@ -72,7 +73,7 @@ public class WaitFor<T> extends TypeSafeMatcher<T> {
     private static final long SLEEP_NOT_MUCH_LONGER_OFFSET_MILLIS = 100L;
 
     /**
-     * Original matcher who is required to changes its state while waiting.
+     * Original matcher who is required to check a mutable aspect of the matched object.
      */
     private final Matcher<T> originalMatcher;
     /**
@@ -278,7 +279,7 @@ public class WaitFor<T> extends TypeSafeMatcher<T> {
 
     /**
      * Creates a matcher which waits for the embedded matcher to evaluate to true.
-     * It is required that the embedded matcher changes its state over time thus
+     * It is required that the embedded matcher checks a mutable aspect of the matched object thus
      * typical default matchers like {@code equalTo} won't work.
      *
      * @param originalMatcher the original matcher to wait to return true
@@ -292,7 +293,7 @@ public class WaitFor<T> extends TypeSafeMatcher<T> {
 
     /**
      * Creates a matcher which waits for the embedded matcher to evaluate to true.
-     * It is required that the embedded matcher changes its state over time thus
+     * It is required that the embedded matcher checks a mutable aspect of the matched object thus
      * typical default matchers like {@code equalTo} won't work.
      *
      * @param originalMatcher the original matcher to wait to return true

--- a/hamcrest-library/src/main/java/org/hamcrest/concurrent/package-info.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/concurrent/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Matchers for concurrent changes of the system/component under test.
+ */
+package org.hamcrest.concurrent;

--- a/hamcrest-library/src/main/java/org/hamcrest/function/ApplyingMatcher.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/function/ApplyingMatcher.java
@@ -1,0 +1,78 @@
+package org.hamcrest.function;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * <p>
+ * Matcher which first transforms the matched object and hands over the comparison to the
+ * delegate matcher.
+ * </p>
+ * <dl>
+ * <dt><strong>Note:</strong></dt>
+ * <dd>
+ * In order not to report a different value on failure than used for comparison the previously
+ * transformed value is stored per thread when matching is tried. As a consequence
+ * {@link #describeMismatchSafely(Object, Description)} ignores the item expecting that it did
+ * not change meanwhile.
+ * </dd>
+ * </dl>
+ *
+ * @param <F> type of the actual value in the assertion; typically the component under test
+ * @param <T> type of the actual value to compare; typically the state of the component under test
+ */
+public class ApplyingMatcher<F, T> extends TypeSafeMatcher<F> {
+    private final ThreadLocal<T> lastValue = new ThreadLocal<>();
+    private final Function<F, T> function;
+    private final Matcher<? super T> delegateMatcher;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param function        the function to apply to convert the matched object to the target value
+     * @param delegateMatcher matcher to apply to the transformed value
+     */
+    public ApplyingMatcher(Function<F, T> function, Matcher<? super T> delegateMatcher) {
+        this.function = requireNonNull(function, "Function must not be null.");
+        this.delegateMatcher = requireNonNull(delegateMatcher, "Delegate matcher must not be null.");
+    }
+
+    @Override
+    protected boolean matchesSafely(F item) {
+        lastValue.set(function.apply(item));
+        return delegateMatcher.matches(lastValue.get());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        delegateMatcher.describeTo(description);
+    }
+
+    @Override
+    protected void describeMismatchSafely(F item, Description mismatchDescription) {
+        // Ignoring item, expecting that it did not change between call to describeMismatch and matches.
+        delegateMatcher.describeMismatch(lastValue.get(), mismatchDescription);
+    }
+
+    /**
+     * <p>
+     * Applies a transformation to the value before comparing the transformed result with the given matcher.
+     * </p>
+     *
+     * @param function        the function to apply to convert the asserted value to the target value
+     * @param delegateMatcher matcher to apply to the transformed value; typically the state of the component under test
+     * @param <F>             type to input into assertion
+     * @param <T>             actual value type to compare
+     * @return matcher which transforms input before comparison
+     */
+    public static <F, T> Matcher<F> applying(Function<F, T> function,
+                                             Matcher<? super T> delegateMatcher) {
+        return new ApplyingMatcher<>(function, delegateMatcher);
+    }
+
+}

--- a/hamcrest-library/src/main/java/org/hamcrest/function/Function.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/function/Function.java
@@ -1,0 +1,20 @@
+package org.hamcrest.function;
+
+/**
+ * <p>
+ * Anticipated function from Java 8+/Guava used in Hamcrest context to access an aspect of the matched object
+ * for comparison.
+ * </p>
+ *
+ * @param <T> type of value to transform; typically the matched object
+ * @param <R> type of the target value to transform to
+ */
+public interface Function<T, R> {
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param input the function argument
+     * @return the function result
+     */
+    R apply(T input);
+}

--- a/hamcrest-library/src/main/java/org/hamcrest/function/package-info.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/function/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Matchers applying functions to the matched objects. This is actually an anticipation of Java 8/Guava and
+ * implementation details might change when Hamcrest migrates to Java 8.
+ */
+package org.hamcrest.function;

--- a/hamcrest-library/src/test/java/org/hamcrest/concurrent/WaitForTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/concurrent/WaitForTest.java
@@ -4,6 +4,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.function.ApplyingMatcher;
+import org.hamcrest.function.Function;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -112,7 +114,7 @@ public class WaitForTest {
     @Test
     public void example_use_case_with_delegating_matcher_works() throws Exception {
         ComponentUnderTest componentUnderTest = new ComponentUnderTest(1, 2);
-        Matcher<ComponentUnderTest> waitForMatcher = new NeverTimeOutWaitFor<>(new WaitFor.DelegatingWaitMatcher<>(new ToState(), Matchers.equalTo(2)));
+        Matcher<ComponentUnderTest> waitForMatcher = new NeverTimeOutWaitFor<>(new ApplyingMatcher<>(new ToState(), Matchers.equalTo(2)));
         assertThat("Requested state should have been reached on second try.", componentUnderTest, waitForMatcher);
     }
 
@@ -120,7 +122,7 @@ public class WaitForTest {
     public void delegating_matcher_remembers_previous_state_on_failure() throws Exception {
         ComponentUnderTest componentUnderTest = new ComponentUnderTest(42, 43);
         Matcher<ComponentUnderTest> waitForMatcher =
-                new TimeOutImmediatelyWaitFor<>(WaitFor.stateMatches(new ToState(), Matchers.equalTo(43)));
+                new TimeOutImmediatelyWaitFor<>(ApplyingMatcher.applying(new ToState(), Matchers.equalTo(43)));
         AssertionError caughtAssertionFailure = null;
         try {
             assertThat("Provoke failure because of timeout.", componentUnderTest, waitForMatcher);
@@ -162,7 +164,7 @@ public class WaitForTest {
     /**
      * Function to retrieve state from the component under test.
      */
-    private static class ToState implements WaitFor.WaitForFunction<ComponentUnderTest, Integer> {
+    private static class ToState implements Function<ComponentUnderTest, Integer> {
         @Override
         public Integer apply(ComponentUnderTest input) {
             return input.getState();

--- a/hamcrest-library/src/test/java/org/hamcrest/concurrent/WaitForTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/concurrent/WaitForTest.java
@@ -26,113 +26,113 @@ import static org.junit.Assert.assertThat;
  */
 @SuppressWarnings({"MagicNumber", "DuplicateStringLiteralInspection"})
 public class WaitForTest {
-  @Rule
-  public ErrorCollector errorCollector = new ErrorCollector();
+    @Rule
+    public ErrorCollector errorCollector = new ErrorCollector();
 
-  @Test
-  public void end_immediately_if_first_match_succeeds() throws Exception {
-    TrackingMatcher<Object> originalMatcher = new AlwaysTrue<>();
-    Matcher<Object> matcher = WaitFor.waitFor(originalMatcher, 30);
-    assertThat(Integer.MAX_VALUE, matcher);
-    assertThat("Original matcher should exactly have been queried once.", 1, equalTo(originalMatcher.getMatchesCalls()));
-  }
-
-  @Test
-  public void retries_on_failure() throws Exception {
-    TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(1);
-    Matcher<Object> matcher = new NeverTimeOutWaitFor<>(originalMatcher);
-    assertThat(Integer.MAX_VALUE, matcher);
-    assertThat("Original matcher should exactly have been queried twice.", 2, equalTo(originalMatcher.getMatchesCalls()));
-  }
-
-  @Test
-  public void fail_on_continuous_failure() throws Exception {
-    TrackingMatcher<Object> originalMatcher = new AlwaysFalse<>();
-    Matcher<Object> matcher = new TimeOutImmediatelyWaitFor<>(originalMatcher);
-    AssertionError caughtAssertionFailure = null;
-    try {
-      assertThat(Integer.MAX_VALUE, matcher);
-    } catch (AssertionError e) {
-      caughtAssertionFailure = e;
+    @Test
+    public void end_immediately_if_first_match_succeeds() throws Exception {
+        TrackingMatcher<Object> originalMatcher = new AlwaysTrue<>();
+        Matcher<Object> matcher = WaitFor.waitFor(originalMatcher, 30);
+        assertThat(Integer.MAX_VALUE, matcher);
+        assertThat("Original matcher should exactly have been queried once.", 1, equalTo(originalMatcher.getMatchesCalls()));
     }
-    assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
-    assertThat(
-            "Original matcher should exactly have been queried once.",
-            1,
-            equalTo(originalMatcher.getMatchesCalls()));
-  }
 
-  @Test
-  public void embedded_matcher_descriptions_bubble_up() throws Exception {
-    String description = "SomeDescription";
-    String mismatchDescription = "SomeMismatchDescription";
-
-    Matcher<Object> originalMatcher = new AlwaysFalse<>(description, mismatchDescription);
-    Matcher<Object> matcher = new TimeOutImmediatelyWaitFor<>(originalMatcher);
-    AssertionError caughtAssertionFailure = null;
-    try {
-      assertThat(Integer.MAX_VALUE, matcher);
-    } catch (AssertionError e) {
-      caughtAssertionFailure = e;
+    @Test
+    public void retries_on_failure() throws Exception {
+        TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(1);
+        Matcher<Object> matcher = new NeverTimeOutWaitFor<>(originalMatcher);
+        assertThat(Integer.MAX_VALUE, matcher);
+        assertThat("Original matcher should exactly have been queried twice.", 2, equalTo(originalMatcher.getMatchesCalls()));
     }
-    assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
-    errorCollector.checkThat(
-            "Embedded matcher's description should be contained in failure message",
-            caughtAssertionFailure.getMessage(),
-            Matchers.containsString(description));
-    errorCollector.checkThat(
-            "Embedded matcher's mismatch description should be contained in failure message",
-            caughtAssertionFailure.getMessage(),
-            Matchers.containsString(mismatchDescription));
-  }
 
-  @Test
-  public void polling_decelerates() throws Exception {
-    TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(2);
-    TrackSleepsWaitFor<Object> matcher = new TrackSleepsWaitFor<>(originalMatcher, 30, TimeUnit.SECONDS);
-    assertThat(Integer.MAX_VALUE, matcher);
-    List<Long> sleeps = matcher.getSleeps();
-    assertThat("Should have slept two times.", sleeps, Matchers.hasSize(2));
-    assertThat("Sleep times should have accelerated.", sleeps.get(0), Matchers.lessThan(sleeps.get(1)));
-  }
-
-  @Test
-  public void polling_should_give_a_last_chance_before_failure() throws Exception {
-    TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(2);
-    TrackSleepsWaitFor<Object> matcher = new TrackSleepsWaitFor<>(originalMatcher, 4, TimeUnit.SECONDS);
-    assertThat(Integer.MAX_VALUE, matcher);
-    List<Long> sleeps = matcher.getSleeps();
-    assertThat("Should have slept two times.", sleeps, Matchers.hasSize(2));
-    assertThat(
-            "Last sleep time should be lower to grant one additional try.",
-            sleeps.get(0),
-            Matchers.greaterThan(sleeps.get(1)));
-  }
-
-  @Test
-  public void example_use_case_with_delegating_matcher_works() throws Exception {
-    ComponentUnderTest componentUnderTest = new ComponentUnderTest(1, 2);
-    Matcher<ComponentUnderTest> waitForMatcher = new NeverTimeOutWaitFor<>(new WaitFor.DelegatingWaitMatcher<>(new ToState(), Matchers.equalTo(2)));
-    assertThat("Requested state should have been reached on second try.", componentUnderTest, waitForMatcher);
-  }
-
-  @Test
-  public void delegating_matcher_remembers_previous_state_on_failure() throws Exception {
-    ComponentUnderTest componentUnderTest = new ComponentUnderTest(42, 43);
-    Matcher<ComponentUnderTest> waitForMatcher =
-            new TimeOutImmediatelyWaitFor<>(WaitFor.stateMatches(new ToState(), Matchers.equalTo(43)));
-    AssertionError caughtAssertionFailure = null;
-    try {
-      assertThat("Provoke failure because of timeout.", componentUnderTest, waitForMatcher);
-    } catch (AssertionError e) {
-      caughtAssertionFailure = e;
+    @Test
+    public void fail_on_continuous_failure() throws Exception {
+        TrackingMatcher<Object> originalMatcher = new AlwaysFalse<>();
+        Matcher<Object> matcher = new TimeOutImmediatelyWaitFor<>(originalMatcher);
+        AssertionError caughtAssertionFailure = null;
+        try {
+            assertThat(Integer.MAX_VALUE, matcher);
+        } catch (AssertionError e) {
+            caughtAssertionFailure = e;
+        }
+        assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
+        assertThat(
+                "Original matcher should exactly have been queried once.",
+                1,
+                equalTo(originalMatcher.getMatchesCalls()));
     }
-    assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
-    assertThat(
-            "Failure message should refer to previous and not current state.",
-            caughtAssertionFailure.getMessage(),
-            Matchers.containsString("42"));
-  }
+
+    @Test
+    public void embedded_matcher_descriptions_bubble_up() throws Exception {
+        String description = "SomeDescription";
+        String mismatchDescription = "SomeMismatchDescription";
+
+        Matcher<Object> originalMatcher = new AlwaysFalse<>(description, mismatchDescription);
+        Matcher<Object> matcher = new TimeOutImmediatelyWaitFor<>(originalMatcher);
+        AssertionError caughtAssertionFailure = null;
+        try {
+            assertThat(Integer.MAX_VALUE, matcher);
+        } catch (AssertionError e) {
+            caughtAssertionFailure = e;
+        }
+        assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
+        errorCollector.checkThat(
+                "Embedded matcher's description should be contained in failure message",
+                caughtAssertionFailure.getMessage(),
+                Matchers.containsString(description));
+        errorCollector.checkThat(
+                "Embedded matcher's mismatch description should be contained in failure message",
+                caughtAssertionFailure.getMessage(),
+                Matchers.containsString(mismatchDescription));
+    }
+
+    @Test
+    public void polling_decelerates() throws Exception {
+        TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(2);
+        TrackSleepsWaitFor<Object> matcher = new TrackSleepsWaitFor<>(originalMatcher, 30, TimeUnit.SECONDS);
+        assertThat(Integer.MAX_VALUE, matcher);
+        List<Long> sleeps = matcher.getSleeps();
+        assertThat("Should have slept two times.", sleeps, Matchers.hasSize(2));
+        assertThat("Sleep times should have accelerated.", sleeps.get(0), Matchers.lessThan(sleeps.get(1)));
+    }
+
+    @Test
+    public void polling_should_give_a_last_chance_before_failure() throws Exception {
+        TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(2);
+        TrackSleepsWaitFor<Object> matcher = new TrackSleepsWaitFor<>(originalMatcher, 4, TimeUnit.SECONDS);
+        assertThat(Integer.MAX_VALUE, matcher);
+        List<Long> sleeps = matcher.getSleeps();
+        assertThat("Should have slept two times.", sleeps, Matchers.hasSize(2));
+        assertThat(
+                "Last sleep time should be lower to grant one additional try.",
+                sleeps.get(0),
+                Matchers.greaterThan(sleeps.get(1)));
+    }
+
+    @Test
+    public void example_use_case_with_delegating_matcher_works() throws Exception {
+        ComponentUnderTest componentUnderTest = new ComponentUnderTest(1, 2);
+        Matcher<ComponentUnderTest> waitForMatcher = new NeverTimeOutWaitFor<>(new WaitFor.DelegatingWaitMatcher<>(new ToState(), Matchers.equalTo(2)));
+        assertThat("Requested state should have been reached on second try.", componentUnderTest, waitForMatcher);
+    }
+
+    @Test
+    public void delegating_matcher_remembers_previous_state_on_failure() throws Exception {
+        ComponentUnderTest componentUnderTest = new ComponentUnderTest(42, 43);
+        Matcher<ComponentUnderTest> waitForMatcher =
+                new TimeOutImmediatelyWaitFor<>(WaitFor.stateMatches(new ToState(), Matchers.equalTo(43)));
+        AssertionError caughtAssertionFailure = null;
+        try {
+            assertThat("Provoke failure because of timeout.", componentUnderTest, waitForMatcher);
+        } catch (AssertionError e) {
+            caughtAssertionFailure = e;
+        }
+        assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
+        assertThat(
+                "Failure message should refer to previous and not current state.",
+                caughtAssertionFailure.getMessage(),
+                Matchers.containsString("42"));
+    }
 
   /*
    * -------------------------------------------------------------------------------------------------------------------
@@ -140,185 +140,186 @@ public class WaitForTest {
    * -------------------------------------------------------------------------------------------------------------------
    */
 
-  /**
-   * Some component under test which changes its state each time the state is queried.
-   */
-  private static class ComponentUnderTest {
-    private final List<Integer> states;
+    /**
+     * Some component under test which changes its state each time the state is queried.
+     */
+    private static class ComponentUnderTest {
+        private final List<Integer> states;
 
-    private ComponentUnderTest(Integer... states) {
-      this(Arrays.asList(states));
+        private ComponentUnderTest(Integer... states) {
+            this(Arrays.asList(states));
+        }
+
+        private ComponentUnderTest(List<Integer> states) {
+            this.states = new ArrayList<>(states);
+        }
+
+        public int getState() {
+            return states.remove(0);
+        }
     }
 
-    private ComponentUnderTest(List<Integer> states) {
-      this.states = new ArrayList<>(states);
+    /**
+     * Function to retrieve state from the component under test.
+     */
+    private static class ToState implements WaitFor.WaitForFunction<ComponentUnderTest, Integer> {
+        @Override
+        public Integer apply(ComponentUnderTest input) {
+            return input.getState();
+        }
     }
 
-    public int getState() {
-      return states.remove(0);
-    }
-  }
+    private static class TrackingMatcher<T> extends TypeSafeMatcher<T> {
+        private int matchesCalls = 0;
 
-  /**
-   * Function to retrieve state from the component under test.
-   */
-  private static class ToState implements WaitFor.WaitForFunction<ComponentUnderTest, Integer> {
-    @Override
-    public Integer apply(ComponentUnderTest input) {
-      return input.getState();
-    }
-  }
+        @Override
+        protected boolean matchesSafely(T item) {
+            matchesCalls++;
+            return false;
+        }
 
-  private static class TrackingMatcher<T> extends TypeSafeMatcher<T> {
-    private int matchesCalls = 0;
+        @Override
+        public void describeTo(Description description) {
+        }
 
-    @Override
-    protected boolean matchesSafely(T item) {
-      matchesCalls++;
-      return false;
+        public int getMatchesCalls() {
+            return matchesCalls;
+        }
     }
 
-    @Override
-    public void describeTo(Description description) {
+    /**
+     * Matcher which eventually will succeed.
+     */
+    private static class TriesUntilTrue<T> extends TrackingMatcher<T> {
+        private final int untilCount;
+        private int currentCount = 0;
+
+        private TriesUntilTrue(int untilCount) {
+            this.untilCount = untilCount;
+        }
+
+        @Override
+        protected boolean matchesSafely(T item) {
+            super.matchesSafely(item);
+            return untilCount == currentCount++;
+        }
     }
 
-    public int getMatchesCalls() {
-      return matchesCalls;
-    }
-  }
-
-  /**
-   * Matcher which eventually will succeed.
-   */
-  private static class TriesUntilTrue<T> extends TrackingMatcher<T> {
-    private final int untilCount;
-    private int currentCount = 0;
-
-    private TriesUntilTrue(int untilCount) {
-      this.untilCount = untilCount;
+    /**
+     * Matcher which denotes success always.
+     */
+    private static class AlwaysTrue<T> extends TrackingMatcher<T> {
+        @Override
+        protected boolean matchesSafely(T item) {
+            super.matchesSafely(item);
+            return true;
+        }
     }
 
-    @Override
-    protected boolean matchesSafely(T item) {
-      super.matchesSafely(item);
-      return untilCount == currentCount++;
-    }
-  }
+    /**
+     * Matcher which denotes failure always.
+     */
+    private static class AlwaysFalse<T> extends TrackingMatcher<T> {
+        private final String fixedDescription;
+        private final String fixedMismatchDescription;
 
-  /**
-   * Matcher which denotes success always.
-   */
-  private static class AlwaysTrue<T> extends TrackingMatcher<T> {
-    @Override
-    protected boolean matchesSafely(T item) {
-      super.matchesSafely(item);
-      return true;
-    }
-  }
+        private AlwaysFalse() {
+            this(null, null);
+        }
 
-  /**
-   * Matcher which denotes failure always.
-   */
-  private static class AlwaysFalse<T> extends TrackingMatcher<T> {
-    private final String fixedDescription;
-    private final String fixedMismatchDescription;
+        public AlwaysFalse(String fixedDescription, String fixedMismatchDescription) {
+            this.fixedDescription = fixedDescription;
+            this.fixedMismatchDescription = fixedMismatchDescription;
+        }
 
-    private AlwaysFalse() {
-      this(null, null);
-    }
+        @Override
+        protected boolean matchesSafely(T item) {
+            super.matchesSafely(item);
+            return false;
+        }
 
-    public AlwaysFalse(String fixedDescription, String fixedMismatchDescription) {
-      this.fixedDescription = fixedDescription;
-      this.fixedMismatchDescription = fixedMismatchDescription;
-    }
+        @Override
+        public void describeTo(Description description) {
+            super.describeTo(description);
+            if (fixedDescription != null) {
+                description.appendText(fixedDescription);
+            }
+        }
 
-    @Override
-    protected boolean matchesSafely(T item) {
-      super.matchesSafely(item);
-      return false;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      super.describeTo(description);
-      if (fixedDescription != null) {
-        description.appendText(fixedDescription);
-      }
+        @Override
+        protected void describeMismatchSafely(T item, Description mismatchDescription) {
+            super.describeMismatchSafely(item, mismatchDescription);
+            if (fixedMismatchDescription != null) {
+                mismatchDescription.appendText(fixedMismatchDescription);
+            }
+        }
     }
 
-    @Override
-    protected void describeMismatchSafely(T item, Description mismatchDescription) {
-      super.describeMismatchSafely(item, mismatchDescription);
-      if (fixedMismatchDescription != null) {
-        mismatchDescription.appendText(fixedMismatchDescription);
-      }
-    }
-  }
+    /**
+     * Special WaitFor matcher which will never time out.
+     */
+    private static class NeverTimeOutWaitFor<T> extends WaitFor<T> {
+        public NeverTimeOutWaitFor(Matcher<T> originalMatcher) {
+            super(originalMatcher, 24, TimeUnit.HOURS);
+        }
 
-  /**
-   * Special WaitFor matcher which will never time out.
-   */
-  private static class NeverTimeOutWaitFor<T> extends WaitFor<T> {
-    public NeverTimeOutWaitFor(Matcher<T> originalMatcher) {
-      super(originalMatcher, 24, TimeUnit.HOURS);
-    }
+        @Override
+        protected long nowMillis() {
+            return 0;
+        }
 
-    @Override
-    protected long nowMillis() {
-      return 0;
+        @Override
+        protected void sleep(long millis) throws InterruptedException {
+            // do nothing, don't sleep
+        }
     }
 
-    @Override
-    protected void sleep(long millis) throws InterruptedException {
-      // do nothing, don't sleep
-    }
-  }
+    /**
+     * Special WaitFor matcher which will time out immediately.
+     */
+    private static class TimeOutImmediatelyWaitFor<T> extends WaitFor<T> {
+        private long count = 0;
 
-  /**
-   * Special WaitFor matcher which will time out immediately.
-   */
-  private static class TimeOutImmediatelyWaitFor<T> extends WaitFor<T> {
-    private long count = 0;
-    public TimeOutImmediatelyWaitFor(Matcher<T> originalMatcher) {
-      super(originalMatcher, 0L, TimeUnit.MILLISECONDS);
-    }
+        public TimeOutImmediatelyWaitFor(Matcher<T> originalMatcher) {
+            super(originalMatcher, 0L, TimeUnit.MILLISECONDS);
+        }
 
-    @Override
-    protected long nowMillis() {
-      return count++;
-    }
+        @Override
+        protected long nowMillis() {
+            return count++;
+        }
 
-    @Override
-    protected void sleep(long millis) throws InterruptedException {
-      // do nothing, don't sleep
-    }
-  }
-
-  /**
-   * WaitFor matcher which tracks sleep-calls for later assertions regarding the decelerating behavior.
-   */
-  private static class TrackSleepsWaitFor<T> extends WaitFor<T> {
-    private long count = 0;
-    private List<Long> sleeps = new ArrayList<>();
-
-    public TrackSleepsWaitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
-      super(originalMatcher, timeout, timeUnit);
+        @Override
+        protected void sleep(long millis) throws InterruptedException {
+            // do nothing, don't sleep
+        }
     }
 
-    @Override
-    protected long nowMillis() {
-      count+=1000;
-      return count;
-    }
+    /**
+     * WaitFor matcher which tracks sleep-calls for later assertions regarding the decelerating behavior.
+     */
+    private static class TrackSleepsWaitFor<T> extends WaitFor<T> {
+        private long count = 0;
+        private List<Long> sleeps = new ArrayList<>();
 
-    @Override
-    protected void sleep(long millis) throws InterruptedException {
-      // don't sleep, just track
-      sleeps.add(millis);
-    }
+        public TrackSleepsWaitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
+            super(originalMatcher, timeout, timeUnit);
+        }
 
-    public List<Long> getSleeps() {
-      return Collections.unmodifiableList(sleeps);
+        @Override
+        protected long nowMillis() {
+            count += 1000;
+            return count;
+        }
+
+        @Override
+        protected void sleep(long millis) throws InterruptedException {
+            // don't sleep, just track
+            sleeps.add(millis);
+        }
+
+        public List<Long> getSleeps() {
+            return Collections.unmodifiableList(sleeps);
+        }
     }
-  }
 }

--- a/hamcrest-library/src/test/java/org/hamcrest/concurrent/WaitForTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/concurrent/WaitForTest.java
@@ -1,0 +1,324 @@
+package org.hamcrest.concurrent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests {@link WaitFor}.
+ *
+ * @author Olaf Kummer
+ * @author Mark Michaelis
+ */
+@SuppressWarnings({"MagicNumber", "DuplicateStringLiteralInspection"})
+public class WaitForTest {
+  @Rule
+  public ErrorCollector errorCollector = new ErrorCollector();
+
+  @Test
+  public void end_immediately_if_first_match_succeeds() throws Exception {
+    TrackingMatcher<Object> originalMatcher = new AlwaysTrue<>();
+    Matcher<Object> matcher = WaitFor.waitFor(originalMatcher, 30);
+    assertThat(Integer.MAX_VALUE, matcher);
+    assertThat("Original matcher should exactly have been queried once.", 1, equalTo(originalMatcher.getMatchesCalls()));
+  }
+
+  @Test
+  public void retries_on_failure() throws Exception {
+    TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(1);
+    Matcher<Object> matcher = new NeverTimeOutWaitFor<>(originalMatcher);
+    assertThat(Integer.MAX_VALUE, matcher);
+    assertThat("Original matcher should exactly have been queried twice.", 2, equalTo(originalMatcher.getMatchesCalls()));
+  }
+
+  @Test
+  public void fail_on_continuous_failure() throws Exception {
+    TrackingMatcher<Object> originalMatcher = new AlwaysFalse<>();
+    Matcher<Object> matcher = new TimeOutImmediatelyWaitFor<>(originalMatcher);
+    AssertionError caughtAssertionFailure = null;
+    try {
+      assertThat(Integer.MAX_VALUE, matcher);
+    } catch (AssertionError e) {
+      caughtAssertionFailure = e;
+    }
+    assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
+    assertThat(
+            "Original matcher should exactly have been queried once.",
+            1,
+            equalTo(originalMatcher.getMatchesCalls()));
+  }
+
+  @Test
+  public void embedded_matcher_descriptions_bubble_up() throws Exception {
+    String description = "SomeDescription";
+    String mismatchDescription = "SomeMismatchDescription";
+
+    Matcher<Object> originalMatcher = new AlwaysFalse<>(description, mismatchDescription);
+    Matcher<Object> matcher = new TimeOutImmediatelyWaitFor<>(originalMatcher);
+    AssertionError caughtAssertionFailure = null;
+    try {
+      assertThat(Integer.MAX_VALUE, matcher);
+    } catch (AssertionError e) {
+      caughtAssertionFailure = e;
+    }
+    assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
+    errorCollector.checkThat(
+            "Embedded matcher's description should be contained in failure message",
+            caughtAssertionFailure.getMessage(),
+            Matchers.containsString(description));
+    errorCollector.checkThat(
+            "Embedded matcher's mismatch description should be contained in failure message",
+            caughtAssertionFailure.getMessage(),
+            Matchers.containsString(mismatchDescription));
+  }
+
+  @Test
+  public void polling_decelerates() throws Exception {
+    TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(2);
+    TrackSleepsWaitFor<Object> matcher = new TrackSleepsWaitFor<>(originalMatcher, 30, TimeUnit.SECONDS);
+    assertThat(Integer.MAX_VALUE, matcher);
+    List<Long> sleeps = matcher.getSleeps();
+    assertThat("Should have slept two times.", sleeps, Matchers.hasSize(2));
+    assertThat("Sleep times should have accelerated.", sleeps.get(0), Matchers.lessThan(sleeps.get(1)));
+  }
+
+  @Test
+  public void polling_should_give_a_last_chance_before_failure() throws Exception {
+    TrackingMatcher<Object> originalMatcher = new TriesUntilTrue<>(2);
+    TrackSleepsWaitFor<Object> matcher = new TrackSleepsWaitFor<>(originalMatcher, 4, TimeUnit.SECONDS);
+    assertThat(Integer.MAX_VALUE, matcher);
+    List<Long> sleeps = matcher.getSleeps();
+    assertThat("Should have slept two times.", sleeps, Matchers.hasSize(2));
+    assertThat(
+            "Last sleep time should be lower to grant one additional try.",
+            sleeps.get(0),
+            Matchers.greaterThan(sleeps.get(1)));
+  }
+
+  @Test
+  public void example_use_case_with_delegating_matcher_works() throws Exception {
+    ComponentUnderTest componentUnderTest = new ComponentUnderTest(1, 2);
+    Matcher<ComponentUnderTest> waitForMatcher = new NeverTimeOutWaitFor<>(new WaitFor.DelegatingWaitMatcher<>(new ToState(), Matchers.equalTo(2)));
+    assertThat("Requested state should have been reached on second try.", componentUnderTest, waitForMatcher);
+  }
+
+  @Test
+  public void delegating_matcher_remembers_previous_state_on_failure() throws Exception {
+    ComponentUnderTest componentUnderTest = new ComponentUnderTest(42, 43);
+    Matcher<ComponentUnderTest> waitForMatcher =
+            new TimeOutImmediatelyWaitFor<>(WaitFor.stateMatches(new ToState(), Matchers.equalTo(43)));
+    AssertionError caughtAssertionFailure = null;
+    try {
+      assertThat("Provoke failure because of timeout.", componentUnderTest, waitForMatcher);
+    } catch (AssertionError e) {
+      caughtAssertionFailure = e;
+    }
+    assertThat("Exception should have been caught.", caughtAssertionFailure, notNullValue());
+    assertThat(
+            "Failure message should refer to previous and not current state.",
+            caughtAssertionFailure.getMessage(),
+            Matchers.containsString("42"));
+  }
+
+  /*
+   * -------------------------------------------------------------------------------------------------------------------
+   * Helper Classes
+   * -------------------------------------------------------------------------------------------------------------------
+   */
+
+  /**
+   * Some component under test which changes its state each time the state is queried.
+   */
+  private static class ComponentUnderTest {
+    private final List<Integer> states;
+
+    private ComponentUnderTest(Integer... states) {
+      this(Arrays.asList(states));
+    }
+
+    private ComponentUnderTest(List<Integer> states) {
+      this.states = new ArrayList<>(states);
+    }
+
+    public int getState() {
+      return states.remove(0);
+    }
+  }
+
+  /**
+   * Function to retrieve state from the component under test.
+   */
+  private static class ToState implements WaitFor.WaitForFunction<ComponentUnderTest, Integer> {
+    @Override
+    public Integer apply(ComponentUnderTest input) {
+      return input.getState();
+    }
+  }
+
+  private static class TrackingMatcher<T> extends TypeSafeMatcher<T> {
+    private int matchesCalls = 0;
+
+    @Override
+    protected boolean matchesSafely(T item) {
+      matchesCalls++;
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+    }
+
+    public int getMatchesCalls() {
+      return matchesCalls;
+    }
+  }
+
+  /**
+   * Matcher which eventually will succeed.
+   */
+  private static class TriesUntilTrue<T> extends TrackingMatcher<T> {
+    private final int untilCount;
+    private int currentCount = 0;
+
+    private TriesUntilTrue(int untilCount) {
+      this.untilCount = untilCount;
+    }
+
+    @Override
+    protected boolean matchesSafely(T item) {
+      super.matchesSafely(item);
+      return untilCount == currentCount++;
+    }
+  }
+
+  /**
+   * Matcher which denotes success always.
+   */
+  private static class AlwaysTrue<T> extends TrackingMatcher<T> {
+    @Override
+    protected boolean matchesSafely(T item) {
+      super.matchesSafely(item);
+      return true;
+    }
+  }
+
+  /**
+   * Matcher which denotes failure always.
+   */
+  private static class AlwaysFalse<T> extends TrackingMatcher<T> {
+    private final String fixedDescription;
+    private final String fixedMismatchDescription;
+
+    private AlwaysFalse() {
+      this(null, null);
+    }
+
+    public AlwaysFalse(String fixedDescription, String fixedMismatchDescription) {
+      this.fixedDescription = fixedDescription;
+      this.fixedMismatchDescription = fixedMismatchDescription;
+    }
+
+    @Override
+    protected boolean matchesSafely(T item) {
+      super.matchesSafely(item);
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      super.describeTo(description);
+      if (fixedDescription != null) {
+        description.appendText(fixedDescription);
+      }
+    }
+
+    @Override
+    protected void describeMismatchSafely(T item, Description mismatchDescription) {
+      super.describeMismatchSafely(item, mismatchDescription);
+      if (fixedMismatchDescription != null) {
+        mismatchDescription.appendText(fixedMismatchDescription);
+      }
+    }
+  }
+
+  /**
+   * Special WaitFor matcher which will never time out.
+   */
+  private static class NeverTimeOutWaitFor<T> extends WaitFor<T> {
+    public NeverTimeOutWaitFor(Matcher<T> originalMatcher) {
+      super(originalMatcher, 24, TimeUnit.HOURS);
+    }
+
+    @Override
+    protected long nowMillis() {
+      return 0;
+    }
+
+    @Override
+    protected void sleep(long millis) throws InterruptedException {
+      // do nothing, don't sleep
+    }
+  }
+
+  /**
+   * Special WaitFor matcher which will time out immediately.
+   */
+  private static class TimeOutImmediatelyWaitFor<T> extends WaitFor<T> {
+    private long count = 0;
+    public TimeOutImmediatelyWaitFor(Matcher<T> originalMatcher) {
+      super(originalMatcher, 0L, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected long nowMillis() {
+      return count++;
+    }
+
+    @Override
+    protected void sleep(long millis) throws InterruptedException {
+      // do nothing, don't sleep
+    }
+  }
+
+  /**
+   * WaitFor matcher which tracks sleep-calls for later assertions regarding the decelerating behavior.
+   */
+  private static class TrackSleepsWaitFor<T> extends WaitFor<T> {
+    private long count = 0;
+    private List<Long> sleeps = new ArrayList<>();
+
+    public TrackSleepsWaitFor(Matcher<T> originalMatcher, long timeout, TimeUnit timeUnit) {
+      super(originalMatcher, timeout, timeUnit);
+    }
+
+    @Override
+    protected long nowMillis() {
+      count+=1000;
+      return count;
+    }
+
+    @Override
+    protected void sleep(long millis) throws InterruptedException {
+      // don't sleep, just track
+      sleeps.add(millis);
+    }
+
+    public List<Long> getSleeps() {
+      return Collections.unmodifiableList(sleeps);
+    }
+  }
+}

--- a/hamcrest-library/src/test/java/org/hamcrest/function/ApplyingMatcherTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/function/ApplyingMatcherTest.java
@@ -1,0 +1,84 @@
+package org.hamcrest.function;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.function.ApplyingMatcher.applying;
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link ApplyingMatcher}.
+ *
+ * @author Olaf Kummer
+ * @author Mark Michaelis
+ */
+public class ApplyingMatcherTest {
+    @Test
+    public void main_use_case_example_works() throws Exception {
+        String expectedProfession = "plumber";
+        Person kurt = new Person(expectedProfession);
+        assertThat(kurt, applying(new GetProfession(), equalTo(expectedProfession)));
+    }
+
+    @Test
+    public void state_is_saved_from_match_to_mismatch_message() throws Exception {
+        String firstShape = "dog";
+        String secondShape = "cat";
+        Shapeshifter shapeshifter = new Shapeshifter(firstShape, secondShape);
+        AssertionError caughtError = null;
+
+        try {
+            assertThat(shapeshifter, applying(new GetShape(), equalTo(secondShape)));
+        } catch (AssertionError e) {
+            caughtError = e;
+        }
+
+        assertThat("Comparison should have failed.", caughtError, notNullValue());
+        assertThat("Message should contain shape from match.", caughtError.getMessage(), Matchers.containsString(firstShape));
+    }
+
+    private static class Shapeshifter {
+        private final List<String> shapes;
+
+
+        private Shapeshifter(String... shapes) {
+            this.shapes = new ArrayList<>(Arrays.asList(shapes));
+        }
+
+        public String getShape() {
+            return shapes.remove(0);
+        }
+    }
+
+    private static class Person {
+        private final String profession;
+
+        private Person(final String profession) {
+            this.profession = profession;
+        }
+
+        public String getProfession() {
+            return profession;
+        }
+    }
+
+    private static class GetProfession implements Function<Person, String> {
+        @Override
+        public String apply(final Person input) {
+            return input.getProfession();
+        }
+    }
+
+    private static class GetShape implements Function<Shapeshifter, String> {
+        @Override
+        public String apply(final Shapeshifter input) {
+            return input.getShape();
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains a matcher implementing a wait pattern as introduced in [Haste makes waste][haste-minds]. The matcher will wait for the matched object to reach a certain state within a given timeout.

As standard matchers won't check a mutable aspect of the matched object this PR contains in addition a matcher which retrieves an aspect of the matched object and hands it over to some standard Hamcrest matcher.

Thus a typical usage looks like this:

```java
ComponentUnderTest cut = ...;
State expectedState = ...;
Function<ComponentUnderTest,State> stateFunction = new Function<>() { ... };
assertThat(componentUnderTest,
           waitFor(applying(stateFunction, equalTo(expectedState)), 2, SECONDS));
```

In Java 8 this one will look even better - and would not require the preliminary function interface which comes with the `ApplyingMatcher` contained in this PR.

We use the given pattern since 2012 now with great success especially in UI tests where it takes some time until a wanted state is reached.

The wait-algorithm is decelerating regarding polls to the component under test. This is a learning when we first tried to poll very frequently that the component under test was busy answering the polls instead of trying to reach the wanted state (in this case we were polling Solr for having indexed a given document).

[haste-minds]: <http://minds.coremedia.com/2012/11/29/haste-makes-waste/> "Haste makes waste | Minds"
