### PR TITLE
IsEqualIgnoringCase, IsEqualIgnoringWhiteSpace: description in plain English

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java
@@ -33,9 +33,9 @@ public class IsEqualIgnoringCase extends TypeSafeMatcher<String> {
     
     @Override
     public void describeTo(Description description) {
-        description.appendText("equalToIgnoringCase(")
+        description.appendText("a string equal to ")
                 .appendValue(string)
-                .appendText(")");
+                .appendText(" ignoring case");
     }
 
     /**

--- a/hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpace.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpace.java
@@ -35,9 +35,9 @@ public class IsEqualIgnoringWhiteSpace extends TypeSafeMatcher<String> {
     
     @Override
     public void describeTo(Description description) {
-        description.appendText("equalToIgnoringWhiteSpace(")
+        description.appendText("a string equal to ")
                 .appendValue(string)
-                .appendText(")");
+                .appendText(" ignoring white space");
     }
 
     public String stripSpace(String toBeStripped) {

--- a/hamcrest-library/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -50,7 +50,7 @@ public final class IsEqualIgnoringCaseTest {
     @Test public void
     describesItself() {
     	final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-        assertDescription("equalToIgnoringCase(\"heLLo\")", matcher);
+        assertDescription("a string equal to \"heLLo\" ignoring case", matcher);
     }
 
     @Test public void

--- a/hamcrest-library/src/test/java/org/hamcrest/text/IsEqualIgnoringWhiteSpaceTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/text/IsEqualIgnoringWhiteSpaceTest.java
@@ -45,7 +45,7 @@ public class IsEqualIgnoringWhiteSpaceTest extends AbstractMatcherTest {
     }
 
     public void testHasAReadableDescription() {
-        assertDescription("equalToIgnoringWhiteSpace(\"Hello World   how\\n are we? \")",
+        assertDescription("a string equal to \"Hello World   how\\n are we? \" ignoring white space",
                         matcher);
     }
 }


### PR DESCRIPTION
'equalToIgnoringCase("heLLo")' -> 'a string equal to "heLLo" ignoring case'
'equalToIgnoringWhiteSpace("hello")' -> 'a string equal to "hello" ignoring white space'