### PR TITLE
Documentation: Escape pipe characters in tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,7 +57,7 @@ Hamcrest comes with a library of useful matchers. Here are some of the most impo
 #### Logical
 `allOf` - matches if all matchers match, short circuits (like Java &&)
 
-`anyOf` - matches if any matchers match, short circuits (like Java ||)
+`anyOf` - matches if any matchers match, short circuits (like Java \|\|)
 
 `not` - matches if the wrapped matcher doesn't match and vice versa
 


### PR DESCRIPTION
The Java "or" operator (`||`) disappears in the tutorial because the pipe characters must be escaped because of Kramdown bug.