### PR TITLE
Escape backslashes properly in BaseDescription

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/BaseDescription.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/BaseDescription.java
@@ -137,6 +137,9 @@ public abstract class BaseDescription implements Description {
             case '\t':
                 append("\\t");
                 break;
+            case '\\':
+                append("\\\\");
+                break;
             default:
                 append(ch);
         }


### PR DESCRIPTION
Before this commit, the following assertion:

```java
assertThat("\n", equalTo("\\n"));
```

gives the output:

```
java.lang.AssertionError:
Expected: "\n"
     but: was "\n"
```

This is confusing because it seems like two identical strings have not
compared equal.

The problem is that in BaseDescription.toJavaSyntax(char) escapes
newline characters but doesn't escape backslash characters, so the two
strings being compared are transformed to the same output for display,
despite having different actual content.

I haven't written a test for this as I couldn't find a test for any of the existing escaping behaviour.