### PR TITLE
Update the maven dependency to 2.2 as well.

### DIFF
--- a/docs/distributables.md
+++ b/docs/distributables.md
@@ -56,7 +56,7 @@ Add the following to the `<dependencies>` section in your `pom.xml`:
 <dependency>
     <groupId>org.hamcrest</groupId>
     <artifactId>hamcrest</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
The catches a version in the docs that got missed in faf09f4f25b4282e75ca423e7f593d9cbaa1ca96