### PR TITLE
Revert "Upgrade Gradle 4.10.2 -> 5.2"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+enableFeaturePreview('STABLE_PUBLISHING')
+
 include 'hamcrest',
         'hamcrest-core',
         'hamcrest-library',


### PR DESCRIPTION
Gradle 5.2 is not compatible with Java 1.7
This reverts commit 3626acd09e5db54de318680c1fa19bf5d9f211bd.