### PR TITLE
Make IsIterableContainingInAnyOrder try all matcher permutations

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/internal/InPlacePermutator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/InPlacePermutator.java
@@ -1,0 +1,60 @@
+package org.hamcrest.internal;
+
+/**
+ * Uses the Heap's algorithm (https://en.wikipedia.org/wiki/Heap%27s_algorithm) to produce all permutations of elements
+ * of the given array.
+ *
+ * The elements are swapped in-place in the provided array. Each permutation is yielded by calling handlePermutation(),
+ * which can return false to signal that the listing should stop.
+ */
+public abstract class InPlacePermutator<T> {
+
+    private final T[] items;
+    private final int size;
+
+    protected InPlacePermutator(T[] items) {
+        this.size = items.length;
+        this.items = items;
+    }
+
+    /**
+     * @return true if iteration was interrupted before reaching the end
+     */
+    public boolean iteratePermutations() {
+        if (size < 1) {
+            return false;
+        }
+        return iterateInternal(size);
+    }
+
+    /**
+     * @return true if iteration should be interrupted
+     */
+    protected abstract boolean handlePermutation();
+
+    private boolean iterateInternal(int n) {
+        if (n == 1) {
+            return handlePermutation();
+        } else {
+            for (int i = 0; i < n - 1; i++) {
+                boolean shouldStop = iterateInternal(n - 1);
+                if (shouldStop) {
+                    return true;
+                }
+                if (n % 2 == 0) {
+                    swap(i, n - 1);
+                } else {
+                    swap(0, n - 1);
+                }
+            }
+            return iterateInternal(n - 1);
+        }
+    }
+
+    private void swap(int i, int j) {
+        T temp = items[i];
+        items[i] = items[j];
+        items[j] = temp;
+    }
+
+}

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
@@ -35,8 +35,8 @@ public class ArrayMatchingInAnyOrderTest extends AbstractMatcherTest {
     public void testMismatchesItemsInAnyOrder() {
       Matcher<Integer[]> matcher = ArrayMatching.arrayContainingInAnyOrder(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);
-      assertMismatchDescription("no item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
-      assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
-      assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
+      assertMismatchDescription("not enough items: []", matcher, new Integer[] {});
+      assertMismatchDescription("not enough items: [<1>]", matcher, new Integer[] {1});
+      assertMismatchDescription("too many items: [<4>, <3>, <2>, <1>]", matcher, new Integer[] {4,3,2,1});
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -36,8 +36,8 @@ public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
     public void testMismatchesItemsInAnyOrder() {
       Matcher<Integer[]> matcher = arrayContainingInAnyOrder(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);
-      assertMismatchDescription("no item matches: <1>, <2>, <3> in []", matcher, new Integer[] {});
-      assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
-      assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
+      assertMismatchDescription("not enough items: []", matcher, new Integer[] {});
+      assertMismatchDescription("not enough items: [<1>]", matcher, new Integer[] {1});
+      assertMismatchDescription("too many items: [<4>, <3>, <2>, <1>]", matcher, new Integer[] {4,3,2,1});
     }
 }

--- a/hamcrest/src/test/java/org/hamcrest/internal/InPlacePermutatorTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/internal/InPlacePermutatorTest.java
@@ -1,0 +1,65 @@
+package org.hamcrest.internal;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InPlacePermutatorTest extends TestCase {
+
+    @SafeVarargs
+    private static <T> List<T[]> getPermutations(T... items) {
+        return getFirstPermutations(Integer.MAX_VALUE, items);
+    }
+
+    @SafeVarargs
+    private static <T> List<T[]> getFirstPermutations(int n, T... items) {
+        final T[] currentPermutation = items.clone();
+        final List<T[]> permutations = new ArrayList<>();
+        final AtomicInteger remaining = new AtomicInteger(n);
+        new InPlacePermutator<T>(currentPermutation) {
+            @Override
+            protected boolean handlePermutation() {
+                permutations.add(currentPermutation.clone());
+                return (remaining.decrementAndGet() == 0);
+            }
+        }.iteratePermutations();
+        return permutations;
+    }
+
+    public void testThereIsNoPermutationOfEmpty() {
+        List<Object[]> permutations = (List<Object[]>) getPermutations();
+        Assert.assertTrue(permutations.isEmpty());
+    }
+
+    public void testThereIsOnePermutationOfASingleton() {
+        List<String[]> permutations = getPermutations("Hello");
+        String[] expected = new String[]{"Hello"};
+        Assert.assertEquals(1, permutations.size());
+        Assert.assertArrayEquals(expected, permutations.get(0));
+    }
+
+    public void testMorePermutations() {
+        List<String[]> permutations = getPermutations("a", "b", "c");
+        Assert.assertEquals(6, permutations.size());
+        Assert.assertArrayEquals(new String[]{"a", "b", "c"}, permutations.get(0));
+        Assert.assertArrayEquals(new String[]{"b", "a", "c"}, permutations.get(1));
+        Assert.assertArrayEquals(new String[]{"c", "a", "b"}, permutations.get(2));
+        Assert.assertArrayEquals(new String[]{"a", "c", "b"}, permutations.get(3));
+        Assert.assertArrayEquals(new String[]{"b", "c", "a"}, permutations.get(4));
+        Assert.assertArrayEquals(new String[]{"c", "b", "a"}, permutations.get(5));
+    }
+
+    public void testStopIteration() {
+        List<String[]> permutations = getFirstPermutations(4, "a", "b", "c");
+        Assert.assertEquals(4, permutations.size());
+        Assert.assertArrayEquals(new String[]{"a", "b", "c"}, permutations.get(0));
+        Assert.assertArrayEquals(new String[]{"b", "a", "c"}, permutations.get(1));
+        Assert.assertArrayEquals(new String[]{"c", "a", "b"}, permutations.get(2));
+        Assert.assertArrayEquals(new String[]{"a", "c", "b"}, permutations.get(3));
+    }
+
+
+}


### PR DESCRIPTION
This is a fix for issue #248
I'm not sure about the names I used, but could not find better ones. Don't hesitate to propose some.

This introduces some loss of information in mismatch reports in some cases (which precise matchers or items remained unpaired), but on the other hand, the full list of items is printed all the time (which, from my experience, is more useful to the user, in non-ordered cases).

This information could be reintroduced if needed, at the cost of some added complexity and performance.