### PR TITLE
Clean-up java-doc of String-related matchers

### DIFF
--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java
@@ -3,7 +3,7 @@ package org.hamcrest.core;
 import org.hamcrest.Matcher;
 
 /**
- * Tests if the argument is a string that contains a substring.
+ * Tests if the argument is a string that contains a specific substring.
  */
 public class StringContains extends SubstringMatcher {
     public StringContains(boolean ignoringCase, String substring) {

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java
@@ -3,7 +3,7 @@ package org.hamcrest.core;
 import org.hamcrest.Matcher;
 
 /**
- * Tests if the argument is a string that contains a substring.
+ * Tests if the argument is a string that ends with a specific substring.
  */
 public class StringEndsWith extends SubstringMatcher {
     public StringEndsWith(boolean ignoringCase, String substring) { super("ending with", ignoringCase, substring); }

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringRegularExpression.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringRegularExpression.java
@@ -37,7 +37,7 @@ public class StringRegularExpression extends TypeSafeDiagnosingMatcher<String> {
   }
 
   /**
-   * Validate a string with a {@link java.util.regex.Pattern}.
+   * Creates a matcher that checks if the examined string matches a specified {@link java.util.regex.Pattern}.
    *
    * <pre>
    * assertThat(&quot;abc&quot;, matchesRegex(Pattern.compile(&quot;&circ;[a-z]$&quot;));
@@ -52,7 +52,7 @@ public class StringRegularExpression extends TypeSafeDiagnosingMatcher<String> {
   }
 
   /**
-   * Validate a string with a regex.
+   * Creates a matcher that checks if the examined string matches a specified regex.
    *
    * <pre>
    * assertThat(&quot;abc&quot;, matchesRegex(&quot;&circ;[a-z]+$&quot;));

--- a/hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java
+++ b/hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java
@@ -3,7 +3,7 @@ package org.hamcrest.core;
 import org.hamcrest.Matcher;
 
 /**
- * Tests if the argument is a string that contains a substring.
+ * Tests if the argument is a string that starts with a specific substring.
  */
 public class StringStartsWith extends SubstringMatcher {
     public StringStartsWith(boolean ignoringCase, String substring) { super("starting with", ignoringCase, substring); }


### PR DESCRIPTION
Fixing a copy/pasted java-doc + making java-doc in `StringRegularExpression` more consistent with other matchers.