### PR TITLE
Fix SubstringMatcher's

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java
@@ -33,7 +33,7 @@ public class StringContains extends SubstringMatcher {
      * Creates a matcher that matches if the examined {@link String} contains the specified
      * {@link String} anywhere, ignoring case.
      * For example:
-     * <pre>assertThat("myStringOfNote", containsString("ring"))</pre>
+     * <pre>assertThat("myStringOfNote", containsStringIgnoringCase("string"))</pre>
      *
      * @param substring
      *     the substring that the returned matcher will expect to find within any examined string

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
  * Tests if the argument is a string that contains a substring.
  */
 public class StringContains extends SubstringMatcher {
+
     public StringContains(boolean ignoringCase, String substring) {
         super("containing", ignoringCase, substring);
     }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java
@@ -3,7 +3,10 @@ package org.hamcrest.core;
 import org.hamcrest.Matcher;
 
 public class StringEndsWith extends SubstringMatcher {
-    public StringEndsWith(boolean ignoringCase, String substring) { super("ending with", ignoringCase, substring); }
+
+    public StringEndsWith(boolean ignoringCase, String substring) {
+        super("ending with", ignoringCase, substring);
+    }
 
     @Override
     protected boolean evalSubstringOf(String s) {

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java
@@ -2,9 +2,6 @@ package org.hamcrest.core;
 
 import org.hamcrest.Matcher;
 
-/**
- * Tests if the argument is a string that contains a substring.
- */
 public class StringEndsWith extends SubstringMatcher {
     public StringEndsWith(boolean ignoringCase, String substring) { super("ending with", ignoringCase, substring); }
 
@@ -30,7 +27,7 @@ public class StringEndsWith extends SubstringMatcher {
      * Creates a matcher that matches if the examined {@link String} ends with the specified
      * {@link String}, ignoring case.
      * For example:
-     * <pre>assertThat("myStringOfNote", endsWith("Note"))</pre>
+     * <pre>assertThat("myStringOfNote", endsWithIgnoringCase("note"))</pre>
      *
      * @param suffix
      *      the substring that the returned matcher will expect at the end of any examined string

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java
@@ -2,9 +2,6 @@ package org.hamcrest.core;
 
 import org.hamcrest.Matcher;
 
-/**
- * Tests if the argument is a string that contains a substring.
- */
 public class StringStartsWith extends SubstringMatcher {
     public StringStartsWith(boolean ignoringCase, String substring) { super("starting with", ignoringCase, substring); }
 
@@ -30,7 +27,7 @@ public class StringStartsWith extends SubstringMatcher {
      * {@link String}, ignoring case
      * </p>
      * For example:
-     * <pre>assertThat("myStringOfNote", startsWith("my"))</pre>
+     * <pre>assertThat("myStringOfNote", startsWithIgnoringCase("My"))</pre>
      *
      * @param prefix
      *      the substring that the returned matcher will expect at the start of any examined string

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java
@@ -3,10 +3,15 @@ package org.hamcrest.core;
 import org.hamcrest.Matcher;
 
 public class StringStartsWith extends SubstringMatcher {
-    public StringStartsWith(boolean ignoringCase, String substring) { super("starting with", ignoringCase, substring); }
+
+    public StringStartsWith(boolean ignoringCase, String substring) {
+        super("starting with", ignoringCase, substring);
+    }
 
     @Override
-    protected boolean evalSubstringOf(String s) { return converted(s).startsWith(converted(substring)); }
+    protected boolean evalSubstringOf(String s) {
+        return converted(s).startsWith(converted(substring));
+    }
 
     /**
      * <p>
@@ -19,7 +24,9 @@ public class StringStartsWith extends SubstringMatcher {
      * @param prefix
      *      the substring that the returned matcher will expect at the start of any examined string
      */
-    public static Matcher<String> startsWith(String prefix) { return new StringStartsWith(false, prefix); }
+    public static Matcher<String> startsWith(String prefix) {
+        return new StringStartsWith(false, prefix);
+    }
 
     /**
      * <p>
@@ -32,6 +39,8 @@ public class StringStartsWith extends SubstringMatcher {
      * @param prefix
      *      the substring that the returned matcher will expect at the start of any examined string
      */
-    public static Matcher<String> startsWithIgnoringCase(String prefix) { return new StringStartsWith(true, prefix); }
+    public static Matcher<String> startsWithIgnoringCase(String prefix) {
+        return new StringStartsWith(true, prefix);
+    }
 
 }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/SubstringMatcher.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/SubstringMatcher.java
@@ -13,6 +13,10 @@ public abstract class SubstringMatcher extends TypeSafeMatcher<String> {
     protected final String substring;
 
     protected SubstringMatcher(String relationship, boolean ignoringCase, String substring) {
+        if (substring == null) {
+            throw new IllegalArgumentException("Substring should be non null");
+        }
+
         this.relationship = relationship;
         this.ignoringCase = ignoringCase;
         this.substring = substring;

--- a/hamcrest-core/src/test/java/org/hamcrest/core/StringContainsTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/StringContainsTest.java
@@ -40,4 +40,23 @@ public class StringContainsTest extends AbstractMatcherTest {
         assertMismatchDescription("was \"Something else\"", ignoringCase, "Something else");
         assertDescription("a string containing \"ExCert\" ignoring case", ignoringCase);
     }
+
+    public void testContainsNullStringShouldThrowIllegalArgumentException() {
+        try {
+            containsString(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    public void testContainsNullStringIgnoringCaseShouldThrowIllegalArgumentException() {
+        try {
+            containsStringIgnoringCase(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
 }

--- a/hamcrest-core/src/test/java/org/hamcrest/core/StringEndsWithTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/StringEndsWithTest.java
@@ -42,4 +42,22 @@ public class StringEndsWithTest extends AbstractMatcherTest {
         assertDescription("a string ending with \"EXCERpt\" ignoring case", ignoringCase);
     }
 
+    public void testEndsWithNullStringShouldThrowIllegalArgumentException() {
+        try {
+            endsWith(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    public void testEndsWithNullStringIgnoringCaseShouldThrowIllegalArgumentException() {
+        try {
+            endsWithIgnoringCase(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
 }

--- a/hamcrest-core/src/test/java/org/hamcrest/core/StringStartsWithTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/StringStartsWithTest.java
@@ -43,4 +43,22 @@ public class StringStartsWithTest extends AbstractMatcherTest {
         assertMismatchDescription("was \"Something else\"", ignoreCase, "Something else");
     }
 
+    public void testStartsWithNullStringShouldThrowIllegalArgumentException() {
+        try {
+            startsWith(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    public void testStartsWithNullStringIgnoringCaseShouldThrowIllegalArgumentException() {
+        try {
+            startsWithIgnoringCase(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
 }

--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -464,7 +464,7 @@ public class Matchers {
    * Creates a matcher that matches if the examined {@link String} contains the specified
    * {@link String} anywhere, ignoring case.
    * For example:
-   * <pre>assertThat("myStringOfNote", containsString("ring"))</pre>
+   * <pre>assertThat("myStringOfNote", containsStringIgnoringCase("string"))</pre>
    * 
    * @param substring
    *     the substring that the returned matcher will expect to find within any examined string
@@ -494,7 +494,7 @@ public class Matchers {
    * {@link String}, ignoring case
    * </p>
    * For example:
-   * <pre>assertThat("myStringOfNote", startsWith("my"))</pre>
+   * <pre>assertThat("myStringOfNote", startsWithIgnoringCase("My"))</pre>
    * 
    * @param prefix
    *      the substring that the returned matcher will expect at the start of any examined string
@@ -520,7 +520,7 @@ public class Matchers {
    * Creates a matcher that matches if the examined {@link String} ends with the specified
    * {@link String}, ignoring case.
    * For example:
-   * <pre>assertThat("myStringOfNote", endsWith("Note"))</pre>
+   * <pre>assertThat("myStringOfNote", endsWithIgnoringCase("note"))</pre>
    * 
    * @param suffix
    *      the substring that the returned matcher will expect at the end of any examined string


### PR DESCRIPTION
fix javadocs
fix NPE in case substring is null: throw IllegalArgumentException instead