### PR TITLE
Checker header in checkstyle

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD License
 
-Copyright (c) 2000-2015 www.hamcrest.org
+Copyright (c) 2000-2022 www.hamcrest.org
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'signing'
+apply plugin: 'checkstyle'
 apply plugin: 'osgi'
 apply plugin: 'maven-publish'
 
@@ -21,10 +22,7 @@ subprojects {
 
     checkstyle {
 
-        project.ext.checkstyleVersion = '6.18'
-            //works with a JDK 7 version which is supposed to be supported although
-            //deprecated, see https://github.com/hamcrest/JavaHamcrest/pull/211 for
-            //the discussion about the support
+        project.ext.checkstyleVersion = '8.41'
 
         sourceSets = [ project.sourceSets.main, project.sourceSets.test ]
         ignoreFailures = false

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0"?>
  <!DOCTYPE module PUBLIC
-   "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-   "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+   "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+   "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <!-- Checks that there are no tab characters ('\t') in the source code. -->
     <module name="FileTabCharacter">
         <!-- Report on each line in each file -->
         <property name="eachLine" value="true"/>
+    </module>
+    <!-- Following interprets the header file as regular expressions. -->
+    <!-- Due to the fact that checkstyle only seems to be able to (re)use text from a license file if no text stands before the header in the source code and the fact that variable text is used in the header (package name), use the `RegexpHeader` module to validate the headers -->
+    <module name="RegexpHeader">
+        <property
+            name="header"
+            value="^/\*\*\n \* Copyright \(c\) 2000-2022 www.hamcrest.org. All rights reserved.\n \*\n \* This work is licensed under the terms of the BSD license.\n \* For a copy, see LICENSE.txt in this repository.\n\*/\n"/>
+        <property name="fileExtensions" value="java"/>
     </module>
 </module>

--- a/hamcrest-core/src/main/java/org/hamcrest/core/deprecated/HamcrestCoreIsDeprecated.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/deprecated/HamcrestCoreIsDeprecated.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core.deprecated;
 
 /**

--- a/hamcrest-core/src/main/java/org/hamcrest/core/deprecated/package-info.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/deprecated/package-info.java
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
+
+/**
  * All classes in <code>hamcrest-core.jar</code> have been migrated to
  * <code>hamcrest.jar</code>. Please use that dependency instead.
  */

--- a/hamcrest-integration/src/main/java/org/hamcrest/EasyMock2Matchers.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/EasyMock2Matchers.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.integration.EasyMock2Adapter;

--- a/hamcrest-integration/src/main/java/org/hamcrest/JMock1Matchers.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/JMock1Matchers.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.integration.JMock1Adapter;

--- a/hamcrest-integration/src/main/java/org/hamcrest/JavaLangMatcherAssert.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/JavaLangMatcherAssert.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest-integration/src/main/java/org/hamcrest/integration/EasyMock2Adapter.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/integration/EasyMock2Adapter.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.integration;
 
 import org.easymock.IArgumentMatcher;

--- a/hamcrest-integration/src/main/java/org/hamcrest/integration/JMock1Adapter.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/integration/JMock1Adapter.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.integration;
 
 import org.jmock.core.Constraint;

--- a/hamcrest-library/src/main/java/org/hamcrest/library/deprecated/HamcrestLibraryIsDeprecated.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/library/deprecated/HamcrestLibraryIsDeprecated.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.library.deprecated;
 
 /**

--- a/hamcrest-library/src/main/java/org/hamcrest/library/deprecated/package-info.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/library/deprecated/package-info.java
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
+
+/**
  * All classes in <code>hamcrest-library.jar</code> have been migrated to
  * <code>hamcrest.jar</code>. Please use that dependency instead.
  */

--- a/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.internal.ArrayIterator;

--- a/hamcrest/src/main/java/org/hamcrest/BaseMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/Condition.java
+++ b/hamcrest/src/main/java/org/hamcrest/Condition.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.core.IsIterableContaining;

--- a/hamcrest/src/main/java/org/hamcrest/CustomMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 

--- a/hamcrest/src/main/java/org/hamcrest/Description.java
+++ b/hamcrest/src/main/java/org/hamcrest/Description.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/DiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/DiagnosingMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.internal.ReflectiveTypeFinder;

--- a/hamcrest/src/main/java/org/hamcrest/Matcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.collection.ArrayMatching;

--- a/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
+++ b/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 /**

--- a/hamcrest/src/main/java/org/hamcrest/StringDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/StringDescription.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import java.io.IOException;

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.internal.ReflectiveTypeFinder;

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.internal.ReflectiveTypeFinder;

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasProperty.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasProperty.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import org.hamcrest.Condition;

--- a/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import java.beans.IntrospectionException;

--- a/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayAsIterableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayAsIterableMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.FeatureMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.FeatureMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInRelativeOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInRelativeOrder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.FeatureMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.FeatureMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
+++ b/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.comparator;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/Every.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Every.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/Is.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Is.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsAnything.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsAnything.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/ShortcutCombination.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/ShortcutCombination.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.BaseMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/StringContains.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringContains.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/StringEndsWith.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringEndsWith.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/StringRegularExpression.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringRegularExpression.java
@@ -1,5 +1,8 @@
 /**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
  *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
  */
 package org.hamcrest.core;
 

--- a/hamcrest/src/main/java/org/hamcrest/core/StringStartsWith.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringStartsWith.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/main/java/org/hamcrest/core/SubstringMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/SubstringMatcher.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.internal;
 
 import java.lang.reflect.Array;

--- a/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.internal;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
@@ -1,4 +1,14 @@
 /**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
+package org.hamcrest.internal;
+
+import java.lang.reflect.Method;
+
+/**
  * The TypeSafe classes, and their descendants, need a mechanism to find out what type has been used as a parameter 
  * for the concrete matcher. Unfortunately, this type is lost during type erasure so we need to use reflection 
  * to get it back, by picking out the type of a known parameter to a known method. 
@@ -23,10 +33,6 @@
  * @author Steve Freeman
  * @author Nat Pryce
  */
-package org.hamcrest.internal;
-
-import java.lang.reflect.Method;
-
 public class ReflectiveTypeFinder {
   private final String methodName;
   private final int expectedNumberOfParameters;

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.internal;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.internal;
 
 import org.hamcrest.SelfDescribing;

--- a/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.io;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/number/IsNaN.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsNaN.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/number/OrderingComparison.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/OrderingComparison.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/main/java/org/hamcrest/object/HasEqualValues.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasEqualValues.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.FeatureMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/CharSequenceLength.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/CharSequenceLength.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.FeatureMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
@@ -1,4 +1,9 @@
-
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
@@ -1,4 +1,9 @@
-
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
+++ b/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.xml;
 
 import org.hamcrest.Condition;

--- a/hamcrest/src/test/java/org/hamcrest/AbstractMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/AbstractMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import junit.framework.TestCase;

--- a/hamcrest/src/test/java/org/hamcrest/BaseDescriptionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/BaseDescriptionTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/BaseMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/BaseMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/CustomMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/CustomMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/FeatureMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/FeatureMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.core.IsEqual;

--- a/hamcrest/src/test/java/org/hamcrest/MatcherAssertTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/MatcherAssertTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/NullDescriptionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/NullDescriptionTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.hamcrest.Description.NullDescription;

--- a/hamcrest/src/test/java/org/hamcrest/TypeSafeDiagnosingMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/TypeSafeDiagnosingMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/TypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/TypeSafeMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest;
 
 import org.junit.Test;

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import org.hamcrest.*;

--- a/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.beans;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/HasItemInArrayTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/HasItemInArrayTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayWithSizeTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInRelativeOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInRelativeOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableWithSizeTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.collection;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherBuilderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherBuilderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.comparator;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.comparator;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/DescribedAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/DescribedAsTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/EveryTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/EveryTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsAnythingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsAnythingTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsEqualTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsEqualTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsInstanceOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsInstanceOfTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsNotTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsNotTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/IsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/core/SampleBaseClass.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/SampleBaseClass.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 public class SampleBaseClass {

--- a/hamcrest/src/test/java/org/hamcrest/core/SampleSubClass.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/SampleSubClass.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 public class SampleSubClass extends SampleBaseClass {

--- a/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/core/StringEndsWithTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringEndsWithTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/core/StringMatchingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringMatchingTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.junit.Rule;

--- a/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/core/StringStartsWithTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringStartsWithTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.core;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.io;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/number/BigDecimalCloseToTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/BigDecimalCloseToTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/number/IsCloseToTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/IsCloseToTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/number/IsNanTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/IsNanTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.number;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/object/HasEqualsValuesTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasEqualsValuesTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/object/IsCompatibleTypeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/IsCompatibleTypeTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/object/IsEventFromTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/IsEventFromTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/object/MatchesPatternTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/MatchesPatternTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.object;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/text/CharSequenceLengthTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/CharSequenceLengthTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/text/IsBlankStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsBlankStringTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEmptyStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEmptyStringTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualCompressingWhiteSpaceTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualCompressingWhiteSpaceTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.Matcher;

--- a/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.text;
 
 import org.hamcrest.AbstractMatcherTest;

--- a/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2000-2022 www.hamcrest.org. All rights reserved.
+ *
+ * This work is licensed under the terms of the BSD license.
+ * For a copy, see LICENSE.txt in this repository.
+ */
 package org.hamcrest.xml;
 
 import org.hamcrest.Matcher;


### PR DESCRIPTION
As suggested in #214 the checkstyle setup can be put forward step by
step in order to minimize controversy. The start contains a rule to
enforce a license header on every Java files which is a must-have.