### PR TITLE
FeatureMatcher factory method for java 8 users

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/FeatureMatcher.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/FeatureMatcher.java
@@ -51,4 +51,18 @@ public abstract class FeatureMatcher<T, U> extends TypeSafeDiagnosingMatcher<T> 
     description.appendText(featureDescription).appendText(" ")
                .appendDescriptionOf(subMatcher);
   }
+
+  public static <T, U> FeatureMatcher<T, U> ofFunction(final Mapper<T, U> mapper, Matcher<? super U> matcher, String featureDescription, String featureName) {
+  	return new FeatureMatcher<T, U>(matcher, featureDescription, featureName) {
+	  @Override
+	  protected U featureValueOf(T actual) {
+	    return mapper.map(actual);
+	  }
+	};
+  }
+
+  // TODO java 8 @FunctionalInterface
+  public interface Mapper<T, U> {
+  	U map(T t);
+  }
 }


### PR DESCRIPTION
This simple addition allows users on java 8 to do this:
```
FeatureMatcher.ofFunction(Thing::calculateName, containsString("foo"), "calculated name contains foo", "calculateName")
```
instead of
```
new FeatureMatcher(containsString("foo"), "calculated name contains foo", "calculateName") {
  @Override
  protected String featureValueOf(Thing actual) {
    return actual.calculateName();
  }
}
```

Less verbose/more concise, more pleasant to work with, and does not require hamcrest to be updated to java 8 or anything.