### PR TITLE
added maven-publish plugin to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'osgi'
 apply plugin: 'signing'
+apply plugin: 'maven-publish'
 
 sourceCompatibility = VERSION_1_7
 targetCompatibility = VERSION_1_7


### PR DESCRIPTION
added maven-publish plugin to build.gradle in order to be able to run `./gradlew publishToMavenLocal` and speed up usage of local fixes