### PR TITLE
gradle should output the stacktrace for test failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ sourceSets {
     }
 }
 
+test {
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
+
 jar {
     manifest {
         attributes 'Implementation-Title': 'hamcrest-all',


### PR DESCRIPTION
With this change:
```
$ ./gradlew test

[..]

org.hamcrest.core.AllOfTest > failingTest FAILED
    java.lang.AssertionError
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.fail(Assert.java:95)
        at org.hamcrest.core.AllOfTest.failingTest(AllOfTest.java:72)

409 tests completed, 1 failed
:test FAILED

[..]
```

Before this change:
```
$ ./gradlew test
[..]

org.hamcrest.core.AllOfTest > failingTest FAILED
    java.lang.AssertionError at AllOfTest.java:72

409 tests completed, 1 failed
:test FAILED

[..]
```