### PR TITLE
Start checkstyle setup 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ group = "org.hamcrest"
 version = "2.2-SNAPSHOT"
 
 subprojects {
+    apply plugin: 'checkstyle'
     apply plugin: 'java-library'
 
     sourceCompatibility = JavaVersion.VERSION_1_7
@@ -16,6 +17,27 @@ subprojects {
 
     repositories {
         mavenCentral()
+    }
+
+    checkstyle {
+
+        project.ext.checkstyleVersion = '6.18'
+            //works with a JDK 7 version which is supposed to be supported although
+            //deprecated, see https://github.com/hamcrest/JavaHamcrest/pull/211 for
+            //the discussion about the support
+
+        sourceSets = [ project.sourceSets.main, project.sourceSets.test ]
+        ignoreFailures = false
+        configFile = file("${project.rootDir}/checkstyle.xml")
+
+        configurations {
+            checkstyle
+        }
+
+        dependencies{
+            assert project.hasProperty("checkstyleVersion")
+            checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
+        }
     }
 
     test {

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+ <!DOCTYPE module PUBLIC
+   "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+   "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <!-- Checks that there are no tab characters ('\t') in the source code. -->
+    <module name="FileTabCharacter">
+        <!-- Report on each line in each file -->
+        <property name="eachLine" value="true"/>
+    </module>
+</module>

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -44,7 +44,7 @@ public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <E> Matcher<Collection<? extends E>> hasSize(int size) {
-    	return (Matcher)IsCollectionWithSize.hasSize(equalTo(size));
+        return (Matcher)IsCollectionWithSize.hasSize(equalTo(size));
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -129,7 +129,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
         // required for JDK 1.6
         //noinspection RedundantTypeArguments
         final List<Matcher<? super E>> nullSafeWithExplicitTypeMatchers = NullSafety.<E>nullSafe(itemMatchers);
-    	return contains(nullSafeWithExplicitTypeMatchers);
+        return contains(nullSafeWithExplicitTypeMatchers);
     }
 
     /**

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
@@ -55,7 +55,7 @@ public class IsIterableContainingInOrderTest extends AbstractMatcherTest {
     }
     
     public void testCanHandleNullMatchers() {
-    	assertMatches(contains(null, null), asList(null, null));
+        assertMatches(contains(null, null), asList(null, null));
     }
 
     public static class WithValue {

--- a/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
@@ -26,30 +26,30 @@ public final class HasToStringTest {
     
     @Test public void
     matchesWhenUtilisingANestedMatcher() {
-    	final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
+        final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
 
-    	assertMatches(matcher, TEST_OBJECT);
-    	assertDoesNotMatch(matcher, new Object());
+        assertMatches(matcher, TEST_OBJECT);
+        assertDoesNotMatch(matcher, new Object());
     }
 
     @Test public void
     matchesWhenUsingShortcutForHasToStringEqualTo() {
-    	final Matcher<Object> matcher = hasToString(TO_STRING_RESULT);
-    	
-		assertMatches(matcher, TEST_OBJECT);
-    	assertDoesNotMatch(matcher, new Object());
+        final Matcher<Object> matcher = hasToString(TO_STRING_RESULT);
+        
+        assertMatches(matcher, TEST_OBJECT);
+        assertDoesNotMatch(matcher, new Object());
     }
 
     @Test public void
     describesItself() {
-    	final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
+        final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
         assertDescription("with toString() \"toString result\"", matcher);
     }
 
     @Test public void
     describesAMismatch() {
-    	final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
-    	String expectedMismatchString = "toString() was \"Cheese\"";
+        final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
+        String expectedMismatchString = "toString() was \"Cheese\"";
         assertMismatchDescription(expectedMismatchString, matcher, "Cheese");
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -19,26 +19,26 @@ public final class IsEqualIgnoringCaseTest {
     @Test public void
     ignoresCaseOfCharsInString() {
         final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-		
+        
         assertMatches(matcher, "HELLO");
         assertMatches(matcher, "hello");
         assertMatches(matcher, "HelLo");
-    	assertDoesNotMatch(matcher, "bye");
+        assertDoesNotMatch(matcher, "bye");
     }
 
     @Test public void 
     mismatchesIfAdditionalWhitespaceIsPresent() {
-    	final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-		
-    	assertDoesNotMatch(matcher, "hello ");
-    	assertDoesNotMatch(matcher, " hello");
+        final Matcher<String> matcher = equalToIgnoringCase("heLLo");
+        
+        assertDoesNotMatch(matcher, "hello ");
+        assertDoesNotMatch(matcher, " hello");
     }
 
     @Test public void 
     mismatchesNull() {
-    	final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-		
-    	assertDoesNotMatch(matcher, null);
+        final Matcher<String> matcher = equalToIgnoringCase("heLLo");
+        
+        assertDoesNotMatch(matcher, null);
     }
 
     @Test(expected=IllegalArgumentException.class) public void
@@ -49,14 +49,14 @@ public final class IsEqualIgnoringCaseTest {
 
     @Test public void
     describesItself() {
-    	final Matcher<String> matcher = equalToIgnoringCase("heLLo");
+        final Matcher<String> matcher = equalToIgnoringCase("heLLo");
         assertDescription("a string equal to \"heLLo\" ignoring case", matcher);
     }
 
     @Test public void
     describesAMismatch() {
-    	final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-    	String expectedMismatchString = "was \"Cheese\"";
+        final Matcher<String> matcher = equalToIgnoringCase("heLLo");
+        String expectedMismatchString = "was \"Cheese\"";
         assertMismatchDescription(expectedMismatchString, matcher, "Cheese");
     }
 }


### PR DESCRIPTION
As suggested in #214 the checkstyle setup can be put forward step by
step in order to minimize controversy. The start contains a rule to
enforce spaces instead of tab characters which are already used in
roughly 99.99% of the source.