### PR TITLE
Fix typo in license name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def pomConfigurationFor(String pomName, String pomDescription) {
 
         licenses {
             license {
-                name = 'BSD Licence 3'
+                name = 'BSD License 3'
                 url = 'http://opensource.org/licenses/BSD-3-Clause'
             }
         }


### PR DESCRIPTION
Change license name from "BSD Licence 3" to "BSD License 3". This typo
fails automated license checks in a project that has
hamcrest dependency.