### PR TITLE
Fix for #27 "The signature of isA is completely wrong".

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/core/Is.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/Is.java
@@ -69,7 +69,7 @@ public class Is<T> extends BaseMatcher<T> {
      * <pre>assertThat(cheese, is(instanceOf(Cheddar.class)))</pre>
      * 
      */
-    public static <T> Matcher<T> isA(Class<T> type) {
+    public static <T> Matcher<T> isA(Class<?> type) {
         final Matcher<T> typeMatcher = instanceOf(type);
         return is(typeMatcher);
     }

--- a/hamcrest-core/src/test/java/org/hamcrest/core/IsTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/core/IsTest.java
@@ -43,8 +43,9 @@ public final class IsTest {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test public void
     providesConvenientShortcutForIsInstanceOf() {
-        final Matcher matcher = isA(Integer.class);
+        final Matcher matcher = isA(Number.class);
         assertMatches(matcher, 1);
+        assertMatches(matcher, 1.1);
         assertDoesNotMatch(matcher, new Object());
         assertDoesNotMatch(matcher, null);
     }

--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -207,7 +207,7 @@ public class Matchers {
    * instead of:
    * <pre>assertThat(cheese, is(instanceOf(Cheddar.class)))</pre>
    */
-  public static <T> org.hamcrest.Matcher<T> isA(java.lang.Class<T> type) {
+  public static <T> org.hamcrest.Matcher<T> isA(java.lang.Class<?> type) {
     return org.hamcrest.core.Is.<T>isA(type);
   }
 


### PR DESCRIPTION
The method `isA(...)` is documented as shortcut to `is(instanceOf(...))`. This was not the case, as the enhanced test `IsA.providesConvenientShortcutForIsInstanceOf()` does not compile (the test was created in analogy to the tests of `instanceof(...)`).

To fix this, the created Matchers need to accept any class instead of the one to check against.

Fixes #27 "The signature of isA is completely wrong".