### PR TITLE
Add FloatIsCloseTo matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 gradle.properties
 release-key.asc
 grade-wrapper.properties
+/.settings
+/.project
+/.classpath

--- a/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/Matchers.java
@@ -1262,7 +1262,22 @@ public class Matchers {
    *     the delta (+/-) within which matches will be allowed
    */
   public static org.hamcrest.Matcher<java.lang.Double> closeTo(double operand, double error) {
-    return org.hamcrest.number.IsCloseTo.closeTo(operand, error);
+    return org.hamcrest.number.DoubleIsCloseTo.closeTo(operand, error);
+  }
+
+  /**
+   * Creates a matcher of {@link Float}s that matches when an examined float is equal
+   * to the specified <code>operand</code>, within a range of +/- <code>error</code>.
+   * For example:
+   * <pre>assertThat(1.03f, is(closeTo(1.0f, 0.03f)))</pre>
+   *
+   * @param operand
+   *     the expected value of matching doubles
+   * @param error
+   *     the delta (+/-) within which matches will be allowed
+   */
+  public static org.hamcrest.Matcher<java.lang.Float> closeTo(float operand, float error) {
+    return org.hamcrest.number.FloatIsCloseTo.closeTo(operand, error);
   }
 
   /**

--- a/hamcrest-library/src/main/java/org/hamcrest/number/DoubleIsCloseTo.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/number/DoubleIsCloseTo.java
@@ -1,0 +1,63 @@
+package org.hamcrest.number;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static java.lang.Math.abs;
+
+
+/**
+ * Is the value a number equal to a value within some range of
+ * acceptable error?
+ */
+public class DoubleIsCloseTo extends TypeSafeMatcher<Double> {
+    private final double delta;
+    private final double value;
+
+    public DoubleIsCloseTo(double value, double error) {
+        this.delta = error;
+        this.value = value;
+    }
+
+    @Override
+    public boolean matchesSafely(Double item) {
+        return actualDelta(item) <= delta;
+    }
+
+    @Override
+    public void describeMismatchSafely(Double item, Description mismatchDescription) {
+      mismatchDescription.appendValue(item)
+                         .appendText(" differed by ")
+                         .appendValue(actualDelta(item))
+                         .appendText(", but delta is ")
+                         .appendValue(delta);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a numeric value within ")
+                .appendValue(delta)
+                .appendText(" of ")
+                .appendValue(value);
+    }
+
+    private double actualDelta(Double item) {
+      return abs(item - value);
+    }
+
+    /**
+     * Creates a matcher of {@link Double}s that matches when an examined double is equal
+     * to the specified <code>operand</code>, within a range of +/- <code>error</code>.
+     * For example:
+     * <pre>assertThat(1.03, is(closeTo(1.0, 0.03)))</pre>
+     *
+     * @param operand
+     *     the expected value of matching doubles
+     * @param error
+     *     the delta (+/-) within which matches will be allowed
+     */
+    public static Matcher<Double> closeTo(double operand, double error) {
+        return new DoubleIsCloseTo(operand, error);
+    }
+}

--- a/hamcrest-library/src/main/java/org/hamcrest/number/FloatIsCloseTo.java
+++ b/hamcrest-library/src/main/java/org/hamcrest/number/FloatIsCloseTo.java
@@ -11,26 +11,26 @@ import static java.lang.Math.abs;
  * Is the value a number equal to a value within some range of
  * acceptable error?
  */
-public class IsCloseTo extends TypeSafeMatcher<Double> {
-    private final double delta;
-    private final double value;
+public class FloatIsCloseTo extends TypeSafeMatcher<Float> {
+    private final float delta;
+    private final float value;
 
-    public IsCloseTo(double value, double error) {
+    public FloatIsCloseTo(float value, float error) {
         this.delta = error;
         this.value = value;
     }
 
     @Override
-    public boolean matchesSafely(Double item) {
-        return actualDelta(item) <= 0.0;
+    public boolean matchesSafely(Float item) {
+        return actualDelta(item) <= delta;
     }
 
     @Override
-    public void describeMismatchSafely(Double item, Description mismatchDescription) {
+    public void describeMismatchSafely(Float item, Description mismatchDescription) {
       mismatchDescription.appendValue(item)
                          .appendText(" differed by ")
                          .appendValue(actualDelta(item))
-                         .appendText(" more than delta ")
+                         .appendText(", but delta is ")
                          .appendValue(delta);
     }
 
@@ -42,22 +42,22 @@ public class IsCloseTo extends TypeSafeMatcher<Double> {
                 .appendValue(value);
     }
 
-    private double actualDelta(Double item) {
-      return abs(item - value) - delta;
+    private float actualDelta(Float item) {
+      return abs(item - value);
     }
 
     /**
-     * Creates a matcher of {@link Double}s that matches when an examined double is equal
+     * Creates a matcher of {@link Float}s that matches when an examined float is equal
      * to the specified <code>operand</code>, within a range of +/- <code>error</code>.
      * For example:
-     * <pre>assertThat(1.03, is(closeTo(1.0, 0.03)))</pre>
-     * 
+     * <pre>assertThat(1.03f, is(closeTo(1.0f, 0.03f)))</pre>
+     *
      * @param operand
-     *     the expected value of matching doubles
+     *     the expected value of matching floats
      * @param error
      *     the delta (+/-) within which matches will be allowed
      */
-    public static Matcher<Double> closeTo(double operand, double error) {
-        return new IsCloseTo(operand, error);
+    public static Matcher<Float> closeTo(float operand, float error) {
+        return new FloatIsCloseTo(operand, error);
     }
 }

--- a/hamcrest-library/src/test/java/org/hamcrest/number/DoubleIsCloseToTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/number/DoubleIsCloseToTest.java
@@ -3,9 +3,9 @@ package org.hamcrest.number;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.hamcrest.number.DoubleIsCloseTo.closeTo;
 
-public class IsCloseToTest extends AbstractMatcherTest {
+public class DoubleIsCloseToTest extends AbstractMatcherTest {
   private final Matcher<Double> matcher = closeTo(1.0d, 0.5d);
 
   @Override
@@ -20,9 +20,9 @@ public class IsCloseToTest extends AbstractMatcherTest {
         assertMatches("1.5d", matcher, 1.5d);
 
         assertDoesNotMatch("too large", matcher, 2.0);
-        assertMismatchDescription("<3.0> differed by <1.5> more than delta <0.5>", matcher, 3.0d);
+        assertMismatchDescription("<3.0> differed by <2.0>, but delta is <0.5>", matcher, 3.0d);
         assertDoesNotMatch("number too small", matcher, 0.0);
-        assertMismatchDescription("<0.1> differed by <0.4> more than delta <0.5>", matcher, 0.1);
+        assertMismatchDescription("<0.1> differed by <0.9>, but delta is <0.5>", matcher, 0.1);
     }
 
     public void test_is_self_describing() {

--- a/hamcrest-library/src/test/java/org/hamcrest/number/FloatIsCloseToTest.java
+++ b/hamcrest-library/src/test/java/org/hamcrest/number/FloatIsCloseToTest.java
@@ -1,0 +1,31 @@
+package org.hamcrest.number;
+
+import org.hamcrest.AbstractMatcherTest;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.number.FloatIsCloseTo.closeTo;
+
+public class FloatIsCloseToTest extends AbstractMatcherTest {
+    private final Matcher<Float> matcher = closeTo(1.0f, 0.5f);
+
+    @Override
+    protected Matcher<?> createMatcher() {
+        final float irrelevant = 0.1f;
+        return closeTo(irrelevant, irrelevant);
+    }
+
+    public void test_matchesIfArgumentIsEqualToADoubleValueWithinSomeError() {
+        assertMatches("1.0F", matcher, 1.0f);
+        assertMatches("0.5F", matcher, 0.5f);
+        assertMatches("1.5F", matcher, 1.5f);
+
+        assertDoesNotMatch("too large", matcher, 2.0f);
+        assertMismatchDescription("<3.0F> differed by <2.0F>, but delta is <0.5F>", matcher, 3.0f);
+        assertDoesNotMatch("number too small", matcher, 0.0f);
+        assertMismatchDescription("<0.1F> differed by <0.9F>, but delta is <0.5F>", matcher, 0.1f);
+    }
+
+    public void test_is_self_describing() {
+        assertDescription("a numeric value within <0.5F> of <1.0F>", matcher);
+    }
+}


### PR DESCRIPTION
* Add `FloatIsCloseTo` matcher as copy of `IsCloseTo` matcher
* Rename `IsCloseTo` matcher to `DoubleIsCloseTo`
* Change error message for excluding errors in additional floating calculations (May user catch this error even with doubles?)
* Ignore eclipse specific files

PS.
Example of error with additional floating calculations:

```java
public static void main(String[] args) {
        System.out.println(abs(1.0f - 0.1f) - 0.5f);
        System.out.println(abs(1.0d - 0.1d) - 0.5d);
}
```
After run:
```
0.39999998
0.4
```