### PR TITLE
[WIP] Add proposed signature for ignoring properties

### DIFF
--- a/hamcrest-library/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
@@ -138,4 +138,11 @@ public class SamePropertyValuesAs<T> extends DiagnosingMatcher<T> {
         return new SamePropertyValuesAs<>(expectedBean);
     }
 
+    /**
+     * TODO implement
+     */
+    public static <B> Matcher<B> samePropertyValuesAs(B expectedBean, PropertyDescriptor[] ignoredProperties) {
+        return new SamePropertyValuesAs<>(expectedBean);
+    }
+
 }

--- a/hamcrest-library/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -2,6 +2,9 @@ package org.hamcrest.beans;
 
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
+import org.junit.Ignore;
+
+import java.beans.PropertyDescriptor;
 
 import static org.hamcrest.beans.SamePropertyValuesAs.samePropertyValuesAs;
 
@@ -10,6 +13,7 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
   private static final Value aValue = new Value("expected");
   private static final ExampleBean expectedBean = new ExampleBean("same", 1, aValue);
   private static final ExampleBean actualBean = new ExampleBean("same", 1, aValue);
+  private static final ExampleBean actualMostPropertiesBean = new ExampleBean("same", 2, aValue);
   
   
   @Override
@@ -20,7 +24,15 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
   public void test_reports_match_when_all_properties_match() {
     assertMatches("matched properties", samePropertyValuesAs(expectedBean), actualBean);
   }
-  
+
+  /**
+   * TODO implement method and un-ignore test
+   */
+  public void _test_reports_match_when_desired_properties_match() {
+    PropertyDescriptor[] ignoredProperties = null;
+    assertMatches("matched properties", samePropertyValuesAs(expectedBean, ignoredProperties), actualMostPropertiesBean);
+  }
+
   public void test_reports_mismatch_when_actual_type_is_not_assignable_to_expected_type() {
     assertMismatchDescription("is incompatible type: ExampleBean", 
                               samePropertyValuesAs((Object)aValue), actualBean);


### PR DESCRIPTION
This is a work in process pull request for addressing [issue 170](https://github.com/hamcrest/JavaHamcrest/issues/170) . 

`SamePropertyValuesAsTest _test_reports_match_when_desired_properties_match`

If this implementation meets style and contribution guidelines, please comment and I will continue with the implementation.

Thanks!