### PR TITLE
Update Travis CI syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: java
 
+os: linux
+
 # Need to select an older Ubuntu distribution that supports JDK7
 dist: trusty
+
+jdk:
+  - openjdk7
+  - oraclejdk8
+  - openjdk8
+  - oraclejdk9
 
 # Workaround to using openjdk7 with Gradle due to security issue:
 # https://github.com/gradle/gradle/issues/2421
@@ -11,12 +19,6 @@ before_install:
 - sudo mv $BCPROV_FILENAME /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext
 - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
 - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
-
-jdk:
-  - openjdk7
-  - oraclejdk8
-  - openjdk8
-  - oraclejdk9
 
 script:
   - ./gradlew clean build javadoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jdk:
   - oraclejdk8
   - openjdk8
   - oraclejdk9
+  - openjdk11
+  - openjdk14
 
 # Workaround to using openjdk7 with Gradle due to security issue:
 # https://github.com/gradle/gradle/issues/2421


### PR DESCRIPTION
### This pull request brings the following changes:

- Adds explicit `os` definition: Github now can build using macos and windows so it is a good practice include the `os` definition on `yml`.

- Re-order commands to follow Travis order of execution.

- Adds new java versions `openjdk11` and `openjdk14`