### PR TITLE
Remove caching of gradle dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,6 @@ before_install:
 - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
 - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
 
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-
 jdk:
   - openjdk7
   - oraclejdk8


### PR DESCRIPTION
Caching build dependencies on a CI system can hide the unavailability
of dependencies for download. The CI build is of higher quality if it
tests the availability of all build dependencies. The increase in
data volume to transfer and the build time is minimal.