### PR TITLE
Use platform-specific line separators

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -10,9 +10,11 @@ public class MatcherAssert {
         if (!matcher.matches(actual)) {
             Description description = new StringDescription();
             description.appendText(reason)
-                       .appendText("\nExpected: ")
+                       .appendText(System.lineSeparator())
+                       .appendText("Expected: ")
                        .appendDescriptionOf(matcher)
-                       .appendText("\n     but: ");
+                       .appendText(System.lineSeparator())
+                       .appendText("     but: ");
             matcher.describeMismatch(actual, description);
             
             throw new AssertionError(description.toString());

--- a/hamcrest/src/test/java/org/hamcrest/MatcherAssertTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/MatcherAssertTest.java
@@ -12,8 +12,9 @@ public final class MatcherAssertTest {
     includesDescriptionOfTestedValueInErrorMessage() {
         String expected = "expected";
         String actual = "actual";
+        String endLine = System.lineSeparator();
 
-        String expectedMessage = "identifier\nExpected: \"expected\"\n     but: was \"actual\"";
+        String expectedMessage = "identifier" + endLine + "Expected: \"expected\"" + endLine + "     but: was \"actual\"";
 
         try {
             assertThat("identifier", actual, equalTo(expected));
@@ -30,8 +31,9 @@ public final class MatcherAssertTest {
     descriptionCanBeElided() {
         String expected = "expected";
         String actual = "actual";
+        String endLine = System.lineSeparator();
 
-        String expectedMessage = "\nExpected: \"expected\"\n     but: was \"actual\"";
+        String expectedMessage = endLine + "Expected: \"expected\"" + endLine + "     but: was \"actual\"";
 
         try {
             assertThat(actual, equalTo(expected));
@@ -78,7 +80,8 @@ public final class MatcherAssertTest {
             }
         };
 
-        String expectedMessage = "\nExpected: Something cool\n     but: Not cool";
+        String endLine = System.lineSeparator();
+        String expectedMessage = endLine + "Expected: Something cool" + endLine + "     but: Not cool";
 
         try {
             assertThat("Value", matcherWithCustomMismatchDescription);


### PR DESCRIPTION
I noticed that when I log an assertion error created by Hamcrest that it uses a single line feed character (Unix style end-of-line). Since the rest of my log uses carriage return / line feed pairs (Windows style end-of-line) this will confuse some editors like Vim or Eclipse which generally expect a file to use the same style throughout.

Rather than hardcoding one or the other, the `System.lineSeparator()` function will return the end of line separator appropriate for the current runtime, i.e. "\r\n" on Windows and "\n" on Unix. This way it will adapt to the Java runtime's platform. And should for some reason a user prefer the other style, they should be able to set the `line.separator` property at startup.