### PR TITLE
Show filename when file matchers fail

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
@@ -94,7 +94,7 @@ public final class FileMatchers {
             public boolean matchesSafely(File actual, Description mismatchDescription) {
                 final boolean result = fileStatus.check(actual);
                 if (!result) {
-                    mismatchDescription.appendText(failureDescription);
+                    mismatchDescription.appendText(String.format("'%s' %s", actual, failureDescription));
                 }
                 return result;
             }

--- a/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
@@ -27,19 +27,19 @@ public class FileMatchersTest extends AbstractMatcherTest {
     public void testAnExistingDirectory() {
         assertMatches("matches existing directory", FileMatchers.anExistingDirectory(), directory);
         assertDoesNotMatch("doesn't match existing file", FileMatchers.anExistingDirectory(), file);
-        assertDoesNotMatch("doesn't match missing file", FileMatchers.anExistingDirectory(), new File("foo"));
+        assertMismatchDescription("'foo' is not a directory", FileMatchers.anExistingDirectory(), new File("foo"));
     }
 
     public void testAnExistingFileOrDirectory() {
         assertMatches("matches existing file", FileMatchers.anExistingFileOrDirectory(), file);
         assertMatches("matches existing directory", FileMatchers.anExistingFileOrDirectory(), directory);
-        assertDoesNotMatch("doesn't match missing file", FileMatchers.anExistingFileOrDirectory(), new File("foo"));
+        assertMismatchDescription("'foo' does not exist", FileMatchers.anExistingFileOrDirectory(), new File("foo"));
     }
 
     public void testAnExistingFile() {
         assertMatches("matches existing file", FileMatchers.anExistingFile(), file);
         assertDoesNotMatch("doesn't match existing directory", FileMatchers.anExistingFile(), directory);
-        assertDoesNotMatch("doesn't match missing file", FileMatchers.anExistingFile(), new File("foo"));
+        assertMismatchDescription("'foo' is not a file", FileMatchers.anExistingFile(), new File("foo"));
     }
 
     public void testAReadableFile() { // Not all OSes will allow setting readability so have to be forgiving here.


### PR DESCRIPTION
e.g.

```text
Expected: an existing File
     but: 'filename.txt' is not a file

```