### PR TITLE
Add coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ jdk:
 
 script:
   - ./gradlew clean build javadoc
+
+after_success:
+- ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![JavaHamcrest](http://hamcrest.org/images/logo.jpg)
 
 [![Build Status](https://travis-ci.org/hamcrest/JavaHamcrest.png?branch=master)](https://travis-ci.org/hamcrest/JavaHamcrest)
+[![Coverage Status](https://coveralls.io/repos/hamcrest/JavaHamcrest/badge.png?branch=master&service=github)](https://coveralls.io/github/hamcrest/JavaHamcrest?branch=master)
+
 
 Java Hamcrest
 =============

--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,23 @@ signing {
     sign configurations.archives
 }
 
+/* these classes aggregate all the Matchers */
+def codeCoverageIgnored = ["org/hamcrest/Matchers.class", "org/hamcrest/CoreMatchers.class"]
+
 jacocoTestReport {
     reports {
         xml.enabled = true // coveralls plugin depends on xml format report
         html.enabled = true
+    }
+    // BUG: https://issues.gradle.org/browse/GRADLE-2955
+    afterEvaluate {
+        classDirectories = fileTree(dir: "${buildDir}/classes/main/").exclude(codeCoverageIgnored)
+    }
+}
+test {
+    jacoco {
+        destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
+        excludes = codeCoverageIgnored
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ import static org.gradle.api.JavaVersion.VERSION_1_7
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 
 sourceCompatibility = VERSION_1_7
 targetCompatibility = VERSION_1_7
@@ -11,6 +13,15 @@ archivesBaseName = "java-hamcrest"
 group = "org.hamcrest"
 version = "2.0.0.0"
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
+    }
+}
 
 repositories {
     mavenCentral()
@@ -61,6 +72,13 @@ artifacts {
 signing {
     required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
 }
 
 uploadArchives {


### PR DESCRIPTION
This at least gives some insight to the lines covered.
I wouldn't recommend enforcing a minimum level of coverage, but I use it to see what I looked at so that I know what to look at next.

If you use your own API, you know what to alter.

_EDITED_:
For reference, [my README.md](https://github.com/Shredder121/JavaHamcrest/tree/6f754ecdbefa5a03c16b50c53052ae9034939780#readme) or alternatively [my README.md using the svg version](https://github.com/Shredder121/JavaHamcrest/tree/4ffee70af25d028ef64925bc032100b0ad9411af#readme).