### PR TITLE
exposed IsEqualCompressingWhiteSpace.string

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
@@ -23,6 +23,10 @@ public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
         this.string = string;
     }
 
+    protected String getString() {
+        return string;
+    }
+
     @Override
     public boolean matchesSafely(String item) {
         return stripSpaces(string).equals(stripSpaces(item));


### PR DESCRIPTION
exposed IsEqualCompressingWhiteSpace.string in protected getString in order to facilitate use in subclasses