### PR TITLE
AllOf/AnyOf: Pass the matchers to constructor using varargs

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
@@ -14,6 +14,11 @@ public class AllOf<T> extends DiagnosingMatcher<T> {
 
     private final Iterable<Matcher<? super T>> matchers;
 
+    @SafeVarargs
+    public AllOf(Matcher<? super T> ... matchers) {
+        this(Arrays.asList(matchers));
+    }
+
     public AllOf(Iterable<Matcher<? super T>> matchers) {
         this.matchers = matchers;
     }

--- a/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
@@ -11,6 +11,11 @@ import java.util.Arrays;
  */
 public class AnyOf<T> extends ShortcutCombination<T> {
 
+    @SafeVarargs
+    public AnyOf(Matcher<? super T> ... matchers) {
+        this(Arrays.asList(matchers));
+    }
+
     public AnyOf(Iterable<Matcher<? super T>> matchers) {
         super(matchers);
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
@@ -4,10 +4,12 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import static org.hamcrest.AbstractMatcherTest.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
@@ -59,5 +61,10 @@ public final class AllOfTest {
     @Test public void
     hasAMismatchDescriptionDescribingTheFirstFailingMatch() {
         assertMismatchDescription("\"good\" was \"bad\"", allOf(equalTo("bad"), equalTo("good")), "bad");
+    }
+
+    @Test public void
+    varargs(){
+        assertThat("the text!", new AllOf<>(startsWith("the"), containsString("text"), endsWith("!")));
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
@@ -4,6 +4,7 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import static org.hamcrest.AbstractMatcherTest.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringEndsWith.endsWith;
@@ -52,5 +53,10 @@ public final class AnyOfTest {
     hasAReadableDescription() {
         assertDescription("(\"good\" or \"bad\" or \"ugly\")",
                 anyOf(equalTo("good"), equalTo("bad"), equalTo("ugly")));
+    }
+
+    @Test public void
+    varargs(){
+        assertThat("the text!", new AnyOf<>(startsWith("the"), endsWith(".")));
     }
 }


### PR DESCRIPTION
Add a way to construct the `AllOf`, `AnyOf` matchers using the `varargs`.
Some projects prohibit the using of static imports/methods, therefore we have to wrap the matchers to the `Iterable`, it's not convenient and looks a bit ugly.

@tumbarumba , could you please review/give feedback on this pull request? 