### PR TITLE
IsCloseTo matcher should operate on Number rather than Double

### DIFF
--- a/hamcrest-core/src/test/java/org/hamcrest/AbstractMatcherTest.java
+++ b/hamcrest-core/src/test/java/org/hamcrest/AbstractMatcherTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractMatcherTest extends TestCase {
     createMatcher().matches(new UnknownType());
   }
 
-    private static <T> String mismatchDescription(Matcher<? super T> matcher, T arg) {
+    protected static <T> String mismatchDescription(Matcher<? super T> matcher, T arg) {
       Description description = new StringDescription();
       matcher.describeMismatch(arg, description);
       return description.toString().trim();

--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1261,7 +1261,7 @@ public class Matchers {
    * @param error
    *     the delta (+/-) within which matches will be allowed
    */
-  public static org.hamcrest.Matcher<java.lang.Double> closeTo(double operand, double error) {
+  public static org.hamcrest.Matcher<Number> closeTo(double operand, double error) {
     return org.hamcrest.number.IsCloseTo.closeTo(operand, error);
   }
 

--- a/hamcrest-library/src/main/java/org/hamcrest/number/IsCloseTo.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/number/IsCloseTo.java
@@ -11,7 +11,7 @@ import static java.lang.Math.abs;
  * Is the value a number equal to a value within some range of
  * acceptable error?
  */
-public class IsCloseTo extends TypeSafeMatcher<Double> {
+public class IsCloseTo extends TypeSafeMatcher<Number> {
     private final double delta;
     private final double value;
 
@@ -21,12 +21,12 @@ public class IsCloseTo extends TypeSafeMatcher<Double> {
     }
 
     @Override
-    public boolean matchesSafely(Double item) {
+    public boolean matchesSafely(Number item) {
         return actualDelta(item) <= 0.0;
     }
 
     @Override
-    public void describeMismatchSafely(Double item, Description mismatchDescription) {
+    public void describeMismatchSafely(Number item, Description mismatchDescription) {
       mismatchDescription.appendValue(item)
                          .appendText(" differed by ")
                          .appendValue(actualDelta(item))
@@ -42,8 +42,8 @@ public class IsCloseTo extends TypeSafeMatcher<Double> {
                 .appendValue(value);
     }
 
-    private double actualDelta(Double item) {
-      return abs(item - value) - delta;
+    private double actualDelta(Number item) {
+      return abs(item.doubleValue() - value) - delta;
     }
 
     /**
@@ -57,7 +57,7 @@ public class IsCloseTo extends TypeSafeMatcher<Double> {
      * @param error
      *     the delta (+/-) within which matches will be allowed
      */
-    public static Matcher<Double> closeTo(double operand, double error) {
+    public static Matcher<Number> closeTo(double operand, double error) {
         return new IsCloseTo(operand, error);
     }
 }

--- a/hamcrest-library/src/test/java/org/hamcrest/number/IsCloseToTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/number/IsCloseToTest.java
@@ -6,7 +6,7 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 
 public class IsCloseToTest extends AbstractMatcherTest {
-  private final Matcher<Double> matcher = closeTo(1.0d, 0.5d);
+  private final Matcher<Number> matcher = closeTo(1.0d, 0.5d);
 
   @Override
     protected Matcher<?> createMatcher() {
@@ -23,6 +23,46 @@ public class IsCloseToTest extends AbstractMatcherTest {
         assertMismatchDescription("<3.0> differed by <1.5> more than delta <0.5>", matcher, 3.0d);
         assertDoesNotMatch("number too small", matcher, 0.0);
         assertMismatchDescription("<0.1> differed by <0.4> more than delta <0.5>", matcher, 0.1);
+    }
+
+    public void test_matchesIfArgumentIsEqualToAFloatValueWithinSomeError() {
+        assertMatches("1.0", matcher, 1.0f);
+        assertMatches("0.5d", matcher, 0.5f);
+        assertMatches("1.5d", matcher, 1.5f);
+
+        assertDoesNotMatch("too large", matcher, 2.0f);
+        String description = mismatchDescription(matcher, 3.0f);
+        assertTrue(description.matches("<3\\.0F> differed by <1\\.(499\\d+|5|500\\d+)> more than delta <0\\.5>"));
+        assertDoesNotMatch("number too small", matcher, 0.1f);
+        description = mismatchDescription(matcher, 0.1f);
+        assertTrue(description.matches("<0\\.1F> differed by <0\\.(399\\d+|4|400\\d+)> more than delta <0\\.5>"));
+    }
+
+    public void test_matchesIfArgumentIsEqualToALongValueWithinSomeError() {
+        assertMatches("1.0", matcher, 1L);
+
+        assertDoesNotMatch("too large", matcher, 2L);
+        assertMismatchDescription("<3L> differed by <1.5> more than delta <0.5>", matcher, 3L);
+        assertDoesNotMatch("number too small", matcher, 0L);
+        assertMismatchDescription("<0L> differed by <0.5> more than delta <0.5>", matcher, 0L);
+    }
+
+    public void test_matchesIfArgumentIsEqualToAnIntegerValueWithinSomeError() {
+        assertMatches("1.0", matcher, 1);
+
+        assertDoesNotMatch("too large", matcher, 2);
+        assertMismatchDescription("<3> differed by <1.5> more than delta <0.5>", matcher, 3);
+        assertDoesNotMatch("number too small", matcher, 0);
+        assertMismatchDescription("<0> differed by <0.5> more than delta <0.5>", matcher, 0);
+    }
+
+    public void test_matchesIfArgumentIsEqualToAShortValueWithinSomeError() {
+        assertMatches("1.0", matcher, (short) 1);
+
+        assertDoesNotMatch("too large", matcher, (short) 2);
+        assertMismatchDescription("<3s> differed by <1.5> more than delta <0.5>", matcher, (short) 3);
+        assertDoesNotMatch("number too small", matcher, (short) 0);
+        assertMismatchDescription("<0s> differed by <0.5> more than delta <0.5>", matcher, (short) 0);
     }
 
     public void test_is_self_describing() {


### PR DESCRIPTION
The `IsCloseTo`/`closeTo` matcher should be able to check all numerical types are within the bounds set, rather than just doubles. The implementation already worked if a primitive value was cast to `double`, but did not work in the case of boxed non-Double numbers, e.g. when trying to check Integer values in a list or map, etc.