### PR TITLE
Allow "normal" objects to describe themself, e.g. in case of a mismatch

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
@@ -3,6 +3,8 @@ package org.hamcrest;
 import org.hamcrest.internal.ArrayIterator;
 import org.hamcrest.internal.SelfDescribingValueIterator;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -29,6 +31,19 @@ public abstract class BaseDescription implements Description {
     public Description appendValue(Object value) {
         if (value == null) {
             append("null");
+        } else if (value instanceof SelfDescribing){
+            append('<');
+            try {
+                appendDescriptionOf( (SelfDescribing) value);
+            } catch (Exception ex){
+                // generating an error message should not throw another exception.
+                // process exception into mismatch description to preserve "nice" error messages
+                StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter);
+                ex.printStackTrace(printWriter);
+                append("Exception while resolving self description: " + stringWriter.toString());
+            }
+            append('>');
         } else if (value instanceof String) {
             toJavaSyntax((String) value);
         } else if (value instanceof Character) {


### PR DESCRIPTION
*Motivation*
I needed to give detailed descriptions of an object in case of a mismatch and couldn't use toString(). 

*Solution*
* Use the existing `SelfDescribing` Interface and retrieve a description based on its `describeTo` method.