### PR TITLE
Added 'hasEntry' matchers for (key, valueMatcher) and (keyMatcher, value)

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1114,6 +1114,38 @@ public class Matchers {
 
   /**
    * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
+   * at least one entry whose key equals the specified <code>key</code> <b>and</b> whose
+   * value satisfies the specified <code>valueMatcher</code>.
+   * For example:
+   * <pre>assertThat(myMap, hasEntry("bar", equalTo("foo")))</pre>
+   *
+   * @param key
+   *     the key that, in combination with the valueMatcher, must be describe at least one entry
+   * @param valueMatcher
+   *     the value matcher that, in combination with the key, must be satisfied by at least one entry
+   */
+  public static <K, V> org.hamcrest.Matcher<java.util.Map<? extends K,? extends V>> hasEntry(K key, org.hamcrest.Matcher<? super V> valueMatcher) {
+    return org.hamcrest.collection.IsMapContaining.hasEntry(key, valueMatcher);
+  }
+
+  /**
+   * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
+   * at least one entry whose key satisfies the specified <code>keyMatcher</code> <b>and</b> whose value
+   * equals the specified <code>value</code>.
+   * For example:
+   * <pre>assertThat(myMap, hasEntry(equalTo("bar"), "foo"))</pre>
+   *
+   * @param keyMatcher
+   *     the key matcher that, in combination with the value, must be satisfied by at least one entry
+   * @param value
+   *     the value that, in combination with the keyMatcher, must be describe at least one entry
+   */
+  public static <K, V> org.hamcrest.Matcher<java.util.Map<? extends K,? extends V>> hasEntry(org.hamcrest.Matcher<? super K> keyMatcher, V value) {
+    return org.hamcrest.collection.IsMapContaining.hasEntry(keyMatcher, value);
+  }
+
+  /**
+   * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
    * at least one key that satisfies the specified matcher.
    * For example:
    * <pre>assertThat(myMap, hasKey(equalTo("bar")))</pre>

--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -74,6 +74,38 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
     public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(K key, V value) {
         return new IsMapContaining<>(equalTo(key), equalTo(value));
     }
+
+    /**
+     * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
+     * at least one entry whose key equals the specified <code>key</code> <b>and</b> whose
+     * value satisfies the specified <code>valueMatcher</code>.
+     * For example:
+     * <pre>assertThat(myMap, hasEntry("bar", equalTo("foo")))</pre>
+     *
+     * @param key
+     *     the key that, in combination with the valueMatcher, must be describe at least one entry
+     * @param valueMatcher
+     *     the value matcher that, in combination with the key, must be satisfied by at least one entry
+     */
+    public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(K key, Matcher<? super V> valueMatcher) {
+        return new IsMapContaining<>(equalTo(key), valueMatcher);
+    }
+
+    /**
+     * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
+     * at least one entry whose key satisfies the specified <code>keyMatcher</code> <b>and</b> whose value
+     * equals the specified <code>value</code>.
+     * For example:
+     * <pre>assertThat(myMap, hasEntry(equalTo("bar"), "foo"))</pre>
+     *
+     * @param keyMatcher
+     *     the key matcher that, in combination with the value, must be satisfied by at least one entry
+     * @param value
+     *     the value that, in combination with the keyMatcher, must be describe at least one entry
+     */
+    public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(Matcher<? super K> keyMatcher, V value) {
+        return new IsMapContaining<>(keyMatcher, equalTo(value));
+    }
     
     /**
      * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains

--- a/hamcrest-library/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
@@ -27,6 +27,26 @@ public class IsMapContainingTest extends AbstractMatcherTest {
         assertMismatchDescription("map was [<a=1>, <b=2>]", hasEntry(equalTo("c"), equalTo(3)), map);
     }
 
+    public void testMatchesMapContainingKeyAndValueMatcher() {
+        Map<String,Integer> map = new TreeMap<>();
+        map.put("a", 1);
+        map.put("b", 2);
+
+        assertMatches("matcherA", hasEntry("a", equalTo(1)), map);
+        assertMatches("matcherB", hasEntry("b", equalTo(2)), map);
+        assertMismatchDescription("map was [<a=1>, <b=2>]", hasEntry("c", equalTo(3)), map);
+    }
+
+    public void testMatchesMapContainingKeyMatcherAndValue() {
+        Map<String,Integer> map = new TreeMap<>();
+        map.put("a", 1);
+        map.put("b", 2);
+
+        assertMatches("matcherA", hasEntry(equalTo("a"), 1), map);
+        assertMatches("matcherB", hasEntry(equalTo("b"), 2), map);
+        assertMismatchDescription("map was [<a=1>, <b=2>]", hasEntry(equalTo("c"), 3), map);
+    }
+
 //    no longer compiles. SF
 //    public void testMatchesMapContainingMatchingKeyAndValueWithoutGenerics() {
 //        Map map = new HashMap();


### PR DESCRIPTION
When I test maps I often need to apply a matcher for the value and check equality for the key. Currently there is no `hasEntry` matcher that consumes a key, and a matcher for the value so I have to do it somewhat like this:
```java
Map<String, List<Integer>> map = singletonMap("key", asList(1, 2));

assertThat(map, hasEntry(equalTo("key"), contains(1, 2)));
```
It would be more convenient to do it like this:
```java
assertThat(map, hasEntry("key", contains(1, 2)));
```

For that reason, I introduced two more `hasEntry` matchers with signatures:
```java
hasEntry(K key, Matcher<? super V> valueMatcher)
```
```java
hasEntry(Matcher<? super K> keyMatcher, V value)
```