### PR TITLE
Feature/string contains in any order

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1508,6 +1508,34 @@ public class Matchers {
   }
 
   /**
+   * Creates a matcher of {@link String} that matches when the examined string contains all of
+   * the specified substrings, regardless of the order of their appearance.
+   * For example:
+   * <pre>assertThat("myfoobarbaz", stringContainsInAnyOrder(Arrays.asList("bar", "foo")))</pre>
+   * succeeds even if "foo" occurs before "bar" in the string "myfoobarbaz"
+   *
+   * @param substrings
+   *     the substrings that must be contained within matching strings
+   */
+  public static Matcher<java.lang.String> stringContainsInAnyOrder(java.lang.Iterable<java.lang.String> substrings) {
+    return org.hamcrest.text.StringContainsInAnyOrder.stringContainsInAnyOrder(substrings);
+  }
+
+  /**
+   * Creates a matcher of {@link String} that matches when the examined string contains all of
+   * the specified substrings, regardless of the order of their appearance.
+   * For example:
+   * <pre>assertThat("myfoobarbaz", stringContainsInAnyOrder("bar", "foo"))</pre>
+   * succeeds even if "foo" occurs before "bar" in the string "myfoobarbaz"
+   *
+   * @param substrings
+   *     the substrings that must be contained within matching strings
+   */
+  public static Matcher<java.lang.String> stringContainsInAnyOrder(java.lang.String... substrings) {
+    return org.hamcrest.text.StringContainsInAnyOrder.stringContainsInAnyOrder(substrings);
+  }
+
+  /**
    * Creates a matcher that matches any examined object whose <code>toString</code> method
    * returns a value that satisfies the specified matcher.
    * For example:

--- a/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInAnyOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInAnyOrder.java
@@ -1,0 +1,67 @@
+package org.hamcrest.text;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Arrays;
+
+public class StringContainsInAnyOrder extends TypeSafeMatcher<String> {
+    private final Iterable<String> substrings;
+
+    public StringContainsInAnyOrder(Iterable<String> substrings) {
+        this.substrings = substrings;
+    }
+
+    @Override
+    public boolean matchesSafely(String s) {
+        for (String substring : substrings) {
+            int index = s.indexOf(substring);
+            if (index == -1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeMismatchSafely(String item, Description mismatchDescription) {
+        mismatchDescription.appendText("was \"").appendText(item).appendText("\"");
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a string containing ")
+                .appendValueList("", ", ", "", substrings)
+                .appendText(" in any order");
+    }
+
+    /**
+     * Creates a matcher of {@link String} that matches when the examined string contains all of
+     * the specified substrings, regardless of the order of their appearance.
+     * <p/>
+     * For example:
+     * <pre>assertThat("myfoobarbaz", stringContainsInAnyOrder("bar", "foo"))</pre>
+     *
+     * @param substrings
+     *     the substrings that must be contained within matching strings
+     */
+    public static Matcher<String> stringContainsInAnyOrder(Iterable<String> substrings) {
+        return new StringContainsInAnyOrder(substrings);
+    }
+
+    /**
+     * Creates a matcher of {@link String} that matches when the examined string contains all of
+     * the specified substrings, regardless of the order of their appearance.
+     * <p/>
+     * For example:
+     * <pre>assertThat("myfoobarbaz", stringContainsInAnyOrder("bar", "foo"))</pre>
+     *
+     * @param substrings
+     *     the substrings that must be contained within matching strings
+     */
+    public static Matcher<String> stringContainsInAnyOrder(String... substrings) {
+        return new StringContainsInAnyOrder(Arrays.asList(substrings));
+    }
+}

--- a/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInAnyOrder.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/text/StringContainsInAnyOrder.java
@@ -40,7 +40,6 @@ public class StringContainsInAnyOrder extends TypeSafeMatcher<String> {
     /**
      * Creates a matcher of {@link String} that matches when the examined string contains all of
      * the specified substrings, regardless of the order of their appearance.
-     * <p/>
      * For example:
      * <pre>assertThat("myfoobarbaz", stringContainsInAnyOrder("bar", "foo"))</pre>
      *
@@ -54,7 +53,6 @@ public class StringContainsInAnyOrder extends TypeSafeMatcher<String> {
     /**
      * Creates a matcher of {@link String} that matches when the examined string contains all of
      * the specified substrings, regardless of the order of their appearance.
-     * <p/>
      * For example:
      * <pre>assertThat("myfoobarbaz", stringContainsInAnyOrder("bar", "foo"))</pre>
      *

--- a/hamcrest-library/src/test/java/org/hamcrest/text/StringContainsInAnyOrderTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/text/StringContainsInAnyOrderTest.java
@@ -1,0 +1,30 @@
+package org.hamcrest.text;
+
+import org.hamcrest.AbstractMatcherTest;
+import org.hamcrest.Matcher;
+
+import static java.util.Arrays.asList;
+
+
+public class StringContainsInAnyOrderTest extends AbstractMatcherTest {
+    final StringContainsInAnyOrder matcher = new StringContainsInAnyOrder(asList("a", "b", "c"));
+
+    @Override
+    protected Matcher<?> createMatcher() {
+        return matcher;
+    }
+    
+    public void testMatchesEvenIfStringContainsGivenSubstringsInAnotherOrder() {
+        assertMatches("substrings in any order", matcher, "abcc");
+        assertMatches("substrings in any order", matcher, "cba");
+        assertMatches("substrings separated", matcher, "1c2a3b4c5");
+
+        assertDoesNotMatch("no substrings in string", matcher, "xyz");
+        assertDoesNotMatch("substring missing", matcher, "ac");
+        assertDoesNotMatch("empty string", matcher, "");
+    }
+    
+    public void testHasAReadableDescription() {
+        assertDescription("a string containing \"a\", \"b\", \"c\" in any order", matcher);
+    }
+}


### PR DESCRIPTION
I kindly request to add `stringContainsInAnyOrder` as a complement to `stringContainsInOrder`. It matches if all of the substrings are contained within the subject, regardless of the order.

I'm aware that you are able to achieve the same with

```
assertThat("this is a string", allOf(
  contains("string"),
  contains("this"),
  contains("a")));
```

But there are cases when you need to work with an unknown list of strings, like String[] or List<String>.

For these cases, it would be nice to have

```
String[] tokens = classUnderTest.getTokens();
String subject = getTemplate();
assertThat(subject, stringContainsInAnyOrder(tokens))
```