### PR TITLE
Update links to Tutorial and Distributables

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Hamcrest"/>
   <meta name="keywords" content="hamcrest java matchers junit testing"/>
   <meta name="robots" content="index, follow"/>
-  <meta name="date" content="2012-09-01"/>
+  <meta name="date" content="2018-11-01"/>
   <title>Java Hamcrest</title>
 
   <style>
@@ -65,17 +65,17 @@
   <div class="content">
    <h1><img class="logo" src="http://hamcrest.org/images/logo.jpg" title="hamcrest" alt="hamcrest surfer"></img>Java Hamcrest</h1>
    <h2>Matchers that can be combined to create flexible expressions of intent</h2>
+   <h3>Documentation</h3>
+   <ul>
+    <li><a href="https://github.com/hamcrest/JavaHamcrest/wiki/The-Hamcrest-Tutorial">Getting Started</a></li>
+    <li><a href="./javadoc/">API Documentation (JavaDoc)</a></li>
+   </ul>
    <h3>Downloads</h3>
    <ul>
     <li><a href="http://search.maven.org/#search|ga|1|g%3Aorg.hamcrest">Java Hamcrest Binaries<a/> (via Maven Central), explained <a href="http://code.google.com/p/hamcrest/wiki/HamcrestDistributables">here</a></li>
     <li><a href="http://github.com/hamcrest/JavaHamcrest">Source Repository</a></li>
     <li><a href="http://opensource.org/licenses/BSD-3-Clause">Project License</a></li>
     <li><a href="https://github.com/hamcrest/JavaHamcrest/wiki/Related-Projects">Extensions</a></li>
-   </ul>
-   <h3>Documentation</h3>
-   <ul>
-    <li><a href="http://code.google.com/p/hamcrest/wiki/Tutorial">Getting Started</a></li>
-    <li><a href="./javadoc/">API Documentation (JavaDoc)</a></li>
    </ul>
    <h3>User Support</h3>
    <ul>
@@ -87,7 +87,7 @@
     <span style="float:right;">
       Released under the <a href="http://opensource.org/licenses/BSD-3-Clause">BSD License</a>.
     </span>
-    Copyright 2012- <a href="http://hamcrest.org">hamcrest.org</a>
+    Copyright 2012-2018 <a href="http://hamcrest.org">hamcrest.org</a>
    </footer>
   </div>
   <a href="http://github.com/hamcrest/JavaHamcrest"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,7 @@
    </ul>
    <h3>Downloads</h3>
    <ul>
-    <li><a href="http://search.maven.org/#search|ga|1|g%3Aorg.hamcrest">Java Hamcrest Binaries<a/> (via Maven Central), explained <a href="http://code.google.com/p/hamcrest/wiki/HamcrestDistributables">here</a></li>
+    <li><a href="https://github.com/hamcrest/JavaHamcrest/wiki/Hamcrest-Distributables">Distributables and Dependency Configuration</a></li>
     <li><a href="http://github.com/hamcrest/JavaHamcrest">Source Repository</a></li>
     <li><a href="http://opensource.org/licenses/BSD-3-Clause">Project License</a></li>
     <li><a href="https://github.com/hamcrest/JavaHamcrest/wiki/Related-Projects">Extensions</a></li>
@@ -93,4 +93,3 @@
   <a href="http://github.com/hamcrest/JavaHamcrest"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
  </body>
 </html>
-


### PR DESCRIPTION
I've replace links to two outdated pages on the old Google Code site. The replacement pages are currently on the JavaHamcrest wiki on GitHub.

For the tutorial, I've linked to the existing Tutorial on the wiki. It's still out of date, but I plan to refresh it soon.

For the distributables, I've created a new wiki page. I'd appreciate it if people could review the page for accuracy and improvements.