### PR TITLE
Deprecated unwanted classes instead of deleting them

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -1,0 +1,112 @@
+package org.hamcrest.collection;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * @deprecated As of release 2.1, replaced by {@link ArrayMatching}.
+ */
+@Deprecated
+public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
+    private final IsIterableContainingInAnyOrder<E> iterableMatcher;
+    private final Collection<Matcher<? super E>> matchers;
+
+    public IsArrayContainingInAnyOrder(Collection<Matcher<? super E>> matchers) {
+        this.iterableMatcher = new IsIterableContainingInAnyOrder<E>(matchers);
+        this.matchers = matchers;
+    }
+
+    @Override
+    public boolean matchesSafely(E[] item) {
+        return iterableMatcher.matches(Arrays.asList(item));
+    }
+    
+    @Override
+    public void describeMismatchSafely(E[] item, Description mismatchDescription) {
+      iterableMatcher.describeMismatch(Arrays.asList(item), mismatchDescription);
+    };
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendList("[", ", ", "]", matchers)
+            .appendText(" in any order");
+    }
+
+    /**
+     * Creates an order agnostic matcher for arrays that matches when each item in the
+     * examined array satisfies one matcher anywhere in the specified matchers.
+     * For a positive match, the examined array must be of the same length as the number of
+     * specified matchers.
+     * <p/>
+     * N.B. each of the specified matchers will only be used once during a given examination, so be
+     * careful when specifying matchers that may be satisfied by more than one entry in an examined
+     * array.
+     * <p>
+     * For example:
+     * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContainingInAnyOrder(Matcher[])}.
+     *
+     * @param itemMatchers
+     *     a list of matchers, each of which must be satisfied by an entry in an examined array
+     */
+    public static <E> Matcher<E[]> arrayContainingInAnyOrder(Matcher<? super E>... itemMatchers) {
+        return arrayContainingInAnyOrder(Arrays.asList(itemMatchers));
+    }
+
+    /**
+     * Creates an order agnostic matcher for arrays that matches when each item in the
+     * examined array satisfies one matcher anywhere in the specified collection of matchers.
+     * For a positive match, the examined array must be of the same length as the specified collection
+     * of matchers.
+     * <p/>
+     * N.B. each matcher in the specified collection will only be used once during a given
+     * examination, so be careful when specifying matchers that may be satisfied by more than
+     * one entry in an examined array.
+     * <p>
+     * For example:
+     * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContainingInAnyOrder(Collection)}.
+     *
+     * @param itemMatchers
+     *     a list of matchers, each of which must be satisfied by an item provided by an examined array
+     */
+    public static <E> Matcher<E[]> arrayContainingInAnyOrder(Collection<Matcher<? super E>> itemMatchers) {
+        return new IsArrayContainingInAnyOrder<E>(itemMatchers);
+    }
+
+    /**
+     * Creates an order agnostic matcher for arrays that matches when each item in the
+     * examined array is logically equal to one item anywhere in the specified items.
+     * For a positive match, the examined array must be of the same length as the number of
+     * specified items.
+     * <p/>
+     * N.B. each of the specified items will only be used once during a given examination, so be
+     * careful when specifying items that may be equal to more than one entry in an examined
+     * array.
+     * <p>
+     * For example:
+     * <pre>assertThat(new String[]{"foo", "bar"}, containsInAnyOrder("bar", "foo"))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContainingInAnyOrder(Object[])}.
+     *
+     * @param items
+     *     the items that must equal the entries of an examined array, in any order
+     */
+    public static <E> Matcher<E[]> arrayContainingInAnyOrder(E... items) {
+      List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
+      for (E item : items) {
+          matchers.add(equalTo(item));
+      }
+      return new IsArrayContainingInAnyOrder<E>(matchers);
+    }
+}

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -1,0 +1,95 @@
+package org.hamcrest.collection;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * @deprecated As of release 2.1, replaced by {@link ArrayMatching}.
+ */
+public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
+    private final Collection<Matcher<? super E>> matchers;
+    private final IsIterableContainingInOrder<E> iterableMatcher;
+
+    public IsArrayContainingInOrder(List<Matcher<? super E>> matchers) {
+        this.iterableMatcher = new IsIterableContainingInOrder<E>(matchers);
+        this.matchers = matchers;
+    }
+
+    @Override
+    public boolean matchesSafely(E[] item) {
+        return iterableMatcher.matches(asList(item));
+    }
+    
+    @Override
+    public void describeMismatchSafely(E[] item, Description mismatchDescription) {
+      iterableMatcher.describeMismatch(asList(item), mismatchDescription);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendList("[", ", ", "]", matchers);
+    }
+
+    /**
+     * Creates a matcher for arrays that matcheswhen each item in the examined array is
+     * logically equal to the corresponding item in the specified items.  For a positive match,
+     * the examined array must be of the same length as the number of specified items.
+     * <p/>
+     * For example:
+     * <pre>assertThat(new String[]{"foo", "bar"}, contains("foo", "bar"))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContaining(Object[])}.
+     *
+     * @param items
+     *     the items that must equal the items within an examined array
+     */
+    public static <E> Matcher<E[]> arrayContaining(E... items) {
+        List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
+        for (E item : items) {
+            matchers.add(equalTo(item));
+        }
+        return arrayContaining(matchers);
+    }
+
+    /**
+     * Creates a matcher for arrays that matches when each item in the examined array satisfies the
+     * corresponding matcher in the specified matchers.  For a positive match, the examined array
+     * must be of the same length as the number of specified matchers.
+     * <p/>
+     * For example:
+     * <pre>assertThat(new String[]{"foo", "bar"}, contains(equalTo("foo"), equalTo("bar")))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContaining(Matcher[])}.
+     *
+     * @param itemMatchers
+     *     the matchers that must be satisfied by the items in the examined array
+     */
+    public static <E> Matcher<E[]> arrayContaining(Matcher<? super E>... itemMatchers) {
+        return arrayContaining(asList(itemMatchers));
+    }
+
+    /**
+     * Creates a matcher for arrays that matches when each item in the examined array satisfies the
+     * corresponding matcher in the specified list of matchers.  For a positive match, the examined array
+     * must be of the same length as the specified list of matchers.
+     * <p/>
+     * For example:
+     * <pre>assertThat(new String[]{"foo", "bar"}, contains(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContaining(List)}.
+     *
+     * @param itemMatchers
+     *     a list of matchers, each of which must be satisfied by the corresponding item in an examined array
+     */
+    public static <E> Matcher<E[]> arrayContaining(List<Matcher<? super E>> itemMatchers) {
+        return new IsArrayContainingInOrder<E>(itemMatchers);
+    }
+}

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -1,0 +1,100 @@
+package org.hamcrest.core;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * @deprecated As of release 2.1, replaced by {@link IsIterableContaining}.
+ */
+@Deprecated
+public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? super T>> {
+    private final IsIterableContaining<T> delegate;
+
+    public IsCollectionContaining(Matcher<? super T> elementMatcher) {
+        this.delegate = new IsIterableContaining<>(elementMatcher);
+    }
+
+    @Override
+    protected boolean matchesSafely(Iterable<? super T> collection, Description mismatchDescription) {
+        return delegate.matchesSafely(collection, mismatchDescription);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        delegate.describeTo(description);
+    }
+
+    
+    /**
+     * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
+     * examined {@link Iterable} yields at least one item that is matched by the specified
+     * <code>itemMatcher</code>.  Whilst matching, the traversal of the examined {@link Iterable}
+     * will stop as soon as a matching item is found.
+     * For example:
+     * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem(startsWith("ba")))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItem(Matcher)}.
+     * 
+     * @param itemMatcher
+     *     the matcher to apply to items provided by the examined {@link Iterable}
+     */
+    public static <T> Matcher<Iterable<? super T>> hasItem(Matcher<? super T> itemMatcher) {
+        return IsIterableContaining.hasItem(itemMatcher);
+    }
+
+    /**
+     * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
+     * examined {@link Iterable} yields at least one item that is equal to the specified
+     * <code>item</code>.  Whilst matching, the traversal of the examined {@link Iterable}
+     * will stop as soon as a matching item is found.
+     * For example:
+     * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem("bar"))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItem(Object)}.
+     *
+     * @param item
+     *     the item to compare against the items provided by the examined {@link Iterable}
+     */
+    public static <T> Matcher<Iterable<? super T>> hasItem(T item) {
+        // Doesn't forward to hasItem() method so compiler can sort out generics.
+        return IsIterableContaining.hasItem(item);
+    }
+
+    /**
+     * Creates a matcher for {@link Iterable}s that matches when consecutive passes over the
+     * examined {@link Iterable} yield at least one item that is matched by the corresponding
+     * matcher from the specified <code>itemMatchers</code>.  Whilst matching, each traversal of
+     * the examined {@link Iterable} will stop as soon as a matching item is found.
+     * For example:
+     * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems(endsWith("z"), endsWith("o")))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItems(Matcher[])}}.
+     *
+     * @param itemMatchers
+     *     the matchers to apply to items provided by the examined {@link Iterable}
+     */
+    @SafeVarargs
+    public static <T> Matcher<Iterable<T>> hasItems(Matcher<? super T>... itemMatchers) {
+        return IsIterableContaining.hasItems(itemMatchers);
+    }
+    
+    /**
+     * Creates a matcher for {@link Iterable}s that matches when consecutive passes over the
+     * examined {@link Iterable} yield at least one item that is equal to the corresponding
+     * item from the specified <code>items</code>.  Whilst matching, each traversal of the
+     * examined {@link Iterable} will stop as soon as a matching item is found.
+     * For example:
+     * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems("baz", "foo"))</pre>
+     *
+     * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItems(Object[])}}.
+     *
+     * @param items
+     *     the items to compare against the items provided by the examined {@link Iterable}
+     */
+    @SafeVarargs
+    public static <T> Matcher<Iterable<T>> hasItems(T... items) {
+        return IsIterableContaining.hasItems(items);
+    }
+
+}

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
@@ -1,0 +1,43 @@
+package org.hamcrest.collection;
+
+import org.hamcrest.AbstractMatcherTest;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class ArrayMatchingInAnyOrderTest extends AbstractMatcherTest {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Matcher<?> createMatcher() {
+        return ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testHasAReadableDescription() {
+        assertDescription("[<1>, <2>] in any order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2)));
+        assertDescription("[<1>, <2>] in any order", ArrayMatching.arrayContainingInAnyOrder(1, 2));
+    }
+    
+    public void testMatchesItemsInAnyOrder() {
+      assertMatches("in order", ArrayMatching.arrayContainingInAnyOrder(1, 2, 3), new Integer[] {1, 2, 3});
+      assertMatches("out of order", ArrayMatching.arrayContainingInAnyOrder(1, 2, 3), new Integer[] {3, 2, 1});
+      assertMatches("single", ArrayMatching.arrayContainingInAnyOrder(1), new Integer[] {1});
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAppliesMatchersInAnyOrder() {
+      assertMatches("in order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
+      assertMatches("out of order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {3, 2, 1});
+      assertMatches("single", ArrayMatching.arrayContainingInAnyOrder(equalTo(1)), new Integer[] {1});
+    }
+
+    public void testMismatchesItemsInAnyOrder() {
+      Matcher<Integer[]> matcher = ArrayMatching.arrayContainingInAnyOrder(1, 2, 3);
+      assertMismatchDescription("was null", matcher, null);
+      assertMismatchDescription("no item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
+      assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
+      assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
+    }
+}

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
@@ -1,12 +1,12 @@
 package org.hamcrest.collection;
 
-import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
-import static org.hamcrest.core.IsEqual.equalTo;
-
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
-public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
+import static org.hamcrest.collection.ArrayMatching.arrayContaining;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class ArrayMatchingInOrderTest extends AbstractMatcherTest {
 
     @SuppressWarnings("unchecked")
     @Override
@@ -33,9 +33,13 @@ public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
     public void testMismatchesItemsInOrder() {
       Matcher<Integer[]> matcher = arrayContaining(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);
-      assertMismatchDescription("No item matched: <1>", matcher, new Integer[] {});
-      assertMismatchDescription("No item matched: <2>", matcher, new Integer[] {1});
+      assertMismatchDescription("no item was <1>", matcher, new Integer[] {});
+      assertMismatchDescription("no item was <2>", matcher, new Integer[] {1});
       assertMismatchDescription("item 0: was <4>", matcher, new Integer[] {4,3,2,1});
       assertMismatchDescription("item 2: was <4>", matcher, new Integer[] {1,2, 4});
+    }
+
+    public void testCanHandleNullValuesInAnArray() {
+      assertMatches("with nulls", arrayContaining(null, null), new Object[]{null, null});
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -1,43 +1,43 @@
 package org.hamcrest.collection;
 
+import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
-
-import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
-import static org.hamcrest.core.IsEqual.equalTo;
 
 public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
 
     @SuppressWarnings("unchecked")
     @Override
     protected Matcher<?> createMatcher() {
-        return ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2));
+        return arrayContainingInAnyOrder(equalTo(1), equalTo(2));
     }
 
     @SuppressWarnings("unchecked")
     public void testHasAReadableDescription() {
-        assertDescription("[<1>, <2>] in any order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2)));
-        assertDescription("[<1>, <2>] in any order", ArrayMatching.arrayContainingInAnyOrder(1, 2));
+        assertDescription("[<1>, <2>] in any order", arrayContainingInAnyOrder(equalTo(1), equalTo(2)));
+        assertDescription("[<1>, <2>] in any order", arrayContainingInAnyOrder(1, 2));
     }
     
     public void testMatchesItemsInAnyOrder() {
-      assertMatches("in order", ArrayMatching.arrayContainingInAnyOrder(1, 2, 3), new Integer[] {1, 2, 3});
-      assertMatches("out of order", ArrayMatching.arrayContainingInAnyOrder(1, 2, 3), new Integer[] {3, 2, 1});
-      assertMatches("single", ArrayMatching.arrayContainingInAnyOrder(1), new Integer[] {1});
+      assertMatches("in order", arrayContainingInAnyOrder(1, 2, 3), new Integer[] {1, 2, 3});
+      assertMatches("out of order", arrayContainingInAnyOrder(1, 2, 3), new Integer[] {3, 2, 1});
+      assertMatches("single", arrayContainingInAnyOrder(1), new Integer[] {1});
     }
 
     @SuppressWarnings("unchecked")
     public void testAppliesMatchersInAnyOrder() {
-      assertMatches("in order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
-      assertMatches("out of order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {3, 2, 1});
-      assertMatches("single", ArrayMatching.arrayContainingInAnyOrder(equalTo(1)), new Integer[] {1});
+      assertMatches("in order", arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
+      assertMatches("out of order", arrayContainingInAnyOrder(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {3, 2, 1});
+      assertMatches("single", arrayContainingInAnyOrder(equalTo(1)), new Integer[] {1});
     }
 
     public void testMismatchesItemsInAnyOrder() {
-      Matcher<Integer[]> matcher = ArrayMatching.arrayContainingInAnyOrder(1, 2, 3);
+      Matcher<Integer[]> matcher = arrayContainingInAnyOrder(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);
-      assertMismatchDescription("no item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
-      assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
-      assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
+      assertMismatchDescription("No item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
+      assertMismatchDescription("No item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
+      assertMismatchDescription("Not matched: <4>", matcher, new Integer[] {4,3,2,1});
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -36,8 +36,8 @@ public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
     public void testMismatchesItemsInAnyOrder() {
       Matcher<Integer[]> matcher = arrayContainingInAnyOrder(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);
-      assertMismatchDescription("No item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
-      assertMismatchDescription("No item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
-      assertMismatchDescription("Not matched: <4>", matcher, new Integer[] {4,3,2,1});
+      assertMismatchDescription("no item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
+      assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
+      assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
@@ -33,8 +33,8 @@ public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
     public void testMismatchesItemsInOrder() {
       Matcher<Integer[]> matcher = arrayContaining(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);
-      assertMismatchDescription("No item matched: <1>", matcher, new Integer[] {});
-      assertMismatchDescription("No item matched: <2>", matcher, new Integer[] {1});
+      assertMismatchDescription("no item was <1>", matcher, new Integer[] {});
+      assertMismatchDescription("no item was <2>", matcher, new Integer[] {1});
       assertMismatchDescription("item 0: was <4>", matcher, new Integer[] {4,3,2,1});
       assertMismatchDescription("item 2: was <4>", matcher, new Integer[] {1,2, 4});
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -1,0 +1,103 @@
+package org.hamcrest.core;
+
+import org.hamcrest.AbstractMatcherTest;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class IsCollectionContainingTest extends AbstractMatcherTest {
+    @Override
+    protected Matcher<?> createMatcher() {
+        return hasItem(equalTo("irrelevant"));
+    }
+
+    public void testMatchesACollectionThatContainsAnElementMatchingTheGivenMatcher() {
+        Matcher<Iterable<? super String>> itemMatcher = hasItem(equalTo("a"));
+        
+        assertMatches("should match list that contains 'a'",
+                itemMatcher, asList("a", "b", "c"));
+    }
+
+    public void testDoesNotMatchCollectionThatDoesntContainAnElementMatchingTheGivenMatcher() {
+        final Matcher<Iterable<? super String>> matcher1 = hasItem(mismatchable("a"));
+        assertMismatchDescription("mismatches were: [mismatched: b, mismatched: c]", matcher1, asList("b", "c"));
+        
+        
+        final Matcher<Iterable<? super String>> matcher2 = hasItem(equalTo("a"));
+        assertMismatchDescription("was empty", matcher2, new ArrayList<String>());
+    }
+
+    public void testDoesNotMatchNull() {
+        assertDoesNotMatch("should not matches null", hasItem(equalTo("a")), null);
+    }
+
+    public void testHasAReadableDescription() {
+        assertDescription("a collection containing \"a\"", hasItem(equalTo("a")));
+    }
+    
+    public void testCanMatchItemWhenCollectionHoldsSuperclass() // Issue 24
+    {
+      final Set<Number> s = new HashSet<Number>();
+      s.add(Integer.valueOf(2));
+      assertThat(s, new IsCollectionContaining<Number>(new IsEqual<Number>(Integer.valueOf(2))));
+      assertThat(s, IsCollectionContaining.hasItem(Integer.valueOf(2)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testMatchesAllItemsInCollection() {
+        final Matcher<Iterable<String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        assertMatches("should match list containing all items",
+                matcher1,
+                asList("a", "b", "c"));
+        
+        final Matcher<Iterable<String>> matcher2 = hasItems("a", "b", "c");
+        assertMatches("should match list containing all items (without matchers)",
+                matcher2,
+                asList("a", "b", "c"));
+        
+        final Matcher<Iterable<String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        assertMatches("should match list containing all items in any order",
+                matcher3,
+                asList("c", "b", "a"));
+        
+        final Matcher<Iterable<String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        assertMatches("should match list containing all items plus others",
+                matcher4,
+                asList("e", "c", "b", "a", "d"));
+        
+        final Matcher<Iterable<String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        assertDoesNotMatch("should not match list unless it contains all items",
+                matcher5,
+                asList("e", "c", "b", "d")); // 'a' missing
+    }
+    
+    
+    private static Matcher<? super String> mismatchable(final String string) {
+      return new TypeSafeDiagnosingMatcher<String>() {
+        @Override
+        protected boolean matchesSafely(String item, Description mismatchDescription) {
+          if (string.equals(item)) 
+            return true;
+          
+          mismatchDescription.appendText("mismatched: " + item);
+          return false;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+          description.appendText("mismatchable: " + string);
+        }
+      };
+    }
+}
+


### PR DESCRIPTION
To preserve backwards compatibility with Hamcrest version 1.3, the following classes have been undeleted, but marked as deprecated:
* `IsCollectionContaining`
* `IsArrayContainingInAnyOrder`
* `IsArrayContainingInOrder`