### PR TITLE
 Build separate jars for core, library, and all.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-/build
-/classes
-/bin
-/out
+build/
+classes/
+bin/
+out/
 .DS_Store
 *~
 *.swp
-/.idea
+.idea/
 *.iws
 *.ipr
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -87,85 +87,63 @@ task allJavadocJar(type: Jar) {
     from allJavadoc
 }
 
-publishing {
-    publications {
-        def coreProject = findProject("hamcrest-core")
-        hamcrestCore(MavenPublication) {
-            from coreProject.components.java
-            artifact coreProject.sourcesJar
-            artifact coreProject.javadocJar
-            pom {
-                name = 'Hamcrest Core'
-                description = 'This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.'
-                url = 'http://hamcrest.org/JavaHamcrest/'
+def pomConfigurationFor(String pomName, String pomDescription) {
+    return {
+        name = pomName
+        description = pomDescription
+        url = 'http://hamcrest.org/JavaHamcrest/'
 
-                scm {
-                    connection = 'git@github.com:hamcrest/JavaHamcrest.git'
-                    url = 'https://github.com/hamcrest/JavaHamcrest'
-                }
+        scm {
+            connection = 'git@github.com:hamcrest/JavaHamcrest.git'
+            url = 'https://github.com/hamcrest/JavaHamcrest'
+        }
 
-                licenses {
-                    license {
-                        name = 'BSD Licence 3'
-                        url = 'http://opensource.org/licenses/BSD-3-Clause'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'joewalnes'
-                        name = 'Joe Walnes'
-                    }
-                    developer {
-                        id = 'npryce'
-                        name = 'Nat Pryce'
-                    }
-                    developer {
-                        id = 'sf105'
-                        name = 'Steve Freeman'
-                    }
-                }
+        licenses {
+            license {
+                name = 'BSD Licence 3'
+                url = 'http://opensource.org/licenses/BSD-3-Clause'
             }
         }
 
-        def libraryProject = findProject("hamcrest-library")
+        developers {
+            developer {
+                id = 'joewalnes'
+                name = 'Joe Walnes'
+            }
+            developer {
+                id = 'npryce'
+                name = 'Nat Pryce'
+            }
+            developer {
+                id = 'sf105'
+                name = 'Steve Freeman'
+            }
+        }
+    }
+}
+
+publishing {
+    publications {
+        def coreProject = project(':hamcrest-core')
+        hamcrestCore(MavenPublication) {
+            from coreProject.components.java
+            artifactId coreProject.name
+            artifact coreProject.sourcesJar
+            artifact coreProject.javadocJar
+            pom pomConfigurationFor(
+                    'Hamcrest Core',
+                    'This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.')
+        }
+
+        def libraryProject = project(':hamcrest-library')
         hamcrestLibrary(MavenPublication) {
-            artifactId = libraryProject.name
             from libraryProject.components.java
+            artifactId = libraryProject.name
             artifact libraryProject.sourcesJar
             artifact libraryProject.javadocJar
-            pom {
-                name = 'Hamcrest Library'
-                description = 'Hamcrest library of matcher implementations.'
-                url = 'http://hamcrest.org/JavaHamcrest/'
-
-                scm {
-                    connection = 'git@github.com:hamcrest/JavaHamcrest.git'
-                    url = 'https://github.com/hamcrest/JavaHamcrest'
-                }
-
-                licenses {
-                    license {
-                        name = 'BSD Licence 3'
-                        url = 'http://opensource.org/licenses/BSD-3-Clause'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'joewalnes'
-                        name = 'Joe Walnes'
-                    }
-                    developer {
-                        id = 'npryce'
-                        name = 'Nat Pryce'
-                    }
-                    developer {
-                        id = 'sf105'
-                        name = 'Steve Freeman'
-                    }
-                }
-            }
+            pom pomConfigurationFor(
+                    'Hamcrest Library',
+                    'Hamcrest library of matcher implementations.')
         }
 
         hamcrestAll(MavenPublication) {
@@ -173,38 +151,9 @@ publishing {
             artifact allClassesJar
             artifact allSourcesJar
             artifact allJavadocJar
-            pom {
-                name = 'Hamcrest All'
-                description = 'A self-contained hamcrest jar containing all of the sub-modules in a single artifact.'
-                url = 'http://hamcrest.org/JavaHamcrest/'
-
-                scm {
-                    connection = 'git@github.com:hamcrest/JavaHamcrest.git'
-                    url = 'https://github.com/hamcrest/JavaHamcrest'
-                }
-
-                licenses {
-                    license {
-                        name = 'BSD Licence 3'
-                        url = 'http://opensource.org/licenses/BSD-3-Clause'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'joewalnes'
-                        name = 'Joe Walnes'
-                    }
-                    developer {
-                        id = 'npryce'
-                        name = 'Nat Pryce'
-                    }
-                    developer {
-                        id = 'sf105'
-                        name = 'Steve Freeman'
-                    }
-                }
-            }
+            pom pomConfigurationFor(
+                    'Hamcrest All',
+                    'A self-contained hamcrest jar containing all of the sub-modules in a single artifact.')
         }
     }
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,79 +1,181 @@
-import static org.gradle.api.JavaVersion.VERSION_1_7
-
-apply plugin: 'java'
-apply plugin: 'osgi'
 apply plugin: 'signing'
+apply plugin: 'osgi'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = VERSION_1_7
-targetCompatibility = VERSION_1_7
-
 group = "org.hamcrest"
-version = "2.0.0.0"
+version = "1.4-SNAPSHOT"
 
+subprojects {
+    apply plugin: 'java-library'
+    apply plugin: 'osgi'
 
-repositories {
-    mavenCentral()
-}
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
 
-dependencies {
-    testCompile(group: 'junit', name: 'junit', version: '4.12') {
-        transitive = false
+    version = rootProject.version
+
+    repositories {
+        mavenCentral()
     }
-}
 
-sourceSets {
-    main {
-        java {
-            srcDirs 'hamcrest-core/src/main/java', 'hamcrest-library/src/main/java'
-        }
-
-    }
     test {
-        java {
-            srcDirs 'hamcrest-core/src/test/java', 'hamcrest-library/src/test/java'
+        testLogging {
+            exceptionFormat = 'full'
         }
     }
-}
 
-test {
-    testLogging {
-        exceptionFormat = 'full'
+    jar {
+        manifest {
+            attributes 'Implementation-Title': project.name,
+                    'Implementation-Vendor': 'hamcrest.org',
+                    'Implementation-Version': version
+            instruction 'Import-Package', '''javax.xml.namespace; resolution:=optional,
+                                         javax.xml.xpath; resolution:=optional,
+                                         org.w3c.dom; resolution:=optional,
+                                         *'''
+        }
+    }
+
+    task sourcesJar(type: Jar) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar) {
+        classifier = 'javadoc'
+        from javadoc
     }
 }
 
-jar {
+task allClassesJar(type: Jar, dependsOn: subprojects.tasks['build']) {
+    baseName = 'hamcrest-all'
+    subprojects.each { subproject ->
+        from zipTree(subproject.jar.archivePath)
+    }
     manifest {
         attributes 'Implementation-Title': 'hamcrest-all',
                 'Implementation-Vendor': 'hamcrest.org',
                 'Implementation-Version': version
-        instruction 'Import-Package', '''javax.xml.namespace; resolution:=optional,
-                                         javax.xml.xpath; resolution:=optional,
-                                         org.w3c.dom; resolution:=optional,
-                                         *'''
     }
 }
 
-task sourcesJar(type: Jar) {
+
+task allSourcesJar(type: Jar) {
+    baseName = 'hamcrest-all'
     classifier = 'sources'
-    from sourceSets.main.allSource
+    subprojects.each { subproject ->
+        from subproject.sourceSets.main.allSource
+    }
 }
 
-task javadocJar(type: Jar) {
+task allJavadoc(type: Javadoc) {
+    group = 'Documentation'
+    description = 'Generate combined Javadoc for all projects'
+    title = "Hamcrest All $version API"
+    subprojects.each { proj ->
+        proj.tasks.withType(Javadoc).each { javadocTask ->
+            source += javadocTask.source
+            classpath += javadocTask.classpath
+            excludes += javadocTask.excludes
+            includes += javadocTask.includes
+        }
+    }
+}
+
+task allJavadocJar(type: Jar) {
     classifier = 'javadoc'
-    from javadoc
+    from allJavadoc
 }
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            artifactId = 'java-hamcrest'
-            from components.java
-            artifact sourcesJar
-            artifact javadocJar
+        def coreProject = findProject("hamcrest-core")
+        hamcrestCore(MavenPublication) {
+            from coreProject.components.java
+            artifact coreProject.sourcesJar
+            artifact coreProject.javadocJar
             pom {
-                name = 'Java Hamcrest'
-                description = 'Hamcrest matcher library for Java'
+                name = 'Hamcrest Core'
+                description = 'This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.'
+                url = 'http://hamcrest.org/JavaHamcrest/'
+
+                scm {
+                    connection = 'git@github.com:hamcrest/JavaHamcrest.git'
+                    url = 'https://github.com/hamcrest/JavaHamcrest'
+                }
+
+                licenses {
+                    license {
+                        name = 'BSD Licence 3'
+                        url = 'http://opensource.org/licenses/BSD-3-Clause'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'joewalnes'
+                        name = 'Joe Walnes'
+                    }
+                    developer {
+                        id = 'npryce'
+                        name = 'Nat Pryce'
+                    }
+                    developer {
+                        id = 'sf105'
+                        name = 'Steve Freeman'
+                    }
+                }
+            }
+        }
+
+        def libraryProject = findProject("hamcrest-library")
+        hamcrestLibrary(MavenPublication) {
+            artifactId = libraryProject.name
+            from libraryProject.components.java
+            artifact libraryProject.sourcesJar
+            artifact libraryProject.javadocJar
+            pom {
+                name = 'Hamcrest Library'
+                description = 'Hamcrest library of matcher implementations.'
+                url = 'http://hamcrest.org/JavaHamcrest/'
+
+                scm {
+                    connection = 'git@github.com:hamcrest/JavaHamcrest.git'
+                    url = 'https://github.com/hamcrest/JavaHamcrest'
+                }
+
+                licenses {
+                    license {
+                        name = 'BSD Licence 3'
+                        url = 'http://opensource.org/licenses/BSD-3-Clause'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'joewalnes'
+                        name = 'Joe Walnes'
+                    }
+                    developer {
+                        id = 'npryce'
+                        name = 'Nat Pryce'
+                    }
+                    developer {
+                        id = 'sf105'
+                        name = 'Steve Freeman'
+                    }
+                }
+            }
+        }
+
+        hamcrestAll(MavenPublication) {
+            artifactId = 'hamcrest-all'
+            artifact allClassesJar
+            artifact allSourcesJar
+            artifact allJavadocJar
+            pom {
+                name = 'Hamcrest All'
+                description = 'A self-contained hamcrest jar containing all of the sub-modules in a single artifact.'
                 url = 'http://hamcrest.org/JavaHamcrest/'
 
                 scm {
@@ -122,5 +224,7 @@ publishing {
 
 signing {
     required { hasProperty('ossrhUsername') && hasProperty('ossrhPassword') }
-    sign publishing.publications.mavenJava
+    sign publishing.publications.hamcrestCore
+    sign publishing.publications.hamcrestLibrary
+    sign publishing.publications.hamcrestAll
 }

--- a/hamcrest-core/hamcrest-core.gradle
+++ b/hamcrest-core/hamcrest-core.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    testCompile(group: 'junit', name: 'junit', version: '4.12') {
+        transitive = false
+    }
+}
+
+javadoc.title = "Hamcrest Core $version API"

--- a/hamcrest-core/hamcrest-core.gradle
+++ b/hamcrest-core/hamcrest-core.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    testCompile(group: 'junit', name: 'junit', version: '4.12') {
+    testImplementation(group: 'junit', name: 'junit', version: '4.12') {
         transitive = false
     }
 }

--- a/hamcrest-library/hamcrest-library.gradle
+++ b/hamcrest-library/hamcrest-library.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    api project(':hamcrest-core')
+
+    testImplementation(group: 'junit', name: 'junit', version: '4.12') {
+        transitive = false
+    }
+    testImplementation project(':hamcrest-core').sourceSets.test.output
+}
+
+javadoc.title = "Hamcrest Library $version API"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,10 @@
 enableFeaturePreview('STABLE_PUBLISHING')
-rootProject.name = 'java-hamcrest'
+
+include 'hamcrest-core',
+        'hamcrest-library'
+
+rootProject.name = 'hamcrest'
+
+// Change the file name of the child project build file to match the directory name
+// This avoids having multiple `build.gradle` files, making them easier to distinguish
+rootProject.children.each { childProject -> childProject.buildFileName = "${childProject.name}.gradle" }


### PR DESCRIPTION
This is done by converting to a multi-project gradle build, with subprojects for `hamcrest-core` and `hamcrest-library`. The root project is responsible for combining all the individual jars into `hamcrest-all.jar`, as well as configuring the publishing.

Note that this changes the version from '2.0.0.0' to '1.4-SNAPSHOT'