### PR TITLE
fix: contains/containsInAnyOrder overloading issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,10 @@ name: Java CI
 
 on: [push]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Default Java/OS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,15 +4,30 @@ name: Java CI
 on: [push]
 
 jobs:
+  build:
+    name: Build Default Java/OS
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 7
+      - name: Gradle Clean Build
+        run: ./gradlew clean build
+
   test:
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
         java: [7, 8, 11, 17, 18-ea, 19-ea]
+        exclude:
+          - os: ubuntu-18.04
+            java: 7
       fail-fast: false
       max-parallel: 4
-    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +35,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Build with Gradle
-        run: ./gradlew clean build javadoc
+      - name: Gradle Clean Build
+        run: ./gradlew clean build
+  qa:
+    name: QA Steps
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 7
+      - name: Gradle JavaDoc
+        run: ./gradlew javadoc
 
 ...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
 
   test:
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,6 +40,7 @@ jobs:
         run: ./gradlew clean build
   qa:
     name: QA Steps
+    needs: test
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/hamcrest-integration/src/main/java/org/hamcrest/JMock1Matchers.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/JMock1Matchers.java
@@ -9,4 +9,5 @@ public class JMock1Matchers {
     public static Constraint equalTo(String string) {
         return JMock1Adapter.adapt(IsEqual.equalTo(string));
     }
+
 }

--- a/hamcrest-integration/src/main/java/org/hamcrest/JavaLangMatcherAssert.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/JavaLangMatcherAssert.java
@@ -15,4 +15,5 @@ public class JavaLangMatcherAssert {
     public static <T> boolean that(T argument, Matcher<? super T> matcher) {
         return matcher.matches(argument);
     }
+
 }

--- a/hamcrest-integration/src/main/java/org/hamcrest/JavaLangMatcherAssert.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/JavaLangMatcherAssert.java
@@ -10,6 +10,7 @@ package org.hamcrest;
  * @author Neil Dunn
  */
 public class JavaLangMatcherAssert {
+
     private JavaLangMatcherAssert() {};
 
     public static <T> boolean that(T argument, Matcher<? super T> matcher) {

--- a/hamcrest-integration/src/main/java/org/hamcrest/integration/EasyMock2Adapter.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/integration/EasyMock2Adapter.java
@@ -44,4 +44,5 @@ public class EasyMock2Adapter implements IArgumentMatcher {
     public void appendTo(StringBuffer buffer) {
         hamcrestMatcher.describeTo(new StringDescription(buffer));
     }
+
 }

--- a/hamcrest-integration/src/main/java/org/hamcrest/integration/EasyMock2Adapter.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/integration/EasyMock2Adapter.java
@@ -19,6 +19,8 @@ public class EasyMock2Adapter implements IArgumentMatcher {
      * EasyMock {@link org.easymock.IArgumentMatcher} and
      * report it to EasyMock so it can be kept track of.
      *
+     * @param matcher
+     *     the matcher to adapt to EasyMock constraint.
      * @return The EasyMock matcher.
      */
     public static IArgumentMatcher adapt(Matcher<?> matcher) {

--- a/hamcrest-integration/src/main/java/org/hamcrest/integration/JMock1Adapter.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/integration/JMock1Adapter.java
@@ -19,6 +19,8 @@ public class JMock1Adapter implements Constraint {
      * Hamcrest {@link org.hamcrest.Matcher} to act as an
      * jMock {@link org.jmock.core.Constraint}.
      *
+     * @param matcher
+     *     the matcher to adapt to jMock constraint.
      * @return The jMock constraint.
      */
     public static Constraint adapt(Matcher<?> matcher) {

--- a/hamcrest-integration/src/main/java/org/hamcrest/integration/JMock1Adapter.java
+++ b/hamcrest-integration/src/main/java/org/hamcrest/integration/JMock1Adapter.java
@@ -43,4 +43,5 @@ public class JMock1Adapter implements Constraint {
         hamcrestMatcher.describeTo(new StringDescription(buffer));
         return buffer;
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
@@ -155,4 +155,5 @@ public abstract class BaseDescription implements Description {
                 append(ch);
         }
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
@@ -18,13 +18,13 @@ public abstract class BaseDescription implements Description {
         append(text);
         return this;
     }
-    
+
     @Override
     public Description appendDescriptionOf(SelfDescribing value) {
         value.describeTo(this);
         return this;
     }
-    
+
     @Override
     public Description appendValue(Object value) {
         if (value == null) {
@@ -75,16 +75,16 @@ public abstract class BaseDescription implements Description {
     public final <T> Description appendValueList(String start, String separator, String end, T... values) {
         return appendValueList(start, separator, end, Arrays.asList(values));
     }
-    
+
     @Override
     public <T> Description appendValueList(String start, String separator, String end, Iterable<T> values) {
         return appendValueList(start, separator, end, values.iterator());
     }
-    
+
     private <T> Description appendValueList(String start, String separator, String end, Iterator<T> values) {
         return appendList(start, separator, end, new SelfDescribingValueIterator<>(values));
     }
-    
+
     @Override
     public Description appendList(String start, String separator, String end, Iterable<? extends SelfDescribing> values) {
         return appendList(start, separator, end, values.iterator());
@@ -92,7 +92,7 @@ public abstract class BaseDescription implements Description {
 
     private Description appendList(String start, String separator, String end, Iterator<? extends SelfDescribing> i) {
         boolean separate = false;
-        
+
         append(start);
         while (i.hasNext()) {
             if (separate) append(separator);
@@ -100,13 +100,13 @@ public abstract class BaseDescription implements Description {
             separate = true;
         }
         append(end);
-        
+
         return this;
     }
 
     /**
-     * Append the String <var>str</var> to the description.  
-     * The default implementation passes every character to {@link #append(char)}.  
+     * Append the String <var>str</var> to the description.
+     * The default implementation passes every character to {@link #append(char)}.
      * Override in subclasses to provide an efficient implementation.
      *
      * @param str
@@ -117,7 +117,7 @@ public abstract class BaseDescription implements Description {
             append(str.charAt(i));
         }
     }
-    
+
     /**
      * Append the char <var>c</var> to the description.
      *

--- a/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseDescription.java
@@ -108,6 +108,9 @@ public abstract class BaseDescription implements Description {
      * Append the String <var>str</var> to the description.  
      * The default implementation passes every character to {@link #append(char)}.  
      * Override in subclasses to provide an efficient implementation.
+     *
+     * @param str
+     *     the string to append.
      */
     protected void append(String str) {
         for (int i = 0; i < str.length(); i++) {
@@ -116,7 +119,10 @@ public abstract class BaseDescription implements Description {
     }
     
     /**
-     * Append the char <var>c</var> to the description.  
+     * Append the char <var>c</var> to the description.
+     *
+     * @param c
+     *     the char to append.
      */
     protected abstract void append(char c);
 

--- a/hamcrest/src/main/java/org/hamcrest/BaseMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/BaseMatcher.java
@@ -39,4 +39,5 @@ public abstract class BaseMatcher<T> implements Matcher<T> {
         }
         return true;
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/Condition.java
+++ b/hamcrest/src/main/java/org/hamcrest/Condition.java
@@ -9,8 +9,8 @@ package org.hamcrest;
  * Based on https://github.com/npryce/maybe-java
  * @author Steve Freeman 2012 http://www.hamcrest.com
  */
-
 public abstract class Condition<T> {
+
     public static final NotMatched<Object> NOT_MATCHED = new NotMatched<Object>();
 
     public interface Step<I, O> {

--- a/hamcrest/src/main/java/org/hamcrest/Condition.java
+++ b/hamcrest/src/main/java/org/hamcrest/Condition.java
@@ -66,4 +66,5 @@ public abstract class Condition<T> {
             return notMatched();
         }
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/Condition.java
+++ b/hamcrest/src/main/java/org/hamcrest/Condition.java
@@ -11,7 +11,7 @@ package org.hamcrest;
  */
 public abstract class Condition<T> {
 
-    public static final NotMatched<Object> NOT_MATCHED = new NotMatched<Object>();
+    public static final NotMatched<Object> NOT_MATCHED = new NotMatched<>();
 
     public interface Step<I, O> {
         Condition<O> apply(I value, Description mismatch);
@@ -31,7 +31,7 @@ public abstract class Condition<T> {
     }
 
     public static <T> Condition<T> matched(final T theValue, final Description mismatch) {
-        return new Matched<T>(theValue, mismatch);
+        return new Matched<>(theValue, mismatch);
     }
 
     private static final class Matched<T> extends Condition<T> {

--- a/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
@@ -199,7 +199,7 @@ public class CoreMatchers {
   /**
    * Creates a matcher that always matches, regardless of the examined object, but describes
    * itself with the specified {@link String}.
-   * 
+   *
    * @param description
    *     a meaningful {@link String} used when describing itself
    * @return The matcher.
@@ -286,17 +286,17 @@ public class CoreMatchers {
    * Creates a matcher that matches when the examined object is logically equal to the specified
    * <code>operand</code>, as determined by calling the {@link java.lang.Object#equals} method on
    * the <b>examined</b> object.
-   * 
+   *
    * <p>If the specified operand is <code>null</code> then the created matcher will only match if
    * the examined object's <code>equals</code> method returns <code>true</code> when passed a
    * <code>null</code> (which would be a violation of the <code>equals</code> contract), unless the
    * examined object itself is <code>null</code>, in which case the matcher will return a positive
    * match.</p>
-   * 
+   *
    * <p>The created matcher provides a special behaviour when examining <code>Array</code>s, whereby
    * it will match if both the operand and the examined object are arrays of the same length and
    * contain items that are equal to each other (according to the above rules) <b>in the same
-   * indexes</b>.</p> 
+   * indexes</b>.</p>
    * For example:
    * <pre>
    * assertThat("foo", equalTo("foo"));
@@ -329,7 +329,7 @@ public class CoreMatchers {
    * Creates a matcher that matches when the examined object is an instance of the specified <code>type</code>,
    * as determined by calling the {@link java.lang.Class#isInstance(Object)} method on that type, passing the
    * the examined object.
-   * 
+   *
    * <p>The created matcher forces a relationship between specified type and the examined object, and should be
    * used when it is necessary to make generics conform, for example in the JMock clause
    * <code>with(any(Thing.class))</code></p>
@@ -350,7 +350,7 @@ public class CoreMatchers {
    * Creates a matcher that matches when the examined object is an instance of the specified <code>type</code>,
    * as determined by calling the {@link java.lang.Class#isInstance(Object)} method on that type, passing the
    * the examined object.
-   * 
+   *
    * <p>The created matcher assumes no relationship between specified type and the examined object.</p>
    * For example:
    * <pre>assertThat(new Canoe(), instanceOf(Paddlable.class));</pre>
@@ -489,7 +489,7 @@ public class CoreMatchers {
    * {@link String} anywhere.
    * For example:
    * <pre>assertThat("myStringOfNote", containsString("ring"))</pre>
-   * 
+   *
    * @param substring
    *     the substring that the returned matcher will expect to find within any examined string
    * @return The matcher.
@@ -503,7 +503,7 @@ public class CoreMatchers {
    * {@link String} anywhere, ignoring case.
    * For example:
    * <pre>assertThat("myStringOfNote", containsString("ring"))</pre>
-   * 
+   *
    * @param substring
    *     the substring that the returned matcher will expect to find within any examined string
    * @return The matcher.
@@ -519,7 +519,7 @@ public class CoreMatchers {
    * </p>
    * For example:
    * <pre>assertThat("myStringOfNote", startsWith("my"))</pre>
-   * 
+   *
    * @param prefix
    *      the substring that the returned matcher will expect at the start of any examined string
    * @return The matcher.
@@ -535,7 +535,7 @@ public class CoreMatchers {
    * </p>
    * For example:
    * <pre>assertThat("myStringOfNote", startsWith("my"))</pre>
-   * 
+   *
    * @param prefix
    *      the substring that the returned matcher will expect at the start of any examined string
    * @return The matcher.
@@ -549,7 +549,7 @@ public class CoreMatchers {
    * {@link String}.
    * For example:
    * <pre>assertThat("myStringOfNote", endsWith("Note"))</pre>
-   * 
+   *
    * @param suffix
    *      the substring that the returned matcher will expect at the end of any examined string
    * @return The matcher.
@@ -563,7 +563,7 @@ public class CoreMatchers {
    * {@link String}, ignoring case.
    * For example:
    * <pre>assertThat("myStringOfNote", endsWith("Note"))</pre>
-   * 
+   *
    * @param suffix
    *      the substring that the returned matcher will expect at the end of any examined string
    * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
@@ -10,6 +10,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     all the matchers must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(java.lang.Iterable<org.hamcrest.Matcher<? super T>> matchers) {
@@ -21,6 +25,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     all the matchers must pass.
    * @return The matcher.
    */
   @SafeVarargs
@@ -34,6 +42,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     any the matchers must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(java.lang.Iterable<org.hamcrest.Matcher<? super T>> matchers) {
@@ -45,6 +57,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     any the matchers must pass.
    * @return The matcher.
    */
   @SafeVarargs
@@ -57,6 +73,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat("fab", both(containsString("a")).and(containsString("b")))</pre>
    *
+   * @param <LHS>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to combine, and both musth pass.
    * @return The matcher.
    */
   public static <LHS> org.hamcrest.core.CombinableMatcher.CombinableBothMatcher<LHS> both(org.hamcrest.Matcher<? super LHS> matcher) {
@@ -68,6 +88,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat("fan", either(containsString("a")).or(containsString("b")))</pre>
    *
+   * @param <LHS>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to combine, and either must pass.
    * @return The matcher.
    */
   public static <LHS> org.hamcrest.core.CombinableMatcher.CombinableEitherMatcher<LHS> either(org.hamcrest.Matcher<? super LHS> matcher) {
@@ -80,13 +104,14 @@ public class CoreMatchers {
    * For example:
    * <pre>describedAs("a big decimal equal to %0", equalTo(myBigDecimal), myBigDecimal.toPlainString())</pre>
    *
+   * @param <T>
+   *     the matcher type.
    * @param description
    *     the new description for the wrapped matcher
    * @param matcher
    *     the matcher to wrap
    * @param values
    *     optional values to insert into the tokenised description
-   *
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> describedAs(java.lang.String description, org.hamcrest.Matcher<T> matcher, java.lang.Object... values) {
@@ -100,9 +125,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat(Arrays.asList("bar", "baz"), everyItem(startsWith("ba")))</pre>
    *
+   * @param <U>
+   *     the matcher type.
    * @param itemMatcher
    *     the matcher to apply to every item provided by the examined {@link Iterable}
-   *
    * @return The matcher.
    */
   public static <U> org.hamcrest.Matcher<java.lang.Iterable<? extends U>> everyItem(org.hamcrest.Matcher<U> itemMatcher) {
@@ -117,6 +143,10 @@ public class CoreMatchers {
    * instead of:
    * <pre>assertThat(cheese, equalTo(smelly))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher {@link org.hamcrest.core.Is#is}.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> is(org.hamcrest.Matcher<T> matcher) {
@@ -130,6 +160,10 @@ public class CoreMatchers {
    * instead of:
    * <pre>assertThat(cheese, is(equalTo(smelly)))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param value
+   *     the value for matcher {@link org.hamcrest.core.Is#is}.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> is(T value) {
@@ -143,6 +177,10 @@ public class CoreMatchers {
    * instead of:
    * <pre>assertThat(cheese, is(instanceOf(Cheddar.class)))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param type
+   *     the type for matcher {@link org.hamcrest.core.Is#isA}.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> isA(java.lang.Class<T> type) {
@@ -164,7 +202,6 @@ public class CoreMatchers {
    * 
    * @param description
    *     a meaningful {@link String} used when describing itself
-   *
    * @return The matcher.
    */
   public static org.hamcrest.Matcher<java.lang.Object> anything(java.lang.String description) {
@@ -178,10 +215,11 @@ public class CoreMatchers {
    * will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem(startsWith("ba")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param itemMatcher
    *     the matcher to apply to items provided by the examined {@link Iterable}
-   *
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<java.lang.Iterable<? super T>> hasItem(org.hamcrest.Matcher<? super T> itemMatcher) {
@@ -195,10 +233,11 @@ public class CoreMatchers {
    * will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem("bar"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param item
    *     the item to compare against the items provided by the examined {@link Iterable}
-   *
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<java.lang.Iterable<? super T>> hasItem(T item) {
@@ -212,10 +251,11 @@ public class CoreMatchers {
    * the examined {@link Iterable} will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems(endsWith("z"), endsWith("o")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param itemMatchers
    *     the matchers to apply to items provided by the examined {@link Iterable}
-   *
    * @return The matcher.
    */
   @SafeVarargs
@@ -230,10 +270,11 @@ public class CoreMatchers {
    * examined {@link Iterable} will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems("baz", "foo"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param items
    *     the items to compare against the items provided by the examined {@link Iterable}
-   *
    * @return The matcher.
    */
   @SafeVarargs
@@ -262,6 +303,10 @@ public class CoreMatchers {
    * assertThat(new String[] {"foo", "bar"}, equalTo(new String[] {"foo", "bar"}));
    * </pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param operand
+   *     for matcher {@link org.hamcrest.core.IsEqual#equalTo}.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> equalTo(T operand) {
@@ -272,6 +317,8 @@ public class CoreMatchers {
    * Creates an {@link org.hamcrest.core.IsEqual} matcher that does not enforce the values being
    * compared to be of the same static type.
    *
+   * @param operand
+   *     the object for matcher {@link org.hamcrest.core.IsEqual#equalToObject}.
    * @return The matcher.
    */
   public static org.hamcrest.Matcher<java.lang.Object> equalToObject(java.lang.Object operand) {
@@ -289,6 +336,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat(new Canoe(), any(Canoe.class));</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param type
+   *     the type for matcher {@link org.hamcrest.core.IsInstanceOf#any}.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> any(java.lang.Class<T> type) {
@@ -304,6 +355,10 @@ public class CoreMatchers {
    * For example:
    * <pre>assertThat(new Canoe(), instanceOf(Paddlable.class));</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param type
+   *     the type for matcher {@link org.hamcrest.core.IsInstanceOf#instanceOf}.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> instanceOf(java.lang.Class<?> type) {
@@ -315,7 +370,9 @@ public class CoreMatchers {
    * it will match.
    * For example:
    * <pre>assertThat(cheese, is(not(equalTo(smelly))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param matcher
    *     the matcher whose sense should be inverted
    * @return The matcher.
@@ -330,7 +387,9 @@ public class CoreMatchers {
    * <pre>assertThat(cheese, is(not(smelly)))</pre>
    * instead of:
    * <pre>assertThat(cheese, is(not(equalTo(smelly))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value
    *     the value that any examined object should <b>not</b> equal
    * @return The matcher.
@@ -359,7 +418,9 @@ public class CoreMatchers {
    * <pre>assertThat(cheese, is(notNullValue(X.class)))</pre>
    * instead of:
    * <pre>assertThat(cheese, is(not(nullValue(X.class))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param type
    *     dummy parameter used to infer the generic type of the returned matcher
    * @return The matcher.
@@ -384,7 +445,9 @@ public class CoreMatchers {
    * single dummy argument to facilitate type inference.
    * For example:
    * <pre>assertThat(cheese, is(nullValue(Cheese.class))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param type
    *     dummy parameter used to infer the generic type of the returned matcher
    * @return The matcher.
@@ -396,7 +459,9 @@ public class CoreMatchers {
   /**
    * Creates a matcher that matches only when the examined object is the same instance as
    * the specified target object.
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param target
    *     the target instance against which others should be assessed
    * @return The matcher.
@@ -408,7 +473,9 @@ public class CoreMatchers {
   /**
    * Creates a matcher that matches only when the examined object is the same instance as
    * the specified target object.
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param target
    *     the target instance against which others should be assessed
    * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
@@ -36,7 +36,6 @@ public class CoreMatchers {
     return org.hamcrest.core.AllOf.allOf(matchers);
   }
 
-
   /**
    * Creates a matcher that matches if the examined object matches <b>ANY</b> of the specified matchers.
    * For example:

--- a/hamcrest/src/main/java/org/hamcrest/CustomMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomMatcher.java
@@ -34,4 +34,5 @@ public abstract class CustomMatcher<T> extends BaseMatcher<T> {
     public final void describeTo(Description description) {
         description.appendText(fixedDescription);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/CustomMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomMatcher.java
@@ -21,6 +21,7 @@ package org.hamcrest;
  * @param <T> The type of object being matched.
  */
 public abstract class CustomMatcher<T> extends BaseMatcher<T> {
+
     private final String fixedDescription;
 
     public CustomMatcher(String description) {

--- a/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
@@ -35,4 +35,5 @@ public abstract class CustomTypeSafeMatcher<T> extends TypeSafeMatcher<T> {
     public final void describeTo(Description description) {
         description.appendText(fixedDescription);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
@@ -1,6 +1,5 @@
 package org.hamcrest;
 
-
 /**
  * Utility class for writing one off matchers.
  * For example:

--- a/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/CustomTypeSafeMatcher.java
@@ -21,6 +21,7 @@ package org.hamcrest;
  * @param <T> The type of object being matched
  */
 public abstract class CustomTypeSafeMatcher<T> extends TypeSafeMatcher<T> {
+
     private final String fixedDescription;
 
     public CustomTypeSafeMatcher(String description) {

--- a/hamcrest/src/main/java/org/hamcrest/Description.java
+++ b/hamcrest/src/main/java/org/hamcrest/Description.java
@@ -91,7 +91,6 @@ public interface Description {
     Description appendList(String start, String separator, String end,
                            Iterable<? extends SelfDescribing> values);
 
-
     public static final class NullDescription implements Description {
       @Override
       public Description appendDescriptionOf(SelfDescribing value) {

--- a/hamcrest/src/main/java/org/hamcrest/Description.java
+++ b/hamcrest/src/main/java/org/hamcrest/Description.java
@@ -15,6 +15,8 @@ public interface Description {
     /**
      * Appends some plain text to the description.
      *
+     * @param text
+     *     the text to append.
      * @return the update description when displaying the matcher error.
      */
     Description appendText(String text);
@@ -22,6 +24,8 @@ public interface Description {
     /**
      * Appends the description of a {@link SelfDescribing} value to this description.
      *
+     * @param value
+     *     the value to append.
      * @return the update description when displaying the matcher error.
      */
     Description appendDescriptionOf(SelfDescribing value);
@@ -29,6 +33,8 @@ public interface Description {
     /**
      * Appends an arbitrary value to the description.
      *
+     * @param value
+     *     the object to append.
      * @return the update description when displaying the matcher error.
      */
     Description appendValue(Object value);
@@ -36,6 +42,16 @@ public interface Description {
     /**
      * Appends a list of values to the description.
      *
+     * @param <T>
+     *     the description type.
+     * @param start
+     *     the prefix.
+     * @param separator
+     *     the separator.
+     * @param end
+     *     the suffix.
+     * @param values
+     *     the values to append.
      * @return the update description when displaying the matcher error.
      */
     <T> Description appendValueList(String start, String separator, String end,
@@ -44,6 +60,16 @@ public interface Description {
     /**
      * Appends a list of values to the description.
      *
+     * @param <T>
+     *     the description type.
+     * @param start
+     *     the prefix.
+     * @param separator
+     *     the separator.
+     * @param end
+     *     the suffix.
+     * @param values
+     *     the values to append.
      * @return the update description when displaying the matcher error.
      */
     <T> Description appendValueList(String start, String separator, String end,
@@ -52,7 +78,14 @@ public interface Description {
     /**
      * Appends a list of {@link org.hamcrest.SelfDescribing} objects
      * to the description.
-     *
+     * @param start
+     *     the prefix.
+     * @param separator
+     *     the separator.
+     * @param end
+     *     the suffix.
+     * @param values
+     *     the values to append.
      * @return the update description when displaying the matcher error.
      */
     Description appendList(String start, String separator, String end,

--- a/hamcrest/src/main/java/org/hamcrest/Description.java
+++ b/hamcrest/src/main/java/org/hamcrest/Description.java
@@ -7,6 +7,7 @@ package org.hamcrest;
  * @see Matcher#describeTo(Description)
  */
 public interface Description {
+
   /**
    * A description that consumes input but does nothing.
    */

--- a/hamcrest/src/main/java/org/hamcrest/Description.java
+++ b/hamcrest/src/main/java/org/hamcrest/Description.java
@@ -11,7 +11,7 @@ public interface Description {
    * A description that consumes input but does nothing.
    */
   static final Description NONE = new NullDescription();
-  
+
     /**
      * Appends some plain text to the description.
      *

--- a/hamcrest/src/main/java/org/hamcrest/Description.java
+++ b/hamcrest/src/main/java/org/hamcrest/Description.java
@@ -131,4 +131,5 @@ public interface Description {
           return "";
         }
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/DiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/DiagnosingMatcher.java
@@ -3,7 +3,7 @@ package org.hamcrest;
 /**
  * TODO(ngd): Document.
  *
- * @param <T>
+ * @param <T> the type of matcher being diagnosed.
  */
 public abstract class DiagnosingMatcher<T> extends BaseMatcher<T> {
 

--- a/hamcrest/src/main/java/org/hamcrest/DiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/DiagnosingMatcher.java
@@ -18,4 +18,5 @@ public abstract class DiagnosingMatcher<T> extends BaseMatcher<T> {
     }
 
     protected abstract boolean matches(Object item, Description mismatchDescription);
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
@@ -51,4 +51,5 @@ public abstract class FeatureMatcher<T, U> extends TypeSafeDiagnosingMatcher<T> 
     description.appendText(featureDescription).appendText(" ")
                .appendDescriptionOf(subMatcher);
   }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
@@ -4,17 +4,17 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
 
 /**
  * Supporting class for matching a feature of an object. Implement <code>featureValueOf()</code>
- * in a subclass to pull out the feature to be matched against. 
+ * in a subclass to pull out the feature to be matched against.
  *
  * @param <T> The type of the object to be matched
  * @param <U> The type of the feature to be matched
  */
 public abstract class FeatureMatcher<T, U> extends TypeSafeDiagnosingMatcher<T> {
-  private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("featureValueOf", 1, 0); 
+  private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("featureValueOf", 1, 0);
   private final Matcher<? super U> subMatcher;
   private final String featureDescription;
   private final String featureName;
-  
+
   /**
    * Constructor
    * @param subMatcher The matcher to apply to the feature
@@ -27,7 +27,7 @@ public abstract class FeatureMatcher<T, U> extends TypeSafeDiagnosingMatcher<T> 
     this.featureDescription = featureDescription;
     this.featureName = featureName;
   }
-  
+
   /**
    * Implement this to extract the interesting feature.
    * @param actual the target object
@@ -45,7 +45,7 @@ public abstract class FeatureMatcher<T, U> extends TypeSafeDiagnosingMatcher<T> 
     }
     return true;
   }
-      
+
   @Override
   public final void describeTo(Description description) {
     description.appendText(featureDescription).appendText(" ")

--- a/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/FeatureMatcher.java
@@ -10,6 +10,7 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  * @param <U> The type of the feature to be matched
  */
 public abstract class FeatureMatcher<T, U> extends TypeSafeDiagnosingMatcher<T> {
+
   private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("featureValueOf", 1, 0);
   private final Matcher<? super U> subMatcher;
   private final String featureDescription;

--- a/hamcrest/src/main/java/org/hamcrest/Matcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matcher.java
@@ -39,12 +39,12 @@ public interface Matcher<T> extends SelfDescribing {
      * @see BaseMatcher
      */
     boolean matches(Object actual);
-    
+
     /**
      * Generate a description of why the matcher has not accepted the item.
      * The description will be part of a larger description of why a matching
-     * failed, so it should be concise. 
-     * This method assumes that <code>matches(item)</code> is false, but 
+     * failed, so it should be concise.
+     * This method assumes that <code>matches(item)</code> is false, but
      * will not check this.
      *
      * @param actual The item that the Matcher has rejected.

--- a/hamcrest/src/main/java/org/hamcrest/Matcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matcher.java
@@ -64,4 +64,5 @@ public interface Matcher<T> extends SelfDescribing {
      */
     @Deprecated
     void _dont_implement_Matcher___instead_extend_BaseMatcher_();
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -1,6 +1,5 @@
 package org.hamcrest;
 
-
 public class MatcherAssert {
     public static <T> void assertThat(T actual, Matcher<? super T> matcher) {
         assertThat("", actual, matcher);

--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -1,6 +1,7 @@
 package org.hamcrest;
 
 public class MatcherAssert {
+
     public static <T> void assertThat(T actual, Matcher<? super T> matcher) {
         assertThat("", actual, matcher);
     }

--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -5,7 +5,7 @@ public class MatcherAssert {
     public static <T> void assertThat(T actual, Matcher<? super T> matcher) {
         assertThat("", actual, matcher);
     }
-    
+
     public static <T> void assertThat(String reason, T actual, Matcher<? super T> matcher) {
         if (!matcher.matches(actual)) {
             Description description = new StringDescription();
@@ -16,11 +16,11 @@ public class MatcherAssert {
                        .appendText(System.lineSeparator())
                        .appendText("     but: ");
             matcher.describeMismatch(actual, description);
-            
+
             throw new AssertionError(description.toString());
         }
     }
-    
+
     public static void assertThat(String reason, boolean assertion) {
         if (!assertion) {
             throw new AssertionError(reason);

--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -26,4 +26,5 @@ public class MatcherAssert {
             throw new AssertionError(reason);
         }
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -15,6 +15,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     all the matchers must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(java.lang.Iterable<org.hamcrest.Matcher<? super T>> matchers) {
@@ -26,6 +30,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     all the matchers must pass.
    * @return The matcher.
    */
   @SafeVarargs
@@ -38,6 +46,12 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher that must pass.
+   * @param second
+   *     second matcher that must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second) {
@@ -49,6 +63,14 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher that must pass.
+   * @param second
+   *     second matcher that must pass.
+   * @param third
+   *     third matcher that must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third) {
@@ -60,6 +82,16 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher that must pass.
+   * @param second
+   *     second matcher that must pass.
+   * @param third
+   *     third matcher that must pass.
+   * @param fourth
+   *     fourth matcher that must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third, org.hamcrest.Matcher<? super T> fourth) {
@@ -71,6 +103,18 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher that must pass.
+   * @param second
+   *     second matcher that must pass.
+   * @param third
+   *     third matcher that must pass.
+   * @param fourth
+   *     fourth matcher that must pass.
+   * @param fifth
+   *     fifth matcher that must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third, org.hamcrest.Matcher<? super T> fourth, org.hamcrest.Matcher<? super T> fifth) {
@@ -82,6 +126,20 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher that must pass.
+   * @param second
+   *     second matcher that must pass.
+   * @param third
+   *     third matcher that must pass.
+   * @param fourth
+   *     fourth matcher that must pass.
+   * @param fifth
+   *     fifth matcher that must pass.
+   * @param sixth
+   *     sixth matcher that must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> allOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third, org.hamcrest.Matcher<? super T> fourth, org.hamcrest.Matcher<? super T> fifth, org.hamcrest.Matcher<? super T> sixth) {
@@ -93,6 +151,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     any the matchers must pass.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(java.lang.Iterable<org.hamcrest.Matcher<? super T>> matchers) {
@@ -104,6 +166,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matchers
+   *     any the matchers must pass.
    * @return The matcher.
    */
   @SafeVarargs
@@ -116,6 +182,12 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher to check.
+   * @param second
+   *     second matcher to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second) {
@@ -127,6 +199,14 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher to check.
+   * @param second
+   *     second matcher to check.
+   * @param third
+   *     third matcher to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third) {
@@ -138,6 +218,16 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher to check.
+   * @param second
+   *     second matcher to check.
+   * @param third
+   *     third matcher to check.
+   * @param fourth
+   *     fourth matcher to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third, org.hamcrest.Matcher<? super T> fourth) {
@@ -149,6 +239,18 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher to check.
+   * @param second
+   *     second matcher to check.
+   * @param third
+   *     third matcher to check.
+   * @param fourth
+   *     fourth matcher to check.
+   * @param fifth
+   *     fifth matcher to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third, org.hamcrest.Matcher<? super T> fourth, org.hamcrest.Matcher<? super T> fifth) {
@@ -160,6 +262,20 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param first
+   *     first matcher to check.
+   * @param second
+   *     second matcher to check.
+   * @param third
+   *     third matcher to check.
+   * @param fourth
+   *     fourth matcher to check.
+   * @param fifth
+   *     fifth matcher to check.
+   * @param sixth
+   *     sixth matcher to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.core.AnyOf<T> anyOf(org.hamcrest.Matcher<? super T> first, org.hamcrest.Matcher<? super T> second, org.hamcrest.Matcher<? super T> third, org.hamcrest.Matcher<? super T> fourth, org.hamcrest.Matcher<? super T> fifth, org.hamcrest.Matcher<? super T> sixth) {
@@ -171,6 +287,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat("fab", both(containsString("a")).and(containsString("b")))</pre>
    *
+   * @param <LHS>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to combine, and both must pass.
    * @return The matcher.
    */
   public static <LHS> org.hamcrest.core.CombinableMatcher.CombinableBothMatcher<LHS> both(org.hamcrest.Matcher<? super LHS> matcher) {
@@ -182,6 +302,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat("fan", either(containsString("a")).or(containsString("b")))</pre>
    *
+   * @param <LHS>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to combine, and either must pass.
    * @return The matcher.
    */
   public static <LHS> org.hamcrest.core.CombinableMatcher.CombinableEitherMatcher<LHS> either(org.hamcrest.Matcher<? super LHS> matcher) {
@@ -193,7 +317,9 @@ public class Matchers {
    * delegated to the decorated matcher, including its mismatch description.
    * For example:
    * <pre>describedAs("a big decimal equal to %0", equalTo(myBigDecimal), myBigDecimal.toPlainString())</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param description
    *     the new description for the wrapped matcher
    * @param matcher
@@ -212,7 +338,9 @@ public class Matchers {
    * <code>itemMatcher</code>.
    * For example:
    * <pre>assertThat(Arrays.asList("bar", "baz"), everyItem(startsWith("ba")))</pre>
-   * 
+   *
+   * @param <U>
+   *     the matcher type.
    * @param itemMatcher
    *     the matcher to apply to every item provided by the examined {@link Iterable}
    * @return The matcher.
@@ -229,6 +357,10 @@ public class Matchers {
    * instead of:
    * <pre>assertThat(cheese, equalTo(smelly))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to wrap.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> is(org.hamcrest.Matcher<T> matcher) {
@@ -242,6 +374,10 @@ public class Matchers {
    * instead of:
    * <pre>assertThat(cheese, is(equalTo(smelly)))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param value
+   *     the value to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> is(T value) {
@@ -255,6 +391,10 @@ public class Matchers {
    * instead of:
    * <pre>assertThat(cheese, is(instanceOf(Cheddar.class)))</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param type
+   *     the type to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> isA(java.lang.Class<?> type) {
@@ -288,7 +428,9 @@ public class Matchers {
    * will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem(startsWith("ba")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param itemMatcher
    *     the matcher to apply to items provided by the examined {@link Iterable}
    * @return The matcher.
@@ -304,7 +446,9 @@ public class Matchers {
    * will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem("bar"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param item
    *     the item to compare against the items provided by the examined {@link Iterable}
    * @return The matcher.
@@ -320,7 +464,9 @@ public class Matchers {
    * the examined {@link Iterable} will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems(endsWith("z"), endsWith("o")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param itemMatchers
    *     the matchers to apply to items provided by the examined {@link Iterable}
    * @return The matcher.
@@ -337,7 +483,9 @@ public class Matchers {
    * examined {@link Iterable} will stop as soon as a matching item is found.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems("baz", "foo"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param items
    *     the items to compare against the items provided by the examined {@link Iterable}
    * @return The matcher.
@@ -368,6 +516,10 @@ public class Matchers {
    * assertThat(new String[] {"foo", "bar"}, equalTo(new String[] {"foo", "bar"}));
    * </pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param operand
+   *     the value to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> equalTo(T operand) {
@@ -378,6 +530,8 @@ public class Matchers {
    * Creates an {@link org.hamcrest.core.IsEqual} matcher that does not enforce the values being
    * compared to be of the same static type.
    *
+   * @param operand
+   *     the value to check.
    * @return The matcher.
    */
   public static org.hamcrest.Matcher<java.lang.Object> equalToObject(java.lang.Object operand) {
@@ -395,6 +549,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new Canoe(), instanceOf(Canoe.class));</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param type
+   *     the type to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> any(java.lang.Class<T> type) {
@@ -410,6 +568,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new Canoe(), instanceOf(Paddlable.class));</pre>
    *
+   * @param <T>
+   *     the matcher type.
+   * @param type
+   *     the type to check.
    * @return The matcher.
    */
   public static <T> org.hamcrest.Matcher<T> instanceOf(java.lang.Class<?> type) {
@@ -421,7 +583,9 @@ public class Matchers {
    * it will match.
    * For example:
    * <pre>assertThat(cheese, is(not(equalTo(smelly))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param matcher
    *     the matcher whose sense should be inverted
    * @return The matcher.
@@ -436,7 +600,9 @@ public class Matchers {
    * <pre>assertThat(cheese, is(not(smelly)))</pre>
    * instead of:
    * <pre>assertThat(cheese, is(not(equalTo(smelly))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value
    *     the value that any examined object should <b>not</b> equal
    * @return The matcher.
@@ -465,7 +631,9 @@ public class Matchers {
    * <pre>assertThat(cheese, is(notNullValue(X.class)))</pre>
    * instead of:
    * <pre>assertThat(cheese, is(not(nullValue(X.class))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param type
    *     dummy parameter used to infer the generic type of the returned matcher
    * @return The matcher.
@@ -490,7 +658,9 @@ public class Matchers {
    * single dummy argument to facilitate type inference.
    * For example:
    * <pre>assertThat(cheese, is(nullValue(Cheese.class))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param type
    *     dummy parameter used to infer the generic type of the returned matcher
    * @return The matcher.
@@ -502,7 +672,9 @@ public class Matchers {
   /**
    * Creates a matcher that matches only when the examined object is the same instance as
    * the specified target object.
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param target
    *     the target instance against which others should be assessed
    * @return The matcher.
@@ -514,7 +686,9 @@ public class Matchers {
   /**
    * Creates a matcher that matches only when the examined object is the same instance as
    * the specified target object.
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param target
    *     the target instance against which others should be assessed
    * @return The matcher.
@@ -647,7 +821,9 @@ public class Matchers {
    * each matcher[i] is satisfied by array[i].
    * For example:
    * <pre>assertThat(new Integer[]{1,2,3}, is(array(equalTo(1), equalTo(2), equalTo(3))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param elementMatchers
    *     the matchers that the elements of examined arrays should satisfy
    * @return The matcher.
@@ -663,7 +839,9 @@ public class Matchers {
    * of the examined array will stop as soon as a matching element is found.
    * For example:
    * <pre>assertThat(new String[] {"foo", "bar"}, hasItemInArray(startsWith("ba")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param elementMatcher
    *     the matcher to apply to elements in examined arrays
    * @return The matcher.
@@ -678,7 +856,9 @@ public class Matchers {
    * <pre>assertThat(hasItemInArray(x))</pre>
    * instead of:
    * <pre>assertThat(hasItemInArray(equalTo(x)))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param element
    *     the element that should be present in examined arrays
    * @return The matcher.
@@ -693,7 +873,9 @@ public class Matchers {
    * the examined array must be of the same length as the number of specified items.
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContaining("foo", "bar"))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param items
    *     the items that must equal the items within an examined array
    * @return The matcher.
@@ -709,7 +891,9 @@ public class Matchers {
    * must be of the same length as the number of specified matchers.
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContaining(equalTo("foo"), equalTo("bar")))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     the matchers that must be satisfied by the items in the examined array
    * @return The matcher.
@@ -725,7 +909,9 @@ public class Matchers {
    * must be of the same length as the specified list of matchers.
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContaining(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by the corresponding item in an examined array
    * @return The matcher.
@@ -750,7 +936,9 @@ public class Matchers {
    * For example:
    * </p>
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by an entry in an examined array
    * @return The matcher.
@@ -776,7 +964,9 @@ public class Matchers {
    * For example:
    * </p>
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by an item provided by an examined array
    * @return The matcher.
@@ -799,7 +989,9 @@ public class Matchers {
    * For example:
    * </p>
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder("bar", "foo"))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param items
    *     the items that must equal the entries of an examined array, in any order
    * @return The matcher.
@@ -814,7 +1006,9 @@ public class Matchers {
    * satisfies the specified matcher.
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayWithSize(equalTo(2)))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param sizeMatcher
    *     a matcher for the length of an examined array
    * @return The matcher.
@@ -828,7 +1022,9 @@ public class Matchers {
    * equals the specified <code>size</code>.
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayWithSize(2))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param size
    *     the length that an examined array must have for a positive match
    * @return The matcher.
@@ -843,6 +1039,8 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new String[0], emptyArray())</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @return The matcher.
    */
   public static <E> org.hamcrest.Matcher<E[]> emptyArray() {
@@ -854,7 +1052,11 @@ public class Matchers {
    * a value that satisfies the specified matcher.
    * For example:
    * <pre>assertThat(myMap, is(aMapWithSize(equalTo(2))))</pre>
-   * 
+   *
+   * @param <K>
+   *     the map key type.
+   * @param <V>
+   *     the map value type.
    * @param sizeMatcher
    *     a matcher for the size of an examined {@link java.util.Map}
    * @return The matcher.
@@ -868,7 +1070,11 @@ public class Matchers {
    * a value equal to the specified <code>size</code>.
    * For example:
    * <pre>assertThat(myMap, is(aMapWithSize(2)))</pre>
-   * 
+   *
+   * @param <K>
+   *     the map key type.
+   * @param <V>
+   *     the map value type.
    * @param size
    *     the expected size of an examined {@link java.util.Map}
    * @return The matcher.
@@ -883,6 +1089,10 @@ public class Matchers {
    * For example:
    * <pre>assertThat(myMap, is(anEmptyMap()))</pre>
    *
+   * @param <K>
+   *     the map key type.
+   * @param <V>
+   *     the map value type.
    * @return The matcher.
    */
   public static <K, V> org.hamcrest.Matcher<java.util.Map<? extends K,? extends V>> anEmptyMap() {
@@ -894,7 +1104,9 @@ public class Matchers {
    * a value that satisfies the specified matcher.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(equalTo(2)))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param sizeMatcher
    *     a matcher for the size of an examined {@link java.util.Collection}
    * @return The matcher.
@@ -908,7 +1120,9 @@ public class Matchers {
    * a value equal to the specified <code>size</code>.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(2))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param size
    *     the expected size of an examined {@link java.util.Collection}
    * @return The matcher.
@@ -923,6 +1137,8 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new ArrayList&lt;String&gt;(), is(empty()))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @return The matcher.
    */
   public static <E> org.hamcrest.Matcher<java.util.Collection<? extends E>> empty() {
@@ -934,7 +1150,9 @@ public class Matchers {
    * method returns <code>true</code>.
    * For example:
    * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyCollectionOf(String.class)))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param unusedToForceReturnType
    *     the type of the collection's content
    * @return The matcher.
@@ -948,6 +1166,8 @@ public class Matchers {
    * For example:
    * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterable()))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @return The matcher.
    */
   public static <E> org.hamcrest.Matcher<java.lang.Iterable<? extends E>> emptyIterable() {
@@ -958,7 +1178,9 @@ public class Matchers {
    * Creates a matcher for {@link Iterable}s matching examined iterables that yield no items.
    * For example:
    * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterableOf(String.class)))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param unusedToForceReturnType
    *     the type of the iterable's content
    * @return The matcher.
@@ -974,7 +1196,9 @@ public class Matchers {
    * must be of the same length as the number of specified items.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), contains("foo", "bar"))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param items
    *     the items that must equal the items provided by an examined {@link Iterable}
    * @return The matcher.
@@ -990,7 +1214,9 @@ public class Matchers {
    * For a positive match, the examined iterable must only yield one item.
    * For example:
    * <pre>assertThat(Arrays.asList("foo"), contains(equalTo("foo")))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatcher
    *     the matcher that must be satisfied by the single item provided by an
    *     examined {@link Iterable}
@@ -1007,7 +1233,9 @@ public class Matchers {
    * must be of the same length as the number of specified matchers.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), contains(equalTo("foo"), equalTo("bar")))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     the matchers that must be satisfied by the items provided by an examined {@link Iterable}
    * @return The matcher.
@@ -1024,7 +1252,9 @@ public class Matchers {
    * must be of the same length as the specified list of matchers.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), contains(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by the corresponding item provided by
    *     an examined {@link Iterable}
@@ -1050,7 +1280,9 @@ public class Matchers {
    * For example:
    * </p>
    * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
    * @return The matcher.
@@ -1076,7 +1308,9 @@ public class Matchers {
    * For example:
    * </p>
    * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder("bar", "foo"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param items
    *     the items that must equal the items provided by an examined {@link Iterable} in any order
    * @return The matcher.
@@ -1100,7 +1334,9 @@ public class Matchers {
    * </p>
    * <p>For example:</p>
    * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
    * @return The matcher.
@@ -1115,7 +1351,9 @@ public class Matchers {
    * corresponding item in the specified items, in the same relative order
    * For example:
    * <pre>assertThat(Arrays.asList("a", "b", "c", "d", "e"), containsInRelativeOrder("b", "d"))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param items
    *     the items that must be contained within items provided by an examined {@link Iterable} in the same relative order
    * @return The matcher.
@@ -1131,7 +1369,9 @@ public class Matchers {
    * matcher in the specified matchers, in the same relative order.
    * For example:
    * <pre>assertThat(Arrays.asList("a", "b", "c", "d", "e"), containsInRelativeOrder(equalTo("b"), equalTo("d")))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     the matchers that must be satisfied by the items provided by an examined {@link Iterable} in the same relative order
    * @return The matcher.
@@ -1147,7 +1387,9 @@ public class Matchers {
    * matcher in the specified list of matchers, in the same relative order.
    * For example:
    * <pre>assertThat(Arrays.asList("a", "b", "c", "d", "e"), contains(Arrays.asList(equalTo("b"), equalTo("d"))))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by the items provided by
    *     an examined {@link Iterable} in the same relative order
@@ -1163,7 +1405,9 @@ public class Matchers {
    * matcher.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), iterableWithSize(equalTo(2)))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param sizeMatcher
    *     a matcher for the number of items that should be yielded by an examined {@link Iterable}
    * @return The matcher.
@@ -1178,7 +1422,9 @@ public class Matchers {
    * <code>size</code> argument.
    * For example:
    * <pre>assertThat(Arrays.asList("foo", "bar"), iterableWithSize(2))</pre>
-   * 
+   *
+   * @param <E>
+   *     the matcher type.
    * @param size
    *     the number of items that should be yielded by an examined {@link Iterable}
    * @return The matcher.
@@ -1193,7 +1439,11 @@ public class Matchers {
    * value satisfies the specified <code>valueMatcher</code>.
    * For example:
    * <pre>assertThat(myMap, hasEntry(equalTo("bar"), equalTo("foo")))</pre>
-   * 
+   *
+   * @param <K>
+   *     the map key type.
+   * @param <V>
+   *     the map value type.
    * @param keyMatcher
    *     the key matcher that, in combination with the valueMatcher, must be satisfied by at least one entry
    * @param valueMatcher
@@ -1210,7 +1460,11 @@ public class Matchers {
    * specified <code>value</code>.
    * For example:
    * <pre>assertThat(myMap, hasEntry("bar", "foo"))</pre>
-   * 
+   *
+   * @param <K>
+   *     the map key type.
+   * @param <V>
+   *     the map value type.
    * @param key
    *     the key that, in combination with the value, must be describe at least one entry
    * @param value
@@ -1226,7 +1480,9 @@ public class Matchers {
    * at least one key that satisfies the specified matcher.
    * For example:
    * <pre>assertThat(myMap, hasKey(equalTo("bar")))</pre>
-   * 
+   *
+   * @param <K>
+   *     the map key type.
    * @param keyMatcher
    *     the matcher that must be satisfied by at least one key
    * @return The matcher.
@@ -1240,7 +1496,9 @@ public class Matchers {
    * at least one key that is equal to the specified key.
    * For example:
    * <pre>assertThat(myMap, hasKey("bar"))</pre>
-   * 
+   *
+   * @param <K>
+   *     the map key type.
    * @param key
    *     the key that satisfying maps must contain
    * @return The matcher.
@@ -1254,7 +1512,9 @@ public class Matchers {
    * at least one value that satisfies the specified valueMatcher.
    * For example:
    * <pre>assertThat(myMap, hasValue(equalTo("foo")))</pre>
-   * 
+   *
+   * @param <V>
+   *     the value type.
    * @param valueMatcher
    *     the matcher that must be satisfied by at least one value
    * @return The matcher.
@@ -1268,7 +1528,9 @@ public class Matchers {
    * at least one value that is equal to the specified value.
    * For example:
    * <pre>assertThat(myMap, hasValue("foo"))</pre>
-   * 
+   *
+   * @param <V>
+   *     the value type.
    * @param value
    *     the value that satisfying maps must contain
    * @return The matcher.
@@ -1282,7 +1544,9 @@ public class Matchers {
    * specified collection.
    * For example:
    * <pre>assertThat("foo", is(in(Arrays.asList("bar", "foo"))))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param collection
    *     the collection in which matching items must be found
    * @return The matcher.
@@ -1296,7 +1560,9 @@ public class Matchers {
    * specified array.
    * For example:
    * <pre>assertThat("foo", is(in(new String[]{"bar", "foo"})))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param elements
    *     the array in which matching items must be found
    * @return The matcher.
@@ -1310,7 +1576,9 @@ public class Matchers {
    * specified collection.
    * For example:
    * <pre>assertThat("foo", isIn(Arrays.asList("bar", "foo")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @deprecated use is(in(...)) instead
    * @param collection
    *     the collection in which matching items must be found
@@ -1326,8 +1594,10 @@ public class Matchers {
    * specified array.
    * For example:
    * <pre>assertThat("foo", isIn(new String[]{"bar", "foo"}))</pre>
-   * 
+   *
    * @deprecated use is(in(...)) instead
+   * @param <T>
+   *     the matcher type.
    * @param elements
    *     the array in which matching items must be found
    * @return The matcher.
@@ -1344,6 +1614,8 @@ public class Matchers {
    * <pre>assertThat("foo", isOneOf("bar", "foo"))</pre>
    * 
    * @deprecated use is(oneOf(...)) instead
+   * @param <T>
+   *     the matcher type.
    * @param elements
    *     the elements amongst which matching items will be found
    * @return The matcher.
@@ -1359,7 +1631,9 @@ public class Matchers {
    * specified elements.
    * For example:
    * <pre>assertThat("foo", is(oneOf("bar", "foo")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param elements
    *     the elements amongst which matching items will be found
    * @return The matcher.
@@ -1419,7 +1693,9 @@ public class Matchers {
    * <b>examined</b> object.
    * For example:
    * <pre>assertThat(1, comparesEqualTo(1))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value the value which, when passed to the compareTo method of the examined object, should return zero
    * @return The matcher.
    */
@@ -1433,7 +1709,9 @@ public class Matchers {
    * <b>examined</b> object.
    * For example:
    * <pre>assertThat(2, greaterThan(1))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value the value which, when passed to the compareTo method of the examined object, should return greater
    *              than zero
    * @return The matcher.
@@ -1448,7 +1726,9 @@ public class Matchers {
    * of the <b>examined</b> object.
    * For example:
    * <pre>assertThat(1, greaterThanOrEqualTo(1))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value the value which, when passed to the compareTo method of the examined object, should return greater
    *              than or equal to zero
    * @return The matcher.
@@ -1463,7 +1743,9 @@ public class Matchers {
    * <b>examined</b> object.
    * For example:
    * <pre>assertThat(1, lessThan(2))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value the value which, when passed to the compareTo method of the examined object, should return less
    *              than zero
    * @return The matcher.
@@ -1478,7 +1760,9 @@ public class Matchers {
    * of the <b>examined</b> object.
    * For example:
    * <pre>assertThat(1, lessThanOrEqualTo(1))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param value the value which, when passed to the compareTo method of the examined object, should return less
    *              than or equal to zero
    * @return The matcher.
@@ -1608,6 +1892,8 @@ public class Matchers {
    * Creates a matcher of {@link java.lang.String} that matches when the examined string
    * exactly matches the given {@link java.util.regex.Pattern}.
    *
+   * @param pattern
+   *     the text pattern to match.
    * @return The matcher.
    */
   public static Matcher<java.lang.String> matchesPattern(java.util.regex.Pattern pattern) {
@@ -1618,6 +1904,8 @@ public class Matchers {
    * Creates a matcher of {@link java.lang.String} that matches when the examined string
    * exactly matches the given regular expression, treated as a {@link java.util.regex.Pattern}.
    *
+   * @param regex
+   *     the regex to match.
    * @return The matcher.
    */
   public static Matcher<java.lang.String> matchesPattern(java.lang.String regex) {
@@ -1691,7 +1979,9 @@ public class Matchers {
    * returns a value that satisfies the specified matcher.
    * For example:
    * <pre>assertThat(true, hasToString(equalTo("TRUE")))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param toStringMatcher
    *     the matcher used to verify the toString result
    * @return The matcher.
@@ -1705,7 +1995,9 @@ public class Matchers {
    * returns a value equalTo the specified string.
    * For example:
    * <pre>assertThat(true, hasToString("TRUE"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param expectedToString
    *     the expected toString result
    * @return The matcher.
@@ -1719,7 +2011,9 @@ public class Matchers {
    * assignable from the examined class.
    * For example:
    * <pre>assertThat(Integer.class, typeCompatibleWith(Number.class))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param baseType
    *     the base class to examine classes against
    * @return The matcher.
@@ -1763,7 +2057,9 @@ public class Matchers {
    * with the specified name.
    * For example:
    * <pre>assertThat(myBean, hasProperty("foo"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param propertyName
    *     the name of the JavaBean property that examined beans should possess
    * @return The matcher.
@@ -1777,7 +2073,9 @@ public class Matchers {
    * with the specified name whose value satisfies the specified matcher.
    * For example:
    * <pre>assertThat(myBean, hasProperty("foo", equalTo("bar"))</pre>
-   * 
+   *
+   * @param <T>
+   *     the matcher type.
    * @param propertyName
    *     the name of the JavaBean property that examined beans should possess
    * @param valueMatcher
@@ -1798,6 +2096,8 @@ public class Matchers {
    * <pre>assertThat(myBean, samePropertyValuesAs(myExpectedBean))</pre>
    * <pre>assertThat(myBean, samePropertyValuesAs(myExpectedBean), "age", "height")</pre>
    *
+   * @param <B>
+   *     the matcher type.
    * @param expectedBean
    *     the bean against which examined beans are compared
    * @param ignoredProperties

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -412,7 +412,7 @@ public class Matchers {
   /**
    * Creates a matcher that always matches, regardless of the examined object, but describes
    * itself with the specified {@link String}.
-   * 
+   *
    * @param description
    *     a meaningful {@link String} used when describing itself
    * @return The matcher.
@@ -499,17 +499,17 @@ public class Matchers {
    * Creates a matcher that matches when the examined object is logically equal to the specified
    * <code>operand</code>, as determined by calling the {@link java.lang.Object#equals} method on
    * the <b>examined</b> object.
-   * 
+   *
    * <p>If the specified operand is <code>null</code> then the created matcher will only match if
    * the examined object's <code>equals</code> method returns <code>true</code> when passed a
    * <code>null</code> (which would be a violation of the <code>equals</code> contract), unless the
    * examined object itself is <code>null</code>, in which case the matcher will return a positive
    * match.</p>
-   * 
+   *
    * <p>The created matcher provides a special behaviour when examining <code>Array</code>s, whereby
    * it will match if both the operand and the examined object are arrays of the same length and
    * contain items that are equal to each other (according to the above rules) <b>in the same
-   * indexes</b>.</p> 
+   * indexes</b>.</p>
    * For example:
    * <pre>
    * assertThat("foo", equalTo("foo"));
@@ -542,7 +542,7 @@ public class Matchers {
    * Creates a matcher that matches when the examined object is an instance of the specified <code>type</code>,
    * as determined by calling the {@link java.lang.Class#isInstance(Object)} method on that type, passing the
    * the examined object.
-   * 
+   *
    * <p>The created matcher forces a relationship between specified type and the examined object, and should be
    * used when it is necessary to make generics conform, for example in the JMock clause
    * <code>with(any(Thing.class))</code></p>
@@ -563,7 +563,7 @@ public class Matchers {
    * Creates a matcher that matches when the examined object is an instance of the specified <code>type</code>,
    * as determined by calling the {@link java.lang.Class#isInstance(Object)} method on that type, passing the
    * the examined object.
-   * 
+   *
    * <p>The created matcher assumes no relationship between specified type and the examined object.</p>
    * For example:
    * <pre>assertThat(new Canoe(), instanceOf(Paddlable.class));</pre>
@@ -696,13 +696,13 @@ public class Matchers {
   public static <T> org.hamcrest.Matcher<T> theInstance(T target) {
     return org.hamcrest.core.IsSame.theInstance(target);
   }
-  
+
   /**
    * Creates a matcher that matches if the examined {@link String} contains the specified
    * {@link String} anywhere.
    * For example:
    * <pre>assertThat("myStringOfNote", containsString("ring"))</pre>
-   * 
+   *
    * @param substring
    *     the substring that the returned matcher will expect to find within any examined string
    * @return The matcher.
@@ -716,7 +716,7 @@ public class Matchers {
    * {@link String} anywhere, ignoring case.
    * For example:
    * <pre>assertThat("myStringOfNote", containsStringIgnoringCase("Ring"))</pre>
-   * 
+   *
    * @param substring
    *     the substring that the returned matcher will expect to find within any examined string
    * @return The matcher.
@@ -732,7 +732,7 @@ public class Matchers {
    * </p>
    * For example:
    * <pre>assertThat("myStringOfNote", startsWith("my"))</pre>
-   * 
+   *
    * @param prefix
    *      the substring that the returned matcher will expect at the start of any examined string
    * @return The matcher.
@@ -748,7 +748,7 @@ public class Matchers {
    * </p>
    * For example:
    * <pre>assertThat("myStringOfNote", startsWithIgnoringCase("My"))</pre>
-   * 
+   *
    * @param prefix
    *      the substring that the returned matcher will expect at the start of any examined string
    * @return The matcher.
@@ -762,7 +762,7 @@ public class Matchers {
    * {@link String}.
    * For example:
    * <pre>assertThat("myStringOfNote", endsWith("Note"))</pre>
-   * 
+   *
    * @param suffix
    *      the substring that the returned matcher will expect at the end of any examined string
    * @return The matcher.
@@ -776,7 +776,7 @@ public class Matchers {
    * {@link String}, ignoring case.
    * For example:
    * <pre>assertThat("myStringOfNote", endsWithIgnoringCase("note"))</pre>
-   * 
+   *
    * @param suffix
    *      the substring that the returned matcher will expect at the end of any examined string
    * @return The matcher.
@@ -1612,7 +1612,7 @@ public class Matchers {
    * specified elements.
    * For example:
    * <pre>assertThat("foo", isOneOf("bar", "foo"))</pre>
-   * 
+   *
    * @deprecated use is(oneOf(...)) instead
    * @param <T>
    *     the matcher type.
@@ -1648,7 +1648,7 @@ public class Matchers {
    * to the specified <code>operand</code>, within a range of +/- <code>error</code>.
    * For example:
    * <pre>assertThat(1.03, is(closeTo(1.0, 0.03)))</pre>
-   * 
+   *
    * @param operand
    *     the expected value of matching doubles
    * @param error
@@ -1676,7 +1676,7 @@ public class Matchers {
    * is done by BigDecimals {@link java.math.BigDecimal#compareTo(java.math.BigDecimal)} method.
    * For example:
    * <pre>assertThat(new BigDecimal("1.03"), is(closeTo(new BigDecimal("1.0"), new BigDecimal("0.03"))))</pre>
-   * 
+   *
    * @param operand
    *     the expected value of matching BigDecimals
    * @param error
@@ -1776,7 +1776,7 @@ public class Matchers {
    * the specified expectedString, ignoring case.
    * For example:
    * <pre>assertThat("Foo", equalToIgnoringCase("FOO"))</pre>
-   * 
+   *
    * @param expectedString
    *     the expected value of matched strings
    * @return The matcher.
@@ -1842,7 +1842,7 @@ public class Matchers {
    * has zero length.
    * For example:
    * <pre>assertThat(((String)null), isEmptyOrNullString())</pre>
-   * 
+   *
    * @deprecated use is(emptyOrNullString()) instead
    * @return The matcher.
    */
@@ -1855,7 +1855,7 @@ public class Matchers {
    * Creates a matcher of {@link String} that matches when the examined string has zero length.
    * For example:
    * <pre>assertThat("", isEmptyString())</pre>
-   * 
+   *
    * @deprecated use is(emptyString()) instead
    * @return The matcher.
    */
@@ -1918,7 +1918,7 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myfoobarbaz", stringContainsInOrder(Arrays.asList("bar", "foo")))</pre>
    * fails as "foo" occurs before "bar" in the string "myfoobarbaz"
-   * 
+   *
    * @param substrings
    *     the substrings that must be contained within matching strings
    * @return The matcher.
@@ -1933,7 +1933,7 @@ public class Matchers {
    * For example:
    * <pre>assertThat("myfoobarbaz", stringContainsInOrder("bar", "foo"))</pre>
    * fails as "foo" occurs before "bar" in the string "myfoobarbaz"
-   * 
+   *
    * @param substrings
    *     the substrings that must be contained within matching strings
    * @return The matcher.
@@ -2027,7 +2027,7 @@ public class Matchers {
    * derived from <var>eventClass</var> announced by <var>source</var>.
    * For example:
    * <pre>assertThat(myEvent, is(eventFrom(PropertyChangeEvent.class, myBean)))</pre>
-   * 
+   *
    * @param eventClass
    *     the class of the event to match on
    * @param source
@@ -2043,7 +2043,7 @@ public class Matchers {
    * announced by <var>source</var>.
    * For example:
    * <pre>assertThat(myEvent, is(eventFrom(myBean)))</pre>
-   * 
+   *
    * @param source
    *     the source of the event
    * @return The matcher.
@@ -2113,7 +2113,7 @@ public class Matchers {
    * specified <code>xPath</code> that satisfies the specified <code>valueMatcher</code>.
    * For example:
    * <pre>assertThat(xml, hasXPath("/root/something[2]/cheese", equalTo("Cheddar")))</pre>
-   * 
+   *
    * @param xPath
    *     the target xpath
    * @param valueMatcher
@@ -2130,7 +2130,7 @@ public class Matchers {
    * the specified <code>valueMatcher</code>.
    * For example:
    * <pre>assertThat(xml, hasXPath("/root/something[2]/cheese", myNs, equalTo("Cheddar")))</pre>
-   * 
+   *
    * @param xPath
    *     the target xpath
    * @param namespaceContext
@@ -2148,7 +2148,7 @@ public class Matchers {
    * at the specified <code>xPath</code>, with any content.
    * For example:
    * <pre>assertThat(xml, hasXPath("/root/something[2]/cheese"))</pre>
-   * 
+   *
    * @param xPath
    *     the target xpath
    * @return The matcher.
@@ -2162,7 +2162,7 @@ public class Matchers {
    * at the specified <code>xPath</code> within the specified namespace context, with any content.
    * For example:
    * <pre>assertThat(xml, hasXPath("/root/something[2]/cheese", myNs))</pre>
-   * 
+   *
    * @param xPath
    *     the target xpath
    * @param namespaceContext

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -2173,5 +2173,4 @@ public class Matchers {
     return org.hamcrest.xml.HasXPath.hasXPath(xPath, namespaceContext);
   }
 
-
 }

--- a/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
+++ b/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
@@ -6,7 +6,7 @@ package org.hamcrest;
 public interface SelfDescribing {
     /**
      * Generates a description of the object.  The description may be part of a
-     * a description of a larger object of which this is just a component, so it 
+     * a description of a larger object of which this is just a component, so it
      * should be worded appropriately.
      *
      * @param description

--- a/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
+++ b/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
@@ -13,4 +13,5 @@ public interface SelfDescribing {
      *     The description to be built or appended to.
      */
     void describeTo(Description description);
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
+++ b/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
@@ -4,6 +4,7 @@ package org.hamcrest;
  * The ability of an object to describe itself.
  */
 public interface SelfDescribing {
+
     /**
      * Generates a description of the object.  The description may be part of a
      * a description of a larger object of which this is just a component, so it

--- a/hamcrest/src/main/java/org/hamcrest/StringDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/StringDescription.java
@@ -20,7 +20,7 @@ public class StringDescription extends BaseDescription {
      * Return the description of a {@link SelfDescribing} object as a String.
      *
      * @param selfDescribing
-     *   The object to be described.
+     *    The object to be described.
      * @return
      *   The description of the object.
      */
@@ -31,6 +31,8 @@ public class StringDescription extends BaseDescription {
     /**
      * Alias for {@link #toString(SelfDescribing)}.
      *
+     * @param selfDescribing
+     *    The object to be described.
      * @return
      *   The description of the object.
      */

--- a/hamcrest/src/main/java/org/hamcrest/StringDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/StringDescription.java
@@ -65,4 +65,5 @@ public class StringDescription extends BaseDescription {
     public String toString() {
         return out.toString();
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/StringDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/StringDescription.java
@@ -6,6 +6,7 @@ import java.io.IOException;
  * A {@link Description} that is stored as a string.
  */
 public class StringDescription extends BaseDescription {
+
     private final Appendable out;
 
     public StringDescription() {

--- a/hamcrest/src/main/java/org/hamcrest/StringDescription.java
+++ b/hamcrest/src/main/java/org/hamcrest/StringDescription.java
@@ -15,7 +15,7 @@ public class StringDescription extends BaseDescription {
     public StringDescription(Appendable out) {
         this.out = out;
     }
-    
+
     /**
      * Return the description of a {@link SelfDescribing} object as a String.
      *
@@ -57,7 +57,7 @@ public class StringDescription extends BaseDescription {
             throw new RuntimeException("Could not write description", e);
         }
     }
-    
+
     /**
      * Returns the description as a string.
      */

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
@@ -10,6 +10,7 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  * To use, implement <pre>matchesSafely()</pre>. 
  *
  * @param <T>
+ *     the matcher type.
  * @author Neil Dunn
  * @author Nat Pryce
  * @author Steve Freeman
@@ -22,6 +23,10 @@ public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
      * Subclasses should implement this. The item will already have been checked
      * for the specific type and will never be null.
      *
+     * @param item
+     *     the item.
+     * @param mismatchDescription
+     *     the mismatch description.
      * @return boolean true/false depending if item matches matcher.
      */
     protected abstract boolean matchesSafely(T item, Description mismatchDescription);
@@ -29,6 +34,7 @@ public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
     /**
      * Use this constructor if the subclass that implements <code>matchesSafely</code> 
      * is <em>not</em> the class that binds &lt;T&gt; to a type. 
+     *
      * @param expectedType The expectedType of the actual value.
      */
     protected TypeSafeDiagnosingMatcher(Class<?> expectedType) {
@@ -37,7 +43,8 @@ public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
 
     /**
      * Use this constructor if the subclass that implements <code>matchesSafely</code> 
-     * is <em>not</em> the class that binds &lt;T&gt; to a type. 
+     * is <em>not</em> the class that binds &lt;T&gt; to a type.
+     *
      * @param typeFinder A type finder to extract the type
      */
     protected TypeSafeDiagnosingMatcher(ReflectiveTypeFinder typeFinder) {

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
@@ -2,7 +2,6 @@ package org.hamcrest;
 
 import org.hamcrest.internal.ReflectiveTypeFinder;
 
-
 /**
  * Convenient base class for Matchers that require a non-null value of a specific type
  * and that will report why the received value has been rejected.

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
@@ -15,6 +15,7 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  * @author Steve Freeman
  */
 public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
+
     private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("matchesSafely", 2, 0);
     private final Class<?> expectedType;
 

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
@@ -80,4 +80,5 @@ public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
         matchesSafely((T) item, mismatchDescription);
       }
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeDiagnosingMatcher.java
@@ -6,8 +6,8 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
 /**
  * Convenient base class for Matchers that require a non-null value of a specific type
  * and that will report why the received value has been rejected.
- * This implements the null check, checks the type and then casts. 
- * To use, implement <pre>matchesSafely()</pre>. 
+ * This implements the null check, checks the type and then casts.
+ * To use, implement <pre>matchesSafely()</pre>.
  *
  * @param <T>
  *     the matcher type.
@@ -16,7 +16,7 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  * @author Steve Freeman
  */
 public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
-    private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("matchesSafely", 2, 0); 
+    private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("matchesSafely", 2, 0);
     private final Class<?> expectedType;
 
     /**
@@ -32,8 +32,8 @@ public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
     protected abstract boolean matchesSafely(T item, Description mismatchDescription);
 
     /**
-     * Use this constructor if the subclass that implements <code>matchesSafely</code> 
-     * is <em>not</em> the class that binds &lt;T&gt; to a type. 
+     * Use this constructor if the subclass that implements <code>matchesSafely</code>
+     * is <em>not</em> the class that binds &lt;T&gt; to a type.
      *
      * @param expectedType The expectedType of the actual value.
      */
@@ -42,20 +42,20 @@ public abstract class TypeSafeDiagnosingMatcher<T> extends BaseMatcher<T> {
     }
 
     /**
-     * Use this constructor if the subclass that implements <code>matchesSafely</code> 
+     * Use this constructor if the subclass that implements <code>matchesSafely</code>
      * is <em>not</em> the class that binds &lt;T&gt; to a type.
      *
      * @param typeFinder A type finder to extract the type
      */
     protected TypeSafeDiagnosingMatcher(ReflectiveTypeFinder typeFinder) {
-      this.expectedType = typeFinder.findExpectedType(getClass()); 
+      this.expectedType = typeFinder.findExpectedType(getClass());
     }
 
     /**
      * The default constructor for simple sub types
      */
     protected TypeSafeDiagnosingMatcher() {
-      this(TYPE_FINDER); 
+      this(TYPE_FINDER);
     }
 
     @Override

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
@@ -13,6 +13,7 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  * @author Nat Pryce
  */
 public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
+
     private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("matchesSafely", 1, 0);
 
     final private Class<?> expectedType;

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
@@ -97,4 +97,5 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
             describeMismatchSafely((T)item, description);
         }
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
@@ -14,7 +14,7 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  */
 public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
     private static final ReflectiveTypeFinder TYPE_FINDER = new ReflectiveTypeFinder("matchesSafely", 1, 0);
-    
+
     final private Class<?> expectedType;
 
     /**
@@ -23,26 +23,26 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
     protected TypeSafeMatcher() {
         this(TYPE_FINDER);
     }
-   
+
     /**
-     * Use this constructor if the subclass that implements <code>matchesSafely</code> 
-     * is <em>not</em> the class that binds &lt;T&gt; to a type. 
+     * Use this constructor if the subclass that implements <code>matchesSafely</code>
+     * is <em>not</em> the class that binds &lt;T&gt; to a type.
      * @param expectedType The expectedType of the actual value.
      */
     protected TypeSafeMatcher(Class<?> expectedType) {
         this.expectedType = expectedType;
     }
-    
+
     /**
-     * Use this constructor if the subclass that implements <code>matchesSafely</code> 
+     * Use this constructor if the subclass that implements <code>matchesSafely</code>
      * is <em>not</em> the class that binds &lt;T&gt; to a type.
      *
      * @param typeFinder A type finder to extract the type
      */
     protected TypeSafeMatcher(ReflectiveTypeFinder typeFinder) {
-      this.expectedType = typeFinder.findExpectedType(getClass()); 
+      this.expectedType = typeFinder.findExpectedType(getClass());
     }
- 
+
     /**
      * Subclasses should implement this. The item will already have been checked for
      * the specific type and will never be null.
@@ -52,7 +52,7 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
      * @return boolean true/false depending if item matches matcher.
      */
     protected abstract boolean matchesSafely(T item);
-    
+
     /**
      * Subclasses should override this. The item will already have been checked for
      * the specific type and will never be null.
@@ -65,7 +65,7 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
         super.describeMismatch(item, mismatchDescription);
     }
-    
+
     /**
      * Methods made final to prevent accidental override.
      * If you need to override this, there's no point on extending TypeSafeMatcher.
@@ -81,7 +81,7 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
                 && expectedType.isInstance(item)
                 && matchesSafely((T) item);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     final public void describeMismatch(Object item, Description description) {

--- a/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/TypeSafeMatcher.java
@@ -6,6 +6,8 @@ import org.hamcrest.internal.ReflectiveTypeFinder;
  * Convenient base class for Matchers that require a non-null value of a specific type.
  * This simply implements the null check, checks the type and then casts.
  *
+ * @param <T>
+ *     the matcher type.
  * @author Joe Walnes
  * @author Steve Freeman
  * @author Nat Pryce
@@ -33,7 +35,8 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
     
     /**
      * Use this constructor if the subclass that implements <code>matchesSafely</code> 
-     * is <em>not</em> the class that binds &lt;T&gt; to a type. 
+     * is <em>not</em> the class that binds &lt;T&gt; to a type.
+     *
      * @param typeFinder A type finder to extract the type
      */
     protected TypeSafeMatcher(ReflectiveTypeFinder typeFinder) {
@@ -44,6 +47,8 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
      * Subclasses should implement this. The item will already have been checked for
      * the specific type and will never be null.
      *
+     * @param item
+     *     the type safe item to match against.
      * @return boolean true/false depending if item matches matcher.
      */
     protected abstract boolean matchesSafely(T item);
@@ -51,6 +56,11 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
     /**
      * Subclasses should override this. The item will already have been checked for
      * the specific type and will never be null.
+     *
+     * @param item
+     *     the type safe item to match against.
+     * @param mismatchDescription
+     *     the mismatch description.
      */
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
         super.describeMismatch(item, mismatchDescription);
@@ -60,6 +70,9 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
      * Methods made final to prevent accidental override.
      * If you need to override this, there's no point on extending TypeSafeMatcher.
      * Instead, extend the {@link BaseMatcher}.
+     *
+     * @param item
+     *     the type safe item to match against.
      */
     @Override
     @SuppressWarnings({"unchecked"})

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasProperty.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasProperty.java
@@ -53,7 +53,7 @@ public class HasProperty<T> extends TypeSafeMatcher<T> {
      * @return The matcher.
      */
     public static <T> Matcher<T> hasProperty(String propertyName) {
-        return new HasProperty<T>(propertyName);
+        return new HasProperty<>(propertyName);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasProperty.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasProperty.java
@@ -46,6 +46,8 @@ public class HasProperty<T> extends TypeSafeMatcher<T> {
      * For example:
      * <pre>assertThat(myBean, hasProperty("foo"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param propertyName
      *     the name of the JavaBean property that examined beans should possess
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
@@ -37,7 +37,7 @@ import static org.hamcrest.beans.PropertyUtil.NO_ARGUMENTS;
  *     return name;
  *   }
  * }</pre>
- * 
+ *
  * And that these person objects are generated within a piece of code under test
  * (a class named PersonGenerator). This object is sent to one of our mock objects
  * which overrides the PersonGenerationListener interface:
@@ -45,14 +45,14 @@ import static org.hamcrest.beans.PropertyUtil.NO_ARGUMENTS;
  * public interface PersonGenerationListener {
  *   public void personGenerated(Person person);
  * }</pre>
- * 
+ *
  * In order to check that the code under test generates a person with name
  * "Iain" we would do the following:
  * <pre>
  * Mock personGenListenerMock = mock(PersonGenerationListener.class);
  * personGenListenerMock.expects(once()).method("personGenerated").with(and(isA(Person.class), hasProperty("Name", eq("Iain")));
  * PersonGenerationListener listener = (PersonGenerationListener)personGenListenerMock.proxy();</pre>
- * 
+ *
  * <p>If an exception is thrown by the getter method for a property, the property
  * does not exist, is not readable, or a reflection related exception is thrown
  * when trying to invoke it then this is treated as an evaluation failure and

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
@@ -71,7 +71,7 @@ import static org.hamcrest.beans.PropertyUtil.NO_ARGUMENTS;
  */
 public class HasPropertyWithValue<T> extends TypeSafeDiagnosingMatcher<T> {
 
-    private static final Condition.Step<PropertyDescriptor,Method> WITH_READ_METHOD = withReadMethod();
+    private static final Condition.Step<PropertyDescriptor, Method> WITH_READ_METHOD = withReadMethod();
     private final String propertyName;
     private final Matcher<Object> valueMatcher;
     private final String messageFormat;
@@ -136,7 +136,7 @@ public class HasPropertyWithValue<T> extends TypeSafeDiagnosingMatcher<T> {
         return (Matcher<Object>) valueMatcher;
     }
 
-    private static Condition.Step<PropertyDescriptor,Method> withReadMethod() {
+    private static Condition.Step<PropertyDescriptor, Method> withReadMethod() {
         return new Condition.Step<PropertyDescriptor, java.lang.reflect.Method>() {
             @Override
             public Condition<Method> apply(PropertyDescriptor property, Description mismatch) {

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
@@ -155,6 +155,8 @@ public class HasPropertyWithValue<T> extends TypeSafeDiagnosingMatcher<T> {
      * For example:
      * <pre>assertThat(myBean, hasProperty("foo", equalTo("bar"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param propertyName
      *     the name of the JavaBean property that examined beans should possess
      * @param valueMatcher
@@ -173,6 +175,8 @@ public class HasPropertyWithValue<T> extends TypeSafeDiagnosingMatcher<T> {
      * For example:
      * <pre>assertThat(myBean, hasProperty("foo.bar.baz", equalTo("a property value"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param path
      *     the dot-separated path from the examined object to the JavaBean property
      * @param valueMatcher

--- a/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java
@@ -70,6 +70,7 @@ import static org.hamcrest.beans.PropertyUtil.NO_ARGUMENTS;
  * @author cristcost at github
  */
 public class HasPropertyWithValue<T> extends TypeSafeDiagnosingMatcher<T> {
+
     private static final Condition.Step<PropertyDescriptor,Method> WITH_READ_METHOD = withReadMethod();
     private final String propertyName;
     private final Matcher<Object> valueMatcher;

--- a/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
@@ -52,4 +52,5 @@ public class PropertyUtil {
     }
 
     public static final Object[] NO_ARGUMENTS = new Object[0];
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
@@ -18,6 +18,10 @@ public class PropertyUtil {
      * Returns the description of the property with the provided
      * name on the provided object's interface.
      *
+     * @param propertyName
+     *     the bean property name.
+     * @param fromObj
+     *     the object to check.
      * @return the descriptor of the property, or null if the property does not exist.
      * @throws IllegalArgumentException if there's a introspection failure
      */

--- a/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/PropertyUtil.java
@@ -14,6 +14,7 @@ import java.beans.PropertyDescriptor;
  * @since 1.1.0
  */
 public class PropertyUtil {
+
     /**
      * Returns the description of the property with the provided
      * name on the provided object's interface.

--- a/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
@@ -46,7 +46,6 @@ public class SamePropertyValuesAs<T> extends DiagnosingMatcher<T> {
         }
     }
 
-
     private boolean isCompatibleType(Object actual, Description mismatchDescription) {
         if (expectedBean.getClass().isAssignableFrom(actual.getClass())) {
             return true;

--- a/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
@@ -147,6 +147,8 @@ public class SamePropertyValuesAs<T> extends DiagnosingMatcher<T> {
      * <pre>assertThat(myBean, samePropertyValuesAs(myExpectedBean))</pre>
      * <pre>assertThat(myBean, samePropertyValuesAs(myExpectedBean), "age", "height")</pre>
      *
+     * @param <B>
+     *     the matcher type.
      * @param expectedBean
      *     the bean against which examined beans are compared
      * @param ignoredProperties

--- a/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/beans/SamePropertyValuesAs.java
@@ -14,6 +14,7 @@ import static org.hamcrest.beans.PropertyUtil.propertyDescriptorsFor;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class SamePropertyValuesAs<T> extends DiagnosingMatcher<T> {
+
     private final T expectedBean;
     private final Set<String> propertyNames;
     private final List<PropertyMatcher> propertyMatchers;

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayAsIterableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayAsIterableMatcher.java
@@ -42,4 +42,5 @@ public class ArrayAsIterableMatcher<E> extends TypeSafeMatcher<E[]> {
       description.appendList("[", ", ", "]", matchers)
           .appendText(" ").appendText(message);
   }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayAsIterableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayAsIterableMatcher.java
@@ -13,6 +13,7 @@ import static java.util.Arrays.asList;
  * @author Steve Freeman 2016 http://www.hamcrest.com
  */
 public class ArrayAsIterableMatcher<E> extends TypeSafeMatcher<E[]> {
+
   protected final TypeSafeDiagnosingMatcher<Iterable<? extends E>> iterableMatcher;
   private final String message;
   protected final Collection<Matcher<? super E>> matchers;

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
@@ -24,6 +24,8 @@ public class ArrayMatching {
    * For example:
    * <pre>assertThat(new String[] {"foo", "bar"}, hasItemInArray(startsWith("ba")))</pre>
    *
+   * @param <T>
+   *     the matcher type.
    * @param elementMatcher
    *     the matcher to apply to elements in examined arrays
    * @return The matcher.
@@ -39,6 +41,8 @@ public class ArrayMatching {
    * instead of:
    * <pre>assertThat(hasItemInArray(equalTo(x)))</pre>
    *
+   * @param <T>
+   *     the matcher type.
    * @param element
    *     the element that should be present in examined arrays
    * @return The matcher.
@@ -64,6 +68,8 @@ public class ArrayMatching {
    * </p>
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by an entry in an examined array
    * @return The matcher.
@@ -90,6 +96,8 @@ public class ArrayMatching {
    * </p>
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by an item provided by an examined array
    * @return The matcher.
@@ -113,6 +121,8 @@ public class ArrayMatching {
    * </p>
    * <pre>assertThat(new String[]{"foo", "bar"}, containsInAnyOrder("bar", "foo"))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @param items
    *     the items that must equal the entries of an examined array, in any order
    * @return The matcher.
@@ -129,6 +139,8 @@ public class ArrayMatching {
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, contains("foo", "bar"))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @param items
    *     the items that must equal the items within an examined array
    * @return The matcher.
@@ -144,6 +156,8 @@ public class ArrayMatching {
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContaining(equalTo("foo"), equalTo("bar")))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     the matchers that must be satisfied by the items in the examined array
    * @return The matcher.
@@ -164,6 +178,8 @@ public class ArrayMatching {
    * For example:
    * <pre>assertThat(new String[]{"foo", "bar"}, arrayContaining(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
    *
+   * @param <E>
+   *     the matcher type.
    * @param itemMatchers
    *     a list of matchers, each of which must be satisfied by the corresponding item in an examined array
    * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
@@ -16,7 +16,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
  */
 public class ArrayMatching {
 
-
   /**
    * Creates a matcher for arrays that matches when the examined array contains at least one item
    * that is matched by the specified <code>elementMatcher</code>.  Whilst matching, the traversal

--- a/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/ArrayMatching.java
@@ -195,5 +195,5 @@ public class ArrayMatching {
     }
     return matchers;
   }
-}
 
+}

--- a/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
@@ -12,6 +12,7 @@ import static java.util.Arrays.asList;
  * Matches if an array contains an item satisfying a nested matcher.
  */
 public class HasItemInArray<T> extends TypeSafeMatcher<T[]> {
+
     private final Matcher<? super T> elementMatcher;
     private final TypeSafeDiagnosingMatcher<Iterable<? super T>> collectionMatcher;
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
@@ -24,7 +24,7 @@ public class HasItemInArray<T> extends TypeSafeMatcher<T[]> {
     public boolean matchesSafely(T[] actual) {
         return collectionMatcher.matches(asList(actual));
     }
-    
+
     @Override
     public void describeMismatchSafely(T[] actual, Description mismatchDescription) {
         collectionMatcher.describeMismatch(asList(actual), mismatchDescription);

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
@@ -12,19 +12,19 @@ import java.util.Arrays;
  */
 public class IsArray<T> extends TypeSafeMatcher<T[]> {
     private final Matcher<? super T>[] elementMatchers;
-    
+
     public IsArray(Matcher<? super T>[] elementMatchers) {
         this.elementMatchers = elementMatchers.clone();
     }
-    
+
     @Override
     public boolean matchesSafely(T[] array) {
         if (array.length != elementMatchers.length) return false;
-        
+
         for (int i = 0; i < array.length; i++) {
             if (!elementMatchers[i].matches(array[i])) return false;
         }
-        
+
         return true;
     }
 
@@ -46,10 +46,10 @@ public class IsArray<T> extends TypeSafeMatcher<T[]> {
     @Override
     @SuppressWarnings("unchecked")
     public void describeTo(Description description) {
-        description.appendList(descriptionStart(), descriptionSeparator(), descriptionEnd(), 
+        description.appendList(descriptionStart(), descriptionSeparator(), descriptionEnd(),
                                Arrays.asList(elementMatchers));
     }
-    
+
     /**
      * Returns the string that starts the description.
      *
@@ -85,7 +85,7 @@ public class IsArray<T> extends TypeSafeMatcher<T[]> {
     protected String descriptionEnd() {
         return "]";
     }
-    
+
     /**
      * Creates a matcher that matches arrays whose elements are satisfied by the specified matchers.  Matches
      * positively only if the number of matchers specified is equal to the length of the examined array and

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
  * The array size must equal the number of element matchers.
  */
 public class IsArray<T> extends TypeSafeMatcher<T[]> {
+
     private final Matcher<? super T>[] elementMatchers;
 
     public IsArray(Matcher<? super T>[] elementMatchers) {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
@@ -101,7 +101,7 @@ public class IsArray<T> extends TypeSafeMatcher<T[]> {
      * @return The matcher.
      */
     public static <T> IsArray<T> array(Matcher<? super T>... elementMatchers) {
-        return new IsArray<T>(elementMatchers);
+        return new IsArray<>(elementMatchers);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArray.java
@@ -93,6 +93,8 @@ public class IsArray<T> extends TypeSafeMatcher<T[]> {
      * For example:
      * <pre>assertThat(new Integer[]{1,2,3}, is(array(equalTo(1), equalTo(2), equalTo(3))))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param elementMatchers
      *     the matchers that the elements of examined arrays should satisfy
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -16,6 +16,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  */
 @Deprecated
 public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
+
     private final IsIterableContainingInAnyOrder<E> iterableMatcher;
     private final Collection<Matcher<? super E>> matchers;
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -21,7 +21,7 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
     private final Collection<Matcher<? super E>> matchers;
 
     public IsArrayContainingInAnyOrder(Collection<Matcher<? super E>> matchers) {
-        this.iterableMatcher = new IsIterableContainingInAnyOrder<E>(matchers);
+        this.iterableMatcher = new IsIterableContainingInAnyOrder<>(matchers);
         this.matchers = matchers;
     }
 
@@ -86,7 +86,7 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      * @return The matcher.
      */
     public static <E> Matcher<E[]> arrayContainingInAnyOrder(Collection<Matcher<? super E>> itemMatchers) {
-        return new IsArrayContainingInAnyOrder<E>(itemMatchers);
+        return new IsArrayContainingInAnyOrder<>(itemMatchers);
     }
 
     /**
@@ -110,11 +110,11 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      * @return The matcher.
      */
     public static <E> Matcher<E[]> arrayContainingInAnyOrder(E... items) {
-      List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
+      List<Matcher<? super E>> matchers = new ArrayList<>();
       for (E item : items) {
           matchers.add(equalTo(item));
       }
-      return new IsArrayContainingInAnyOrder<E>(matchers);
+      return new IsArrayContainingInAnyOrder<>(matchers);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -28,7 +28,7 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
     public boolean matchesSafely(E[] item) {
         return iterableMatcher.matches(Arrays.asList(item));
     }
-    
+
     @Override
     public void describeMismatchSafely(E[] item, Description mismatchDescription) {
       iterableMatcher.describeMismatch(Arrays.asList(item), mismatchDescription);

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -54,7 +54,8 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
      *
      * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContainingInAnyOrder(Matcher[])}.
-     *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an entry in an examined array
      * @return The matcher.
@@ -77,7 +78,8 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      * <pre>assertThat(new String[]{"foo", "bar"}, arrayContainingInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
      *
      * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContainingInAnyOrder(Collection)}.
-     *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an item provided by an examined array
      * @return The matcher.
@@ -100,7 +102,8 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
      * <pre>assertThat(new String[]{"foo", "bar"}, containsInAnyOrder("bar", "foo"))</pre>
      *
      * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContainingInAnyOrder(Object[])}.
-     *
+     * @param <E>
+     *     the matcher type.
      * @param items
      *     the items that must equal the entries of an examined array, in any order
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
@@ -115,4 +115,5 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
       }
       return new IsArrayContainingInAnyOrder<E>(matchers);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -98,4 +98,5 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
     public static <E> Matcher<E[]> arrayContaining(List<Matcher<? super E>> itemMatchers) {
         return new IsArrayContainingInOrder<E>(itemMatchers);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -47,7 +47,8 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      * <pre>assertThat(new String[]{"foo", "bar"}, contains("foo", "bar"))</pre>
      *
      * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContaining(Object[])}.
-     *
+     * @param <E>
+     *     the matcher type.
      * @param items
      *     the items that must equal the items within an examined array
      * @return The matcher.
@@ -69,7 +70,8 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      * <pre>assertThat(new String[]{"foo", "bar"}, contains(equalTo("foo"), equalTo("bar")))</pre>
      *
      * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContaining(Matcher[])}.
-     *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     the matchers that must be satisfied by the items in the examined array
      * @return The matcher.
@@ -87,7 +89,8 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      * <pre>assertThat(new String[]{"foo", "bar"}, contains(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
      *
      * @deprecated As of version 2.1, use {@link ArrayMatching#arrayContaining(List)}.
-     *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by the corresponding item in an examined array
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -15,6 +15,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * @deprecated As of release 2.1, replaced by {@link ArrayMatching}.
  */
 public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
+
     private final Collection<Matcher<? super E>> matchers;
     private final IsIterableContainingInOrder<E> iterableMatcher;
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -27,7 +27,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
     public boolean matchesSafely(E[] item) {
         return iterableMatcher.matches(asList(item));
     }
-    
+
     @Override
     public void describeMismatchSafely(E[] item, Description mismatchDescription) {
       iterableMatcher.describeMismatch(asList(item), mismatchDescription);

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
@@ -20,7 +20,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
     private final IsIterableContainingInOrder<E> iterableMatcher;
 
     public IsArrayContainingInOrder(List<Matcher<? super E>> matchers) {
-        this.iterableMatcher = new IsIterableContainingInOrder<E>(matchers);
+        this.iterableMatcher = new IsIterableContainingInOrder<>(matchers);
         this.matchers = matchers;
     }
 
@@ -55,7 +55,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      * @return The matcher.
      */
     public static <E> Matcher<E[]> arrayContaining(E... items) {
-        List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>();
+        List<Matcher<? super E>> matchers = new ArrayList<>();
         for (E item : items) {
             matchers.add(equalTo(item));
         }
@@ -97,7 +97,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
      * @return The matcher.
      */
     public static <E> Matcher<E[]> arrayContaining(List<Matcher<? super E>> itemMatchers) {
-        return new IsArrayContainingInOrder<E>(itemMatchers);
+        return new IsArrayContainingInOrder<>(itemMatchers);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
@@ -10,6 +10,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * Matches if array size satisfies a nested matcher.
  */
 public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
+
     public IsArrayWithSize(Matcher<? super Integer> sizeMatcher) {
         super(sizeMatcher, "an array with size","array size");
     }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
@@ -24,7 +24,8 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
      * satisfies the specified matcher.
      * For example:
      * <pre>assertThat(new String[]{"foo", "bar"}, arrayWithSize(equalTo(2)))</pre>
-     *
+     * @param <E>
+     *     the matcher type.
      * @param sizeMatcher
      *     a matcher for the length of an examined array
      * @return The matcher.
@@ -39,6 +40,8 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
      * For example:
      * <pre>assertThat(new String[]{"foo", "bar"}, arrayWithSize(2))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param size
      *     the length that an examined array must have for a positive match
      * @return The matcher.
@@ -53,6 +56,8 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
      * For example:
      * <pre>assertThat(new String[0], emptyArray())</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @return The matcher.
      */
     public static <E> Matcher<E[]> emptyArray() {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsArrayWithSize.java
@@ -63,4 +63,5 @@ public class IsArrayWithSize<E> extends FeatureMatcher<E[], Integer> {
     public static <E> Matcher<E[]> emptyArray() {
         return describedAs("an empty array", IsArrayWithSize.<E>arrayWithSize(0));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -26,6 +26,8 @@ public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(equalTo(2)))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param sizeMatcher
      *     a matcher for the size of an examined {@link java.util.Collection}
      * @return The matcher.
@@ -40,6 +42,8 @@ public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasSize(2))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param size
      *     the expected size of an examined {@link java.util.Collection}
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -11,6 +11,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * Matches if collection size satisfies a nested matcher.
  */
 public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends E>, Integer> {
+
     public IsCollectionWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a collection with size", "collection size");
     }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsCollectionWithSize.java
@@ -34,7 +34,7 @@ public class IsCollectionWithSize<E> extends FeatureMatcher<Collection<? extends
      * @return The matcher.
      */
     public static <E> Matcher<Collection<? extends E>> hasSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsCollectionWithSize<E>(sizeMatcher);
+        return new IsCollectionWithSize<>(sizeMatcher);
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -37,7 +37,7 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * @return The matcher.
      */
     public static <E> Matcher<Collection<? extends E>> empty() {
-        return new IsEmptyCollection<E>();
+        return new IsEmptyCollection<>();
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -32,6 +32,8 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(empty()))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @return The matcher.
      */
     public static <E> Matcher<Collection<? extends E>> empty() {
@@ -44,6 +46,8 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyCollectionOf(String.class)))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param unusedToForceReturnType
      *     the type of the collection's content
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyCollection.java
@@ -56,4 +56,5 @@ public class IsEmptyCollection<E> extends TypeSafeMatcher<Collection<? extends E
     public static <E> Matcher<Collection<E>> emptyCollectionOf(Class<E> unusedToForceReturnType) {
       return (Matcher)empty();
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
@@ -51,4 +51,5 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
     public static <E> Matcher<Iterable<E>> emptyIterableOf(Class<E> unusedToForceReturnType) {
       return (Matcher)emptyIterable();
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
@@ -33,7 +33,7 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * @return The matcher.
      */
     public static <E> Matcher<Iterable<? extends E>> emptyIterable() {
-        return new IsEmptyIterable<E>();
+        return new IsEmptyIterable<>();
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsEmptyIterable.java
@@ -28,6 +28,8 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterable()))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @return The matcher.
      */
     public static <E> Matcher<Iterable<? extends E>> emptyIterable() {
@@ -39,6 +41,8 @@ public class IsEmptyIterable<E> extends TypeSafeMatcher<Iterable<? extends E>> {
      * For example:
      * <pre>assertThat(new ArrayList&lt;String&gt;(), is(emptyIterableOf(String.class)))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param unusedToForceReturnType
      *     the type of the iterable's content
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
@@ -13,11 +13,11 @@ public class IsIn<T> extends BaseMatcher<T> {
     public IsIn(Collection<T> collection) {
         this.collection = collection;
     }
-    
+
     public IsIn(T[] elements) {
         collection = Arrays.asList(elements);
     }
-    
+
     @SuppressWarnings("SuspiciousMethodCalls")
     @Override
     public boolean matches(Object o) {
@@ -29,7 +29,7 @@ public class IsIn<T> extends BaseMatcher<T> {
         buffer.appendText("one of ");
         buffer.appendValueList("{", ", ", "}", collection);
     }
-    
+
     /**
      * Creates a matcher that matches when the examined object is found within the
      * specified collection.
@@ -47,7 +47,7 @@ public class IsIn<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> isIn(Collection<T> collection) {
         return in(collection);
     }
-    
+
     /**
      * Creates a matcher that matches when the examined object is found within the
      * specified collection.
@@ -81,7 +81,7 @@ public class IsIn<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> isIn(T[] elements) {
         return in(elements);
     }
-    
+
     /**
      * Creates a matcher that matches when the examined object is found within the
      * specified array.
@@ -97,7 +97,7 @@ public class IsIn<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> in(T[] elements) {
         return new IsIn<>(elements);
     }
-    
+
     /**
      * Creates a matcher that matches when the examined object is equal to one of the
      * specified elements.
@@ -116,7 +116,7 @@ public class IsIn<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> isOneOf(T... elements) {
         return oneOf(elements);
     }
-    
+
     /**
      * Creates a matcher that matches when the examined object is equal to one of the
      * specified elements.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
@@ -37,7 +37,8 @@ public class IsIn<T> extends BaseMatcher<T> {
      * <pre>assertThat("foo", isIn(Arrays.asList("bar", "foo")))</pre>
      *
      * @deprecated use is(in(...)) instead
-     *
+     * @param <T>
+     *     the matcher type.
      * @param collection
      *     the collection in which matching items must be found
      * @return The matcher.
@@ -53,6 +54,8 @@ public class IsIn<T> extends BaseMatcher<T> {
      * For example:
      * <pre>assertThat("foo", is(in(Arrays.asList("bar", "foo"))))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param collection
      *     the collection in which matching items must be found
      * @return The matcher.
@@ -68,7 +71,8 @@ public class IsIn<T> extends BaseMatcher<T> {
      * <pre>assertThat("foo", isIn(new String[]{"bar", "foo"}))</pre>
      *
      * @deprecated use is(in(...)) instead
-     *
+     * @param <T>
+     *     the matcher type.
      * @param elements
      *     the array in which matching items must be found
      * @return The matcher.
@@ -84,6 +88,8 @@ public class IsIn<T> extends BaseMatcher<T> {
      * For example:
      * <pre>assertThat("foo", is(in(new String[]{"bar", "foo"})))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param elements
      *     the array in which matching items must be found
      * @return The matcher.
@@ -99,7 +105,8 @@ public class IsIn<T> extends BaseMatcher<T> {
      * <pre>assertThat("foo", isOneOf("bar", "foo"))</pre>
      *
      * @deprecated use is(oneOf(...)) instead
-     *
+     * @param <T>
+     *     the matcher type.
      * @param elements
      *     the elements amongst which matching items will be found
      * @return The matcher.
@@ -116,6 +123,8 @@ public class IsIn<T> extends BaseMatcher<T> {
      * For example:
      * <pre>assertThat("foo", is(oneOf("bar", "foo")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param elements
      *     the elements amongst which matching items will be found
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
@@ -133,4 +133,5 @@ public class IsIn<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> oneOf(T... elements) {
         return in(elements);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIn.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class IsIn<T> extends BaseMatcher<T> {
+
     private final Collection<T> collection;
 
     public IsIn(Collection<T> collection) {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -17,7 +17,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
     public IsIterableContainingInAnyOrder(Collection<Matcher<? super T>> matchers) {
         this.matchers = matchers;
     }
-    
+
     @Override
     protected boolean matchesSafely(Iterable<? extends T> items, Description mismatchDescription) {
       final Matching<T> matching = new Matching<>(matchers, mismatchDescription);
@@ -26,10 +26,10 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
           return false;
         }
       }
-      
+
       return matching.isFinished(items);
     }
-    
+
     @Override
     public void describeTo(Description description) {
       description.appendText("iterable with items ")
@@ -45,7 +45,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
         this.matchers = new ArrayList<>(matchers);
         this.mismatchDescription = mismatchDescription;
       }
-      
+
       public boolean matches(S item) {
         if (matchers.isEmpty()) {
           mismatchDescription.appendText("no match for: ").appendValue(item);
@@ -133,7 +133,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
         for (T item : items) {
             matchers.add(equalTo(item));
         }
-        
+
         return new IsIterableContainingInAnyOrder<>(matchers);
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
+
     private final Collection<Matcher<? super T>> matchers;
 
     public IsIterableContainingInAnyOrder(Collection<Matcher<? super T>> matchers) {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -131,10 +131,17 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
     @SafeVarargs
     public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(T... items) {
         List<Matcher<? super T>> matchers = new ArrayList<>();
-        for (T item : items) {
+        if (items.length == 1 && items[0].getClass().isArray()) {
+          @SuppressWarnings("unchecked")
+          T[] realItems = (T[]) items[0];
+          for (T item : realItems) {
             matchers.add(equalTo(item));
+          }
+        } else {
+          for (T item : items) {
+              matchers.add(equalTo(item));
+          }
         }
-
         return new IsIterableContainingInAnyOrder<>(matchers);
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -161,5 +161,5 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
     public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(Collection<Matcher<? super T>> itemMatchers) {
         return new IsIterableContainingInAnyOrder<>(itemMatchers);
     }
-}
 
+}

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -93,6 +93,8 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * </p>
      * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder(equalTo("bar"), equalTo("foo")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
      * @return The matcher.
@@ -119,6 +121,8 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * </p>
      * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder("bar", "foo"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param items
      *     the items that must equal the items provided by an examined {@link Iterable} in any order
      * @return The matcher.
@@ -148,6 +152,8 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      * <p>For example:</p>
      * <pre>assertThat(Arrays.asList("foo", "bar"), containsInAnyOrder(Arrays.asList(equalTo("bar"), equalTo("foo"))))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by an item provided by an examined {@link Iterable}
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -12,6 +12,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.collection.ArrayMatching.asEqualMatchers;
 
 public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<Iterable<? extends E>> {
+
     private final List<Matcher<? super E>> matchers;
 
     public IsIterableContainingInOrder(List<Matcher<? super E>> matchers) {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -89,6 +89,8 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), contains("foo", "bar"))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param items
      *     the items that must equal the items provided by an examined {@link Iterable}
      * @return The matcher.
@@ -105,6 +107,8 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * For example:
      * <pre>assertThat(Arrays.asList("foo"), contains(equalTo("foo")))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatcher
      *     the matcher that must be satisfied by the single item provided by an
      *     examined {@link Iterable}
@@ -123,6 +127,8 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), contains(equalTo("foo"), equalTo("bar")))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     the matchers that must be satisfied by the items provided by an examined {@link Iterable}
      * @return The matcher.
@@ -143,6 +149,8 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), contains(Arrays.asList(equalTo("foo"), equalTo("bar"))))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by the corresponding item provided by
      *     an examined {@link Iterable}

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -159,4 +159,5 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
     public static <E> Matcher<Iterable<? extends E>> contains(List<Matcher<? super E>> itemMatchers) {
         return new IsIterableContainingInOrder<>(itemMatchers);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -98,6 +98,11 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      */
     @SafeVarargs
     public static <E> Matcher<Iterable<? extends E>> contains(E... items) {
+        if (items.length == 1 && items[0].getClass().isArray()) {
+            @SuppressWarnings("unchecked")
+            E[] realItems = (E[]) items[0];
+            return contains(asEqualMatchers(realItems));
+        }
         return contains(asEqualMatchers(items));
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInRelativeOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInRelativeOrder.java
@@ -125,4 +125,5 @@ public class IsIterableContainingInRelativeOrder<E> extends TypeSafeDiagnosingMa
     public static <E> Matcher<Iterable<? extends E>> containsInRelativeOrder(List<Matcher<? super E>> itemMatchers) {
         return new IsIterableContainingInRelativeOrder<>(itemMatchers);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInRelativeOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInRelativeOrder.java
@@ -74,6 +74,8 @@ public class IsIterableContainingInRelativeOrder<E> extends TypeSafeDiagnosingMa
      * For example:
      * <pre>assertThat(Arrays.asList("a", "b", "c", "d", "e"), containsInRelativeOrder("b", "d"))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param items
      *     the items that must be contained within items provided by an examined {@link Iterable} in the same relative order
      * @return The matcher.
@@ -95,6 +97,8 @@ public class IsIterableContainingInRelativeOrder<E> extends TypeSafeDiagnosingMa
      * For example:
      * <pre>assertThat(Arrays.asList("a", "b", "c", "d", "e"), containsInRelativeOrder(equalTo("b"), equalTo("d")))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     the matchers that must be satisfied by the items provided by an examined {@link Iterable} in the same relative order
      * @return The matcher.
@@ -111,6 +115,8 @@ public class IsIterableContainingInRelativeOrder<E> extends TypeSafeDiagnosingMa
      * For example:
      * <pre>assertThat(Arrays.asList("a", "b", "c", "d", "e"), contains(Arrays.asList(equalTo("b"), equalTo("d"))))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param itemMatchers
      *     a list of matchers, each of which must be satisfied by the items provided by
      *     an examined {@link Iterable} in the same relative order

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -56,4 +56,5 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
     public static <E> Matcher<Iterable<E>> iterableWithSize(int size) {
         return iterableWithSize(equalTo(size));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -30,6 +30,8 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), iterableWithSize(equalTo(2)))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param sizeMatcher
      *     a matcher for the number of items that should be yielded by an examined {@link Iterable}
      * @return The matcher.
@@ -45,6 +47,8 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), iterableWithSize(2))</pre>
      *
+     * @param <E>
+     *     the matcher type.
      * @param size
      *     the number of items that should be yielded by an examined {@link Iterable}
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -13,7 +13,6 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
         super(sizeMatcher, "an iterable with size", "iterable size");
     }
 
-
     @Override
     protected Integer featureValueOf(Iterable<E> actual) {
       int size = 0;

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -36,7 +36,7 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
      * @return The matcher.
      */
     public static <E> Matcher<Iterable<E>> iterableWithSize(Matcher<? super Integer> sizeMatcher) {
-        return new IsIterableWithSize<E>(sizeMatcher);
+        return new IsIterableWithSize<>(sizeMatcher);
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableWithSize.java
@@ -12,7 +12,7 @@ public class IsIterableWithSize<E> extends FeatureMatcher<Iterable<E>, Integer> 
     public IsIterableWithSize(Matcher<? super Integer> sizeMatcher) {
         super(sizeMatcher, "an iterable with size", "iterable size");
     }
-    
+
 
     @Override
     protected Integer featureValueOf(Iterable<E> actual) {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -10,7 +10,7 @@ import java.util.Map.Entry;
 import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? extends V>> {
+public class IsMapContaining<K, V> extends TypeSafeMatcher<Map<? extends K, ? extends V>> {
 
     private final Matcher<? super K> keyMatcher;
     private final Matcher<? super V> valueMatcher;
@@ -61,7 +61,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      *     the value matcher that, in combination with the keyMatcher, must be satisfied by at least one entry
      * @return The matcher.
      */
-    public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
+    public static <K, V> Matcher<Map<? extends K, ? extends V>> hasEntry(Matcher<? super K> keyMatcher, Matcher<? super V> valueMatcher) {
         return new IsMapContaining<>(keyMatcher, valueMatcher);
     }
 
@@ -82,7 +82,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      *     the value that, in combination with the key, must be describe at least one entry
      * @return The matcher.
      */
-    public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(K key, V value) {
+    public static <K, V> Matcher<Map<? extends K, ? extends V>> hasEntry(K key, V value) {
         return new IsMapContaining<>(equalTo(key), equalTo(value));
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -50,6 +50,10 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * For example:
      * <pre>assertThat(myMap, hasEntry(equalTo("bar"), equalTo("foo")))</pre>
      *
+     * @param <K>
+     *     the map key type.
+     * @param <V>
+     *     the map value type.
      * @param keyMatcher
      *     the key matcher that, in combination with the valueMatcher, must be satisfied by at least one entry
      * @param valueMatcher
@@ -67,6 +71,10 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * For example:
      * <pre>assertThat(myMap, hasEntry("bar", "foo"))</pre>
      *
+     * @param <K>
+     *     the map key type.
+     * @param <V>
+     *     the map value type.
      * @param key
      *     the key that, in combination with the value, must be describe at least one entry
      * @param value
@@ -83,6 +91,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * For example:
      * <pre>assertThat(myMap, hasKey(equalTo("bar")))</pre>
      *
+     * @param <K>
+     *     the map key type.
      * @param keyMatcher
      *     the matcher that must be satisfied by at least one key
      * @return The matcher.
@@ -97,6 +107,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * For example:
      * <pre>assertThat(myMap, hasKey("bar"))</pre>
      *
+     * @param <K>
+     *     the map key type.
      * @param key
      *     the key that satisfying maps must contain
      * @return The matcher.
@@ -111,6 +123,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * For example:
      * <pre>assertThat(myMap, hasValue(equalTo("foo")))</pre>
      *
+     * @param <V>
+     *     the value type.
      * @param valueMatcher
      *     the matcher that must be satisfied by at least one value
      * @return The matcher.
@@ -125,6 +139,8 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
      * For example:
      * <pre>assertThat(myMap, hasValue("foo"))</pre>
      *
+     * @param <V>
+     *     the value type.
      * @param value
      *     the value that satisfying maps must contain
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -148,4 +148,5 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
     public static <V> Matcher<Map<?, ? extends V>> hasValue(V value) {
         return new IsMapContaining<>(anything(), equalTo(value));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -11,6 +11,7 @@ import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? extends V>> {
+
     private final Matcher<? super K> keyMatcher;
     private final Matcher<? super V> valueMatcher;
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapContaining.java
@@ -84,7 +84,7 @@ public class IsMapContaining<K,V> extends TypeSafeMatcher<Map<? extends K, ? ext
     public static <K,V> Matcher<Map<? extends K,? extends V>> hasEntry(K key, V value) {
         return new IsMapContaining<>(equalTo(key), equalTo(value));
     }
-    
+
     /**
      * Creates a matcher for {@link java.util.Map}s matching when the examined {@link java.util.Map} contains
      * at least one key that satisfies the specified matcher.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -27,6 +27,10 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * For example:
      * <pre>assertThat(myMap, is(aMapWithSize(equalTo(2))))</pre>
      *
+     * @param <K>
+     *     the map key type.
+     * @param <V>
+     *     the map value type.
      * @param sizeMatcher
      *     a matcher for the size of an examined {@link java.util.Map}
      * @return The matcher.
@@ -41,6 +45,10 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * For example:
      * <pre>assertThat(myMap, is(aMapWithSize(2)))</pre>
      *
+     * @param <K>
+     *     the map key type.
+     * @param <V>
+     *     the map value type.
      * @param size
      *     the expected size of an examined {@link java.util.Map}
      * @return The matcher.
@@ -55,6 +63,10 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
      * For example:
      * <pre>assertThat(myMap, is(anEmptyMap()))</pre>
      *
+     * @param <K>
+     *     the map key type.
+     * @param <V>
+     *     the map value type.
      * @return The matcher.
      */
     public static <K, V> Matcher<Map<? extends K, ? extends V>> anEmptyMap() {

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -72,4 +72,5 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
     public static <K, V> Matcher<Map<? extends K, ? extends V>> anEmptyMap() {
         return IsMapWithSize.aMapWithSize(equalTo(0));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -56,7 +56,7 @@ public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ?
     public static <K, V> Matcher<Map<? extends K, ? extends V>> aMapWithSize(int size) {
         return IsMapWithSize.aMapWithSize(equalTo(size));
     }
-    
+
     /**
      * Creates a matcher for {@link java.util.Map}s that matches when the <code>size()</code> method returns
      * zero.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsMapWithSize.java
@@ -11,6 +11,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * Matches if map size satisfies a nested matcher.
  */
 public final class IsMapWithSize<K, V> extends FeatureMatcher<Map<? extends K, ? extends V>, Integer> {
+
     @SuppressWarnings("WeakerAccess")
     public IsMapWithSize(Matcher<? super Integer> sizeMatcher) {
       super(sizeMatcher, "a map with size", "map size");

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsUnmodifiableCollection.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsUnmodifiableCollection.java
@@ -1,0 +1,176 @@
+package org.hamcrest.collection;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Matches if collection is truly unmodifiable
+ */
+public class IsUnmodifiableCollection<E> extends TypeSafeDiagnosingMatcher<Collection<? extends E>> {
+
+    private static final Map<Class, Object> DEFAULT_COLLECTIONS = new HashMap<>();
+
+    static {
+        final List<String> list = Arrays.asList("a", "b", "c");
+        DEFAULT_COLLECTIONS.put(Collection.class, list);
+        DEFAULT_COLLECTIONS.put(List.class, list);
+        DEFAULT_COLLECTIONS.put(Set.class, new HashSet<>(list));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected boolean matchesSafely(final Collection collection, final Description mismatchDescription) {
+        final Class<? extends Collection> collectionClass = collection.getClass();
+        final Collection item = getInstanceOfType(collectionClass);
+        if (item == null) {
+            throw failedToInstantiateItem(collectionClass, null);
+        }
+        final Object testObject = new Object();
+        final Set<Object> singletonList = Collections.singleton(testObject);
+
+        try {
+            item.add(testObject);
+            mismatchDescription.appendText("was able to add a value into the collection");
+            return false;
+        } catch (Exception ignore) {
+        }
+
+        try {
+            item.addAll(singletonList);
+            mismatchDescription.appendText("was able to perform addAll on the collection");
+            return false;
+        } catch (Exception ignore) {
+        }
+
+        try {
+            item.remove(testObject);
+            mismatchDescription.appendText("was able to remove a value from the collection");
+            return false;
+        } catch (Exception ignore) {
+        }
+
+        try {
+            item.removeAll(singletonList);
+            mismatchDescription.appendText("was able to perform removeAll on the collection");
+            return false;
+        } catch (Exception ignore) {
+        }
+
+        try {
+            item.retainAll(singletonList);
+            mismatchDescription.appendText("was able to perform retainAll on the collection");
+            return false;
+        } catch (Exception ignore) {
+        }
+
+        try {
+            item.clear();
+            mismatchDescription.appendText("was able to clear the collection");
+            return false;
+        } catch (Exception ignore) {
+        }
+
+        return true;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private <T> T getInstanceOfType(final Class<T> clazz) {
+        Exception lastException = null;
+
+        if (clazz.isArray()) {
+            return (T) Array.newInstance(clazz, 0);
+        }
+
+        if (clazz.isPrimitive()) {
+            if (Byte.TYPE.isAssignableFrom(clazz)) {
+                return (T) Byte.valueOf((byte) 1);
+            }
+            if (Short.TYPE.isAssignableFrom(clazz)) {
+                return (T) Short.valueOf((short) 1);
+            }
+            if (Integer.TYPE.isAssignableFrom(clazz)) {
+                return (T) Integer.valueOf(1);
+            }
+            if (Long.TYPE.isAssignableFrom(clazz)) {
+                return (T) Long.valueOf(1L);
+            }
+            if (Float.TYPE.isAssignableFrom(clazz)) {
+                return (T) Float.valueOf(1L);
+            }
+            if (Double.TYPE.isAssignableFrom(clazz)) {
+                return (T) Double.valueOf(1L);
+            }
+            if (Boolean.TYPE.isAssignableFrom(clazz)) {
+                return (T) Boolean.valueOf(true);
+            }
+            if (Character.TYPE.isAssignableFrom(clazz)) {
+                return (T) Character.valueOf(' ');
+            }
+        }
+
+        if (clazz.isInterface()) {
+            Object defaultCollection = DEFAULT_COLLECTIONS.get(clazz);
+            if (defaultCollection != null) {
+                return (T) defaultCollection;
+            }
+            return null;
+        }
+
+        // For the most part of implementations there probably won't be any default constructor
+        final Constructor<?>[] declaredConstructors = clazz.getDeclaredConstructors();
+        // First take constructor with fewer number of arguments
+        Arrays.sort(declaredConstructors, new Comparator<Constructor<?>>() {
+            @Override
+            public int compare(Constructor<?> o1, Constructor<?> o2) {
+                return Integer.compare(o2.getParameterTypes().length, o1.getParameterTypes().length);
+            }
+        });
+        for (Constructor<?> declaredConstructor : declaredConstructors) {
+            declaredConstructor.setAccessible(true);
+            final int parametersNumber = declaredConstructor.getParameterTypes().length;
+
+            Object[] arguments = new Object[parametersNumber];
+            for (int argumentIndex = 0; argumentIndex < arguments.length; argumentIndex++) {
+                arguments[argumentIndex] = getInstanceOfType(declaredConstructor.getParameterTypes()[argumentIndex]);
+            }
+            try {
+                return (T) declaredConstructor.newInstance(arguments);
+            } catch (Exception e) {
+                lastException = e;
+            }
+
+        }
+        throw failedToInstantiateItem(clazz, lastException);
+    }
+
+    private <T> IllegalStateException failedToInstantiateItem(Class<T> clazz, Exception e) {
+        return new IllegalStateException("Failed to create an instance of <" + clazz + "> class.", e);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Expected to be unmodifiable collection, but ");
+    }
+
+    /**
+     * Creates matcher that matches when collection is truly unmodifiable
+     */
+    public static <E> Matcher<Collection<? extends E>> isUnmodifiable() {
+        return new IsUnmodifiableCollection<>();
+    }
+
+}

--- a/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
+++ b/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
@@ -190,4 +190,5 @@ public final class ComparatorMatcherBuilder<T> {
     public Matcher<T> lessThanOrEqualTo(T value) {
         return new ComparatorMatcher<T>(comparator, value, ComparatorMatcher.LESS_THAN, ComparatorMatcher.EQUAL, includeComparatorInDescription);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
+++ b/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
@@ -23,7 +23,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public static <T extends Comparable<T>> ComparatorMatcherBuilder<T> usingNaturalOrdering() {
-        return new ComparatorMatcherBuilder<T>(new Comparator<T>() {
+        return new ComparatorMatcherBuilder<>(new Comparator<T>() {
             @Override
             public int compare(T o1, T o2) {
                 return o1.compareTo(o2);
@@ -47,7 +47,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public static <T> ComparatorMatcherBuilder<T> comparedBy(Comparator<T> comparator) {
-        return new ComparatorMatcherBuilder<T>(comparator, true);
+        return new ComparatorMatcherBuilder<>(comparator, true);
     }
 
     private ComparatorMatcherBuilder(Comparator<T> comparator, boolean includeComparatorInDescription) {
@@ -128,7 +128,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public Matcher<T> comparesEqualTo(T value) {
-        return new ComparatorMatcher<T>(comparator, value, ComparatorMatcher.EQUAL, ComparatorMatcher.EQUAL, includeComparatorInDescription);
+        return new ComparatorMatcher<>(comparator, value, ComparatorMatcher.EQUAL, ComparatorMatcher.EQUAL, includeComparatorInDescription);
     }
 
     /**
@@ -143,7 +143,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public Matcher<T> greaterThan(T value) {
-        return new ComparatorMatcher<T>(comparator, value, ComparatorMatcher.GREATER_THAN, ComparatorMatcher.GREATER_THAN, includeComparatorInDescription);
+        return new ComparatorMatcher<>(comparator, value, ComparatorMatcher.GREATER_THAN, ComparatorMatcher.GREATER_THAN, includeComparatorInDescription);
     }
 
     /**
@@ -158,7 +158,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public Matcher<T> greaterThanOrEqualTo(T value) {
-        return new ComparatorMatcher<T>(comparator, value, ComparatorMatcher.EQUAL, ComparatorMatcher.GREATER_THAN, includeComparatorInDescription);
+        return new ComparatorMatcher<>(comparator, value, ComparatorMatcher.EQUAL, ComparatorMatcher.GREATER_THAN, includeComparatorInDescription);
     }
 
     /**
@@ -173,7 +173,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public Matcher<T> lessThan(T value) {
-        return new ComparatorMatcher<T>(comparator, value, ComparatorMatcher.LESS_THAN, ComparatorMatcher.LESS_THAN, includeComparatorInDescription);
+        return new ComparatorMatcher<>(comparator, value, ComparatorMatcher.LESS_THAN, ComparatorMatcher.LESS_THAN, includeComparatorInDescription);
     }
 
     /**
@@ -188,7 +188,7 @@ public final class ComparatorMatcherBuilder<T> {
      * @return The matcher.
      */
     public Matcher<T> lessThanOrEqualTo(T value) {
-        return new ComparatorMatcher<T>(comparator, value, ComparatorMatcher.LESS_THAN, ComparatorMatcher.EQUAL, includeComparatorInDescription);
+        return new ComparatorMatcher<>(comparator, value, ComparatorMatcher.LESS_THAN, ComparatorMatcher.EQUAL, includeComparatorInDescription);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
+++ b/hamcrest/src/main/java/org/hamcrest/comparator/ComparatorMatcherBuilder.java
@@ -18,6 +18,8 @@ public final class ComparatorMatcherBuilder<T> {
      * For example:
      * <pre>assertThat(1, ComparatorMatcherBuilder.&lt;Integer&gt;usingNaturalOrdering().lessThanOrEqualTo(1))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @return The matcher.
      */
     public static <T extends Comparable<T>> ComparatorMatcherBuilder<T> usingNaturalOrdering() {
@@ -38,6 +40,10 @@ public final class ComparatorMatcherBuilder<T> {
      * }
      * }).lessThan(4))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param comparator
+     *     the comparator for the matcher to use.
      * @return The matcher.
      */
     public static <T> ComparatorMatcherBuilder<T> comparedBy(Comparator<T> comparator) {

--- a/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
@@ -45,6 +45,10 @@ public class AllOf<T> extends DiagnosingMatcher<T> {
      * For example:
      * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param matchers
+     *     all the matchers must pass.
      * @return The matcher.
      */
     public static <T> Matcher<T> allOf(Iterable<Matcher<? super T>> matchers) {
@@ -56,6 +60,10 @@ public class AllOf<T> extends DiagnosingMatcher<T> {
      * For example:
      * <pre>assertThat("myValue", allOf(startsWith("my"), containsString("Val")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param matchers
+     *     all the matchers must pass.
      * @return The matcher.
      */
     @SafeVarargs

--- a/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AllOf.java
@@ -70,4 +70,5 @@ public class AllOf<T> extends DiagnosingMatcher<T> {
     public static <T> Matcher<T> allOf(Matcher<? super T>... matchers) {
         return allOf(Arrays.asList(matchers));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
@@ -44,7 +44,7 @@ public class AnyOf<T> extends ShortcutCombination<T> {
     public static <T> AnyOf<T> anyOf(Iterable<Matcher<? super T>> matchers) {
         return new AnyOf<>(matchers);
     }
-    
+
     /**
      * Creates a matcher that matches if the examined object matches <b>ANY</b> of the specified matchers.
      * For example:

--- a/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
@@ -35,6 +35,10 @@ public class AnyOf<T> extends ShortcutCombination<T> {
      * For example:
      * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param matchers
+     *     any the matchers must pass.
      * @return The matcher.
      */
     public static <T> AnyOf<T> anyOf(Iterable<Matcher<? super T>> matchers) {
@@ -46,6 +50,10 @@ public class AnyOf<T> extends ShortcutCombination<T> {
      * For example:
      * <pre>assertThat("myValue", anyOf(startsWith("foo"), containsString("Val")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param matchers
+     *     any the matchers must pass.
      * @return The matcher.
      */
     @SafeVarargs

--- a/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/AnyOf.java
@@ -60,4 +60,5 @@ public class AnyOf<T> extends ShortcutCombination<T> {
     public static <T> AnyOf<T> anyOf(Matcher<? super T>... matchers) {
         return anyOf(Arrays.asList(matchers));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
@@ -6,6 +6,11 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.ArrayList;
 
+/**
+ * TODO: Finish Class Level Documentation.
+ *
+ * @param <T> the type of matcher being combined.
+ */
 public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
   private final Matcher<? super T> matcher;
 
@@ -47,6 +52,10 @@ public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
    * For example:
    * <pre>assertThat("fab", both(containsString("a")).and(containsString("b")))</pre>
    *
+   * @param <LHS>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to combine, and both must pass.
    * @return The matcher.
    */
   public static <LHS> CombinableBothMatcher<LHS> both(Matcher<? super LHS> matcher) {
@@ -68,6 +77,10 @@ public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
    * For example:
    * <pre>assertThat("fan", either(containsString("a")).or(containsString("b")))</pre>
    *
+   * @param <LHS>
+   *     the matcher type.
+   * @param matcher
+   *     the matcher to combine, and either must pass.
    * @return The matcher.
    */
   public static <LHS> CombinableEitherMatcher<LHS> either(Matcher<? super LHS> matcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
  * @param <T> the type of matcher being combined.
  */
 public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
+
   private final Matcher<? super T> matcher;
 
   public CombinableMatcher(Matcher<? super T> matcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
@@ -96,4 +96,5 @@ public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
       return new CombinableMatcher<>(first).or(other);
     }
   }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/CombinableMatcher.java
@@ -61,7 +61,7 @@ public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
   public static <LHS> CombinableBothMatcher<LHS> both(Matcher<? super LHS> matcher) {
     return new CombinableBothMatcher<>(matcher);
   }
-  
+
   public static final class CombinableBothMatcher<X> {
     private final Matcher<? super X> first;
     public CombinableBothMatcher(Matcher<? super X> matcher) {
@@ -86,7 +86,7 @@ public class CombinableMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
   public static <LHS> CombinableEitherMatcher<LHS> either(Matcher<? super LHS> matcher) {
     return new CombinableEitherMatcher<>(matcher);
   }
-  
+
   public static final class CombinableEitherMatcher<X> {
     private final Matcher<? super X> first;
     public CombinableEitherMatcher(Matcher<? super X> matcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
@@ -15,15 +15,15 @@ public class DescribedAs<T> extends BaseMatcher<T> {
     private final String descriptionTemplate;
     private final Matcher<T> matcher;
     private final Object[] values;
-    
-    private final static Pattern ARG_PATTERN = Pattern.compile("%([0-9]+)"); 
-    
+
+    private final static Pattern ARG_PATTERN = Pattern.compile("%([0-9]+)");
+
     public DescribedAs(String descriptionTemplate, Matcher<T> matcher, Object[] values) {
         this.descriptionTemplate = descriptionTemplate;
         this.matcher = matcher;
         this.values = values.clone();
     }
-    
+
     @Override
     public boolean matches(Object o) {
         return matcher.matches(o);
@@ -32,19 +32,19 @@ public class DescribedAs<T> extends BaseMatcher<T> {
     @Override
     public void describeTo(Description description) {
         java.util.regex.Matcher arg = ARG_PATTERN.matcher(descriptionTemplate);
-        
+
         int textStart = 0;
         while (arg.find()) {
             description.appendText(descriptionTemplate.substring(textStart, arg.start()));
             description.appendValue(values[parseInt(arg.group(1))]);
             textStart = arg.end();
         }
-        
+
         if (textStart < descriptionTemplate.length()) {
             description.appendText(descriptionTemplate.substring(textStart));
         }
     }
-    
+
     @Override
     public void describeMismatch(Object item, Description description) {
         matcher.describeMismatch(item, description);

--- a/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
@@ -68,7 +68,7 @@ public class DescribedAs<T> extends BaseMatcher<T> {
      * @return The matcher.
      */
     public static <T> Matcher<T> describedAs(String description, Matcher<T> matcher, Object... values) {
-        return new DescribedAs<T>(description, matcher, values);
+        return new DescribedAs<>(description, matcher, values);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
@@ -54,8 +54,10 @@ public class DescribedAs<T> extends BaseMatcher<T> {
      * Wraps an existing matcher, overriding its description with that specified.  All other functions are
      * delegated to the decorated matcher, including its mismatch description.
      * For example:
-     * <pre>describedAs("a big decimal equal to %0", equalTo(myBigDecimal), myBigDecimal.toPlainString())</pre> 
+     * <pre>describedAs("a big decimal equal to %0", equalTo(myBigDecimal), myBigDecimal.toPlainString())</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param description
      *     the new description for the wrapped matcher
      * @param matcher

--- a/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
@@ -69,4 +69,5 @@ public class DescribedAs<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> describedAs(String description, Matcher<T> matcher, Object... values) {
         return new DescribedAs<T>(description, matcher, values);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/DescribedAs.java
@@ -12,6 +12,7 @@ import static java.lang.Integer.parseInt;
  * Provides a custom description to another matcher.
  */
 public class DescribedAs<T> extends BaseMatcher<T> {
+
     private final String descriptionTemplate;
     private final Matcher<T> matcher;
     private final Object[] values;

--- a/hamcrest/src/main/java/org/hamcrest/core/Every.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Every.java
@@ -35,6 +35,8 @@ public class Every<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
      * For example:
      * <pre>assertThat(Arrays.asList("bar", "baz"), everyItem(startsWith("ba")))</pre>
      *
+     * @param <U>
+     *     the matcher type.
      * @param itemMatcher
      *     the matcher to apply to every item provided by the examined {@link Iterable}
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/core/Every.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Every.java
@@ -44,4 +44,5 @@ public class Every<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
     public static <U> Matcher<Iterable<? extends U>> everyItem(final Matcher<U> itemMatcher) {
         return new Every<>(itemMatcher);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/Every.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Every.java
@@ -5,6 +5,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 public class Every<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
+
     private final Matcher<? super T> matcher;
 
     public Every(Matcher<? super T> matcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/Is.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Is.java
@@ -43,6 +43,10 @@ public class Is<T> extends BaseMatcher<T> {
      * instead of:
      * <pre>assertThat(cheese, equalTo(smelly))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param matcher
+     *     the matcher to wrap.
      * @return The matcher.
      */
     public static <T> Matcher<T> is(Matcher<T> matcher) {
@@ -56,6 +60,10 @@ public class Is<T> extends BaseMatcher<T> {
      * instead of:
      * <pre>assertThat(cheese, is(equalTo(smelly)))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param value
+     *     the value to check.
      * @return The matcher.
      */
     public static <T> Matcher<T> is(T value) {
@@ -69,6 +77,10 @@ public class Is<T> extends BaseMatcher<T> {
      * instead of:
      * <pre>assertThat(cheese, is(instanceOf(Cheddar.class)))</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param type
+     *     the type to check.
      * @return The matcher.
      */
     public static <T> Matcher<T> isA(Class<?> type) {

--- a/hamcrest/src/main/java/org/hamcrest/core/Is.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Is.java
@@ -86,4 +86,5 @@ public class Is<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> isA(Class<?> type) {
         return is(IsInstanceOf.<T>instanceOf(type));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/Is.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/Is.java
@@ -14,6 +14,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  *          vs.  assertThat(cheese, is(equalTo(smelly)))
  */
 public class Is<T> extends BaseMatcher<T> {
+
     private final Matcher<T> matcher;
 
     public Is(Matcher<T> matcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsAnything.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsAnything.java
@@ -4,7 +4,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-
 /**
  * A matcher that always returns <code>true</code>.
  */

--- a/hamcrest/src/main/java/org/hamcrest/core/IsAnything.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsAnything.java
@@ -48,4 +48,5 @@ public class IsAnything<T> extends BaseMatcher<T> {
     public static Matcher<Object> anything(String description) {
         return new IsAnything<>(description);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -25,7 +25,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
         delegate.describeTo(description);
     }
 
-    
+
     /**
      * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
      * examined {@link Iterable} yields at least one item that is matched by the specified
@@ -85,7 +85,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
     public static <T> Matcher<Iterable<T>> hasItems(Matcher<? super T>... itemMatchers) {
         return IsIterableContaining.hasItems(itemMatchers);
     }
-    
+
     /**
      * Creates a matcher for {@link Iterable}s that matches when consecutive passes over the
      * examined {@link Iterable} yield at least one item that is equal to the corresponding

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -36,6 +36,8 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      *
      * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItem(Matcher)}.
      *
+     * @param <T>
+     *     the matcher type.
      * @param itemMatcher
      *     the matcher to apply to items provided by the examined {@link Iterable}
      * @return The matcher.
@@ -53,7 +55,8 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem("bar"))</pre>
      *
      * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItem(Object)}.
-     *
+     * @param <T>
+     *     the matcher type.
      * @param item
      *     the item to compare against the items provided by the examined {@link Iterable}
      * @return The matcher.
@@ -72,7 +75,8 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems(endsWith("z"), endsWith("o")))</pre>
      *
      * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItems(Matcher[])}}.
-     *
+     * @param <T>
+     *     the matcher type.
      * @param itemMatchers
      *     the matchers to apply to items provided by the examined {@link Iterable}
      * @return The matcher.
@@ -91,7 +95,8 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems("baz", "foo"))</pre>
      *
      * @deprecated As of version 2.1, use {@link IsIterableContaining#hasItems(Object[])}}.
-     *
+     * @param <T>
+     *     the matcher type.
      * @param items
      *     the items to compare against the items provided by the examined {@link Iterable}
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -25,7 +25,6 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
         delegate.describeTo(description);
     }
 
-
     /**
      * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
      * examined {@link Iterable} yields at least one item that is matched by the specified

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -9,6 +9,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  */
 @Deprecated
 public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? super T>> {
+
     private final IsIterableContaining<T> delegate;
 
     public IsCollectionContaining(Matcher<? super T> elementMatcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
@@ -103,4 +103,5 @@ public class IsEqual<T> extends BaseMatcher<T> {
     public static Matcher<Object> equalToObject(Object operand) {
         return new IsEqual<>(operand);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
@@ -32,11 +32,11 @@ public class IsEqual<T> extends BaseMatcher<T> {
         if (actual == null) {
             return expected == null;
         }
-        
+
         if (expected != null && isArray(actual)) {
             return isArray(expected) && areArraysEqual(actual, expected);
         }
-        
+
         return actual.equals(expected);
     }
 
@@ -75,7 +75,7 @@ public class IsEqual<T> extends BaseMatcher<T> {
      * <p>The created matcher provides a special behaviour when examining <code>Array</code>s, whereby
      * it will match if both the operand and the examined object are arrays of the same length and
      * contain items that are equal to each other (according to the above rules) <b>in the same
-     * indexes</b>.</p> 
+     * indexes</b>.</p>
      * For example:
      * <pre>
      * assertThat("foo", equalTo("foo"));

--- a/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
@@ -82,6 +82,10 @@ public class IsEqual<T> extends BaseMatcher<T> {
      * assertThat(new String[] {"foo", "bar"}, equalTo(new String[] {"foo", "bar"}));
      * </pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param operand
+     *     the value to check.
      * @return The matcher.
      */
     public static <T> Matcher<T> equalTo(T operand) {
@@ -92,6 +96,8 @@ public class IsEqual<T> extends BaseMatcher<T> {
      * Creates an {@link org.hamcrest.core.IsEqual} matcher that does not enforce the values being
      * compared to be of the same static type.
      *
+     * @param operand
+     *     the value to check.
      * @return The matcher.
      */
     public static Matcher<Object> equalToObject(Object operand) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 
 import java.lang.reflect.Array;
 
-
 /**
  * Is the value equal to another value, as tested by the
  * {@link java.lang.Object#equals} invokedMethod?

--- a/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsEqual.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Array;
  * {@link java.lang.Object#equals} invokedMethod?
  */
 public class IsEqual<T> extends BaseMatcher<T> {
+
     private final Object expectedValue;
 
     public IsEqual(T equalArg) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
@@ -25,14 +25,14 @@ public class IsInstanceOf extends DiagnosingMatcher<Object> {
     }
 
     private static Class<?> matchableClass(Class<?> expectedClass) {
-      if (boolean.class.equals(expectedClass)) return Boolean.class; 
-      if (byte.class.equals(expectedClass)) return Byte.class; 
-      if (char.class.equals(expectedClass)) return Character.class; 
-      if (double.class.equals(expectedClass)) return Double.class; 
-      if (float.class.equals(expectedClass)) return Float.class; 
-      if (int.class.equals(expectedClass)) return Integer.class; 
-      if (long.class.equals(expectedClass)) return Long.class; 
-      if (short.class.equals(expectedClass)) return Short.class; 
+      if (boolean.class.equals(expectedClass)) return Boolean.class;
+      if (byte.class.equals(expectedClass)) return Byte.class;
+      if (char.class.equals(expectedClass)) return Character.class;
+      if (double.class.equals(expectedClass)) return Double.class;
+      if (float.class.equals(expectedClass)) return Float.class;
+      if (int.class.equals(expectedClass)) return Integer.class;
+      if (long.class.equals(expectedClass)) return Long.class;
+      if (short.class.equals(expectedClass)) return Short.class;
       return expectedClass;
     }
 
@@ -42,12 +42,12 @@ public class IsInstanceOf extends DiagnosingMatcher<Object> {
         mismatch.appendText("null");
         return false;
       }
-      
+
       if (!matchableClass.isInstance(item)) {
         mismatch.appendValue(item).appendText(" is a " + item.getClass().getName());
         return false;
       }
-      
+
       return true;
     }
 
@@ -75,7 +75,7 @@ public class IsInstanceOf extends DiagnosingMatcher<Object> {
     public static <T> Matcher<T> instanceOf(Class<?> type) {
         return (Matcher<T>) new IsInstanceOf(type);
     }
-    
+
     /**
      * Creates a matcher that matches when the examined object is an instance of the specified <code>type</code>,
      * as determined by calling the {@link java.lang.Class#isInstance(Object)} method on that type, passing the

--- a/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
@@ -65,6 +65,10 @@ public class IsInstanceOf extends DiagnosingMatcher<Object> {
      * For example:
      * <pre>assertThat(new Canoe(), instanceOf(Paddlable.class));</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param type
+     *     the type to check.
      * @return The matcher.
      */
     @SuppressWarnings("unchecked")
@@ -83,6 +87,10 @@ public class IsInstanceOf extends DiagnosingMatcher<Object> {
      * For example:
      * <pre>assertThat(new Canoe(), instanceOf(Canoe.class));</pre>
      *
+     * @param <T>
+     *     the matcher type.
+     * @param type
+     *     the type to check.
      * @return The matcher.
      */
     @SuppressWarnings("unchecked")

--- a/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
@@ -4,7 +4,6 @@ import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 
-
 /**
  * Tests whether the value is an instance of a class.
  * Classes of basic types will be converted to the relevant "Object" classes

--- a/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsInstanceOf.java
@@ -9,6 +9,7 @@ import org.hamcrest.Matcher;
  * Classes of basic types will be converted to the relevant "Object" classes
  */
 public class IsInstanceOf extends DiagnosingMatcher<Object> {
+
     private final Class<?> expectedClass;
     private final Class<?> matchableClass;
 

--- a/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
@@ -54,7 +54,7 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
             .appendDescriptionOf(elementMatcher);
     }
 
-    
+
     /**
      * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
      * examined {@link Iterable} yields at least one item that is matched by the specified
@@ -109,15 +109,15 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
     @SafeVarargs
     public static <T> Matcher<Iterable<T>> hasItems(Matcher<? super T>... itemMatchers) {
         List<Matcher<? super Iterable<T>>> all = new ArrayList<>(itemMatchers.length);
-        
+
         for (Matcher<? super T> elementMatcher : itemMatchers) {
           // Doesn't forward to hasItem() method so compiler can sort out generics.
           all.add(new IsIterableContaining<>(elementMatcher));
         }
-        
+
         return allOf(all);
     }
-    
+
     /**
      * Creates a matcher for {@link Iterable}s that matches when consecutive passes over the
      * examined {@link Iterable} yield at least one item that is equal to the corresponding
@@ -138,7 +138,7 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
         for (T item : items) {
             all.add(hasItem(item));
         }
-        
+
         return allOf(all);
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
@@ -54,7 +54,6 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
             .appendDescriptionOf(elementMatcher);
     }
 
-
     /**
      * Creates a matcher for {@link Iterable}s that only matches when a single pass over the
      * examined {@link Iterable} yields at least one item that is matched by the specified

--- a/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
@@ -63,6 +63,8 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem(startsWith("ba")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param itemMatcher
      *     the matcher to apply to items provided by the examined {@link Iterable}
      * @return The matcher.
@@ -79,6 +81,8 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar"), hasItem("bar"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param item
      *     the item to compare against the items provided by the examined {@link Iterable}
      * @return The matcher.
@@ -96,6 +100,8 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems(endsWith("z"), endsWith("o")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param itemMatchers
      *     the matchers to apply to items provided by the examined {@link Iterable}
      * @return The matcher.
@@ -120,6 +126,8 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      * For example:
      * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), hasItems("baz", "foo"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param items
      *     the items to compare against the items provided by the examined {@link Iterable}
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
@@ -11,6 +11,7 @@ import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? super T>> {
+
     private final Matcher<? super T> elementMatcher;
 
     public IsIterableContaining(Matcher<? super T> elementMatcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -10,6 +10,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * Calculates the logical negation of a matcher.
  */
 public class IsNot<T> extends BaseMatcher<T>  {
+
     private final Matcher<T> matcher;
 
     public IsNot(Matcher<T> matcher) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 
-
 /**
  * Calculates the logical negation of a matcher.
  */
@@ -26,7 +25,6 @@ public class IsNot<T> extends BaseMatcher<T>  {
     public void describeTo(Description description) {
         description.appendText("not ").appendDescriptionOf(matcher);
     }
-
 
     /**
      * Creates a matcher that wraps an existing matcher, but inverts the logic by which

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -27,7 +27,7 @@ public class IsNot<T> extends BaseMatcher<T>  {
         description.appendText("not ").appendDescriptionOf(matcher);
     }
 
-    
+
     /**
      * Creates a matcher that wraps an existing matcher, but inverts the logic by which
      * it will match.

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -40,7 +40,7 @@ public class IsNot<T> extends BaseMatcher<T>  {
      * @return The matcher.
      */
     public static <T> Matcher<T> not(Matcher<T> matcher) {
-        return new IsNot<T>(matcher);
+        return new IsNot<>(matcher);
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -60,4 +60,5 @@ public class IsNot<T> extends BaseMatcher<T>  {
     public static <T> Matcher<T> not(T value) {
         return not(equalTo(value));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNot.java
@@ -34,6 +34,8 @@ public class IsNot<T> extends BaseMatcher<T>  {
      * For example:
      * <pre>assertThat(cheese, is(not(equalTo(smelly))))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param matcher
      *     the matcher whose sense should be inverted
      * @return The matcher.
@@ -49,6 +51,8 @@ public class IsNot<T> extends BaseMatcher<T>  {
      * instead of:
      * <pre>assertThat(cheese, is(not(equalTo(smelly))))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param value
      *     the value that any examined object should <b>not</b> equal
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
@@ -29,7 +29,7 @@ public class IsNull<T> extends BaseMatcher<T> {
      * @return The matcher.
      */
     public static Matcher<Object> nullValue() {
-        return new IsNull<Object>();
+        return new IsNull<>();
     }
 
     /**
@@ -58,7 +58,7 @@ public class IsNull<T> extends BaseMatcher<T> {
      * @return The matcher.
      */
     public static <T> Matcher<T> nullValue(Class<T> type) {
-        return new IsNull<T>();
+        return new IsNull<>();
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
@@ -77,5 +77,5 @@ public class IsNull<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> notNullValue(Class<T> type) {
         return not(nullValue(type));
     }
-}
 
+}

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
@@ -10,6 +10,7 @@ import static org.hamcrest.core.IsNot.not;
  * Is the value null?
  */
 public class IsNull<T> extends BaseMatcher<T> {
+
     @Override
     public boolean matches(Object o) {
         return o == null;

--- a/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsNull.java
@@ -50,6 +50,8 @@ public class IsNull<T> extends BaseMatcher<T> {
      * For example:
      * <pre>assertThat(cheese, is(nullValue(Cheese.class))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param type
      *     dummy parameter used to infer the generic type of the returned matcher
      * @return The matcher.
@@ -66,6 +68,8 @@ public class IsNull<T> extends BaseMatcher<T> {
      * instead of:
      * <pre>assertThat(cheese, is(not(nullValue(X.class))))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param type
      *     dummy parameter used to infer the generic type of the returned matcher
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -54,4 +54,5 @@ public class IsSame<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> theInstance(T target) {
         return new IsSame<T>(target);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -31,6 +31,8 @@ public class IsSame<T> extends BaseMatcher<T> {
      * Creates a matcher that matches only when the examined object is the same instance as
      * the specified target object.
      *
+     * @param <T>
+     *     the matcher type.
      * @param target
      *     the target instance against which others should be assessed
      * @return The matcher.
@@ -43,6 +45,8 @@ public class IsSame<T> extends BaseMatcher<T> {
      * Creates a matcher that matches only when the examined object is the same instance as
      * the specified target object.
      *
+     * @param <T>
+     *     the matcher type.
      * @param target
      *     the target instance against which others should be assessed
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -38,7 +38,7 @@ public class IsSame<T> extends BaseMatcher<T> {
      * @return The matcher.
      */
     public static <T> Matcher<T> sameInstance(T target) {
-        return new IsSame<T>(target);
+        return new IsSame<>(target);
     }
 
     /**
@@ -52,7 +52,7 @@ public class IsSame<T> extends BaseMatcher<T> {
      * @return The matcher.
      */
     public static <T> Matcher<T> theInstance(T target) {
-        return new IsSame<T>(target);
+        return new IsSame<>(target);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -4,7 +4,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-
 /**
  * Is the value the same object as another value?
  */

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -8,6 +8,7 @@ import org.hamcrest.Matcher;
  * Is the value the same object as another value?
  */
 public class IsSame<T> extends BaseMatcher<T> {
+
     private final T object;
 
     public IsSame(T object) {

--- a/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsSame.java
@@ -10,7 +10,7 @@ import org.hamcrest.Matcher;
  */
 public class IsSame<T> extends BaseMatcher<T> {
     private final T object;
-    
+
     public IsSame(T object) {
         this.object = object;
     }
@@ -26,7 +26,7 @@ public class IsSame<T> extends BaseMatcher<T> {
                 .appendValue(object)
                 .appendText(")");
     }
-    
+
     /**
      * Creates a matcher that matches only when the examined object is the same instance as
      * the specified target object.
@@ -40,7 +40,7 @@ public class IsSame<T> extends BaseMatcher<T> {
     public static <T> Matcher<T> sameInstance(T target) {
         return new IsSame<T>(target);
     }
-    
+
     /**
      * Creates a matcher that matches only when the examined object is the same instance as
      * the specified target object.

--- a/hamcrest/src/main/java/org/hamcrest/core/ShortcutCombination.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/ShortcutCombination.java
@@ -11,13 +11,13 @@ abstract class ShortcutCombination<T> extends BaseMatcher<T> {
     public ShortcutCombination(Iterable<Matcher<? super T>> matchers) {
         this.matchers = matchers;
     }
-    
+
     @Override
     public abstract boolean matches(Object o);
-    
+
     @Override
     public abstract void describeTo(Description description);
-    
+
     protected boolean matches(Object o, boolean shortcut) {
         for (Matcher<? super T> matcher : matchers) {
             if (matcher.matches(o) == shortcut) {
@@ -26,7 +26,7 @@ abstract class ShortcutCombination<T> extends BaseMatcher<T> {
         }
         return !shortcut;
     }
-    
+
     public void describeTo(Description description, String operator) {
         description.appendList("(", " " + operator + " ", ")", matchers);
     }

--- a/hamcrest/src/main/java/org/hamcrest/core/ShortcutCombination.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/ShortcutCombination.java
@@ -30,4 +30,5 @@ abstract class ShortcutCombination<T> extends BaseMatcher<T> {
     public void describeTo(Description description, String operator) {
         description.appendList("(", " " + operator + " ", ")", matchers);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/StringContains.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringContains.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
  * Tests if the argument is a string that contains a specific substring.
  */
 public class StringContains extends SubstringMatcher {
+
     public StringContains(String substring) { this(false, substring); }
 
     public StringContains(boolean ignoringCase, String substring) {

--- a/hamcrest/src/main/java/org/hamcrest/core/StringEndsWith.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringEndsWith.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
  * Tests if the argument is a string that ends with a specific substring.
  */
 public class StringEndsWith extends SubstringMatcher {
+
     public StringEndsWith(String substring) { this(false, substring); }
 
     public StringEndsWith(boolean ignoringCase, String substring) { super("ending with", ignoringCase, substring); }

--- a/hamcrest/src/main/java/org/hamcrest/core/StringRegularExpression.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringRegularExpression.java
@@ -65,4 +65,5 @@ public class StringRegularExpression extends TypeSafeDiagnosingMatcher<String> {
   public static Matcher<String> matchesRegex(String regex) {
     return matchesRegex(Pattern.compile(regex));
   }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/core/StringRegularExpression.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringRegularExpression.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.hamcrest.core;
 
 import java.util.regex.Pattern;

--- a/hamcrest/src/main/java/org/hamcrest/core/StringStartsWith.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/StringStartsWith.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
  * Tests if the argument is a string that starts with a specific substring.
  */
 public class StringStartsWith extends SubstringMatcher {
+
     public StringStartsWith(String substring) { this(false, substring); }
 
     public StringStartsWith(boolean ignoringCase, String substring) { super("starting with", ignoringCase, substring); }

--- a/hamcrest/src/main/java/org/hamcrest/core/SubstringMatcher.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/SubstringMatcher.java
@@ -29,7 +29,7 @@ public abstract class SubstringMatcher extends TypeSafeMatcher<String> {
     public void describeMismatchSafely(String item, Description mismatchDescription) {
       mismatchDescription.appendText("was \"").appendText(item).appendText("\"");
     }
-    
+
     @Override
     public void describeTo(Description description) {
         description.appendText("a string ")

--- a/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
@@ -6,14 +6,14 @@ import java.util.Iterator;
 public class ArrayIterator implements Iterator<Object> {
     private final Object array;
     private int currentIndex = 0;
-    
+
     public ArrayIterator(Object array) {
         if (!array.getClass().isArray()) {
             throw new IllegalArgumentException("not an array");
         }
         this.array = array;
     }
-    
+
     @Override
     public boolean hasNext() {
         return currentIndex < Array.getLength(array);
@@ -23,7 +23,7 @@ public class ArrayIterator implements Iterator<Object> {
     public Object next() {
         return Array.get(array, currentIndex++);
     }
-    
+
     @Override
     public void remove() {
         throw new UnsupportedOperationException("cannot remove items from an array");

--- a/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
@@ -28,4 +28,5 @@ public class ArrayIterator implements Iterator<Object> {
     public void remove() {
         throw new UnsupportedOperationException("cannot remove items from an array");
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ArrayIterator.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Array;
 import java.util.Iterator;
 
 public class ArrayIterator implements Iterator<Object> {
+
     private final Object array;
     private int currentIndex = 0;
 

--- a/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
@@ -10,7 +10,7 @@ public class NullSafety {
 
     @SuppressWarnings("unchecked")
     public static <E> List<Matcher<? super E>> nullSafe(Matcher<? super E>[] itemMatchers) {
-        final List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>(itemMatchers.length);
+        final List<Matcher<? super E>> matchers = new ArrayList<>(itemMatchers.length);
         for (final Matcher<? super E> itemMatcher : itemMatchers) {
             matchers.add((Matcher<? super E>) (itemMatcher == null ? IsNull.nullValue() : itemMatcher));
         }

--- a/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
@@ -15,4 +15,5 @@ public class NullSafety {
         }
         return matchers;
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/NullSafety.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NullSafety {
+
     @SuppressWarnings("unchecked")
     public static <E> List<Matcher<? super E>> nullSafe(Matcher<? super E>[] itemMatchers) {
         final List<Matcher<? super E>> matchers = new ArrayList<Matcher<? super E>>(itemMatchers.length);

--- a/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
@@ -67,4 +67,5 @@ public class ReflectiveTypeFinder {
   private Class<?> expectedTypeFrom(Method method) {
       return method.getParameterTypes()[typedParameter];
   }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
@@ -28,6 +28,7 @@ package org.hamcrest.internal;
 import java.lang.reflect.Method;
 
 public class ReflectiveTypeFinder {
+
   private final String methodName;
   private final int expectedNumberOfParameters;
   private final int typedParameter;

--- a/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
@@ -59,7 +59,6 @@ public class ReflectiveTypeFinder {
               && !method.isSynthetic();
   }
 
-
   /**
    * @param method The method from which to extract
    * @return The type we're looking for

--- a/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/ReflectiveTypeFinder.java
@@ -1,25 +1,25 @@
 /**
- * The TypeSafe classes, and their descendants, need a mechanism to find out what type has been used as a parameter 
- * for the concrete matcher. Unfortunately, this type is lost during type erasure so we need to use reflection 
- * to get it back, by picking out the type of a known parameter to a known method. 
- * The catch is that, with bridging methods, this type is only visible in the class that actually implements 
+ * The TypeSafe classes, and their descendants, need a mechanism to find out what type has been used as a parameter
+ * for the concrete matcher. Unfortunately, this type is lost during type erasure so we need to use reflection
+ * to get it back, by picking out the type of a known parameter to a known method.
+ * The catch is that, with bridging methods, this type is only visible in the class that actually implements
  * the expected method, so the ReflectiveTypeFinder needs to be applied to that class or a subtype.
- * 
+ *
  * For example, the abstract <code>TypeSafeDiagnosingMatcher&lt;T&gt;</code> defines an abstract method
  * <pre>protected abstract boolean matchesSafely(T item, Description mismatchDescription);</pre>
  * By default it uses <code>new ReflectiveTypeFinder("matchesSafely", 2, 0); </code> to find the
  * parameterised type. If we create a <code>TypeSafeDiagnosingMatcher&lt;String&gt;</code>, the type
  * finder will return <code>String.class</code>.
- * 
- * A <code>FeatureMatcher</code> is an abstract subclass of <code>TypeSafeDiagnosingMatcher</code>. 
+ *
+ * A <code>FeatureMatcher</code> is an abstract subclass of <code>TypeSafeDiagnosingMatcher</code>.
  * Although it has a templated implementation of <code>matchesSafely(&lt;T&gt;, Description);</code>, the
  * actual run-time signature of this is <code>matchesSafely(Object, Description);</code>. Instead,
- * we must find the type by reflecting on the concrete implementation of 
+ * we must find the type by reflecting on the concrete implementation of
  * <pre>protected abstract U featureValueOf(T actual);</pre>
  * a method which is declared in <code>FeatureMatcher</code>.
- * 
- * In short, use this to extract a type from a method in the leaf class of a templated class hierarchy. 
- *  
+ *
+ * In short, use this to extract a type from a method in the leaf class of a templated class hierarchy.
+ *
  * @author Steve Freeman
  * @author Nat Pryce
  */
@@ -37,7 +37,7 @@ public class ReflectiveTypeFinder {
     this.expectedNumberOfParameters = expectedNumberOfParameters;
     this.typedParameter = typedParameter;
   }
-  
+
   public Class<?> findExpectedType(Class<?> fromClass) {
     for (Class<?> c = fromClass; c != Object.class; c = c.getSuperclass()) {
         for (Method method : c.getDeclaredMethods()) {

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
@@ -5,7 +5,7 @@ import org.hamcrest.SelfDescribing;
 
 public class SelfDescribingValue<T> implements SelfDescribing {
     private T value;
-    
+
     public SelfDescribingValue(T value) {
         this.value = value;
     }

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
@@ -4,6 +4,7 @@ import org.hamcrest.Description;
 import org.hamcrest.SelfDescribing;
 
 public class SelfDescribingValue<T> implements SelfDescribing {
+
     private T value;
 
     public SelfDescribingValue(T value) {

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValue.java
@@ -14,4 +14,5 @@ public class SelfDescribingValue<T> implements SelfDescribing {
     public void describeTo(Description description) {
         description.appendValue(value);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
@@ -6,11 +6,11 @@ import java.util.Iterator;
 
 public class SelfDescribingValueIterator<T> implements Iterator<SelfDescribing> {
     private Iterator<T> values;
-    
+
     public SelfDescribingValueIterator(Iterator<T> values) {
         this.values = values;
     }
-    
+
     @Override
     public boolean hasNext() {
         return values.hasNext();

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
@@ -25,4 +25,5 @@ public class SelfDescribingValueIterator<T> implements Iterator<SelfDescribing> 
     public void remove() {
         values.remove();
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
+++ b/hamcrest/src/main/java/org/hamcrest/internal/SelfDescribingValueIterator.java
@@ -5,6 +5,7 @@ import org.hamcrest.SelfDescribing;
 import java.util.Iterator;
 
 public class SelfDescribingValueIterator<T> implements Iterator<SelfDescribing> {
+
     private Iterator<T> values;
 
     public SelfDescribingValueIterator(Iterator<T> values) {

--- a/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
@@ -104,4 +104,5 @@ public final class FileMatchers {
             }
         };
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
@@ -49,7 +49,7 @@ public class BigDecimalCloseTo extends TypeSafeMatcher<BigDecimal> {
    * is done by BigDecimals {@link java.math.BigDecimal#compareTo(java.math.BigDecimal)} method.
    * For example:
    * <pre>assertThat(new BigDecimal("1.03"), is(closeTo(new BigDecimal("1.0"), new BigDecimal("0.03"))))</pre>
-   * 
+   *
    * @param operand
    *     the expected value of matching BigDecimals
    * @param error

--- a/hamcrest/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/BigDecimalCloseTo.java
@@ -61,4 +61,3 @@ public class BigDecimalCloseTo extends TypeSafeMatcher<BigDecimal> {
   }
 
 }
-

--- a/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
@@ -11,6 +11,7 @@ import static java.lang.Math.abs;
  * acceptable error?
  */
 public class IsCloseTo extends TypeSafeMatcher<Double> {
+
     private final double delta;
     private final double value;
 

--- a/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
@@ -61,4 +61,5 @@ public class IsCloseTo extends TypeSafeMatcher<Double> {
     public static Matcher<Double> closeTo(double operand, double error) {
         return new IsCloseTo(operand, error);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsCloseTo.java
@@ -6,7 +6,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 import static java.lang.Math.abs;
 
-
 /**
  * Is the value a number equal to a value within some range of
  * acceptable error?

--- a/hamcrest/src/main/java/org/hamcrest/number/IsNaN.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsNaN.java
@@ -37,4 +37,5 @@ public final class IsNaN extends TypeSafeMatcher<Double> {
     public static Matcher<Double> notANumber() {
         return new IsNaN();
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/number/IsNaN.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/IsNaN.java
@@ -4,7 +4,6 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-
 /**
  * Is the value a number actually not a number (NaN)?
  */

--- a/hamcrest/src/main/java/org/hamcrest/number/OrderingComparison.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/OrderingComparison.java
@@ -91,4 +91,5 @@ public class OrderingComparison {
     public static <T extends Comparable<T>> Matcher<T> lessThanOrEqualTo(T value) {
         return ComparatorMatcherBuilder.<T>usingNaturalOrdering().lessThanOrEqualTo(value);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/number/OrderingComparison.java
+++ b/hamcrest/src/main/java/org/hamcrest/number/OrderingComparison.java
@@ -15,6 +15,8 @@ public class OrderingComparison {
      * For example:
      * <pre>assertThat(1, comparesEqualTo(1))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param value the value which, when passed to the compareTo method of the examined object, should return zero
      * @return The matcher.
      */
@@ -29,6 +31,8 @@ public class OrderingComparison {
      * For example:
      * <pre>assertThat(2, greaterThan(1))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param value the value which, when passed to the compareTo method of the examined object, should return greater
      *              than zero
      * @return The matcher.
@@ -44,6 +48,8 @@ public class OrderingComparison {
      * For example:
      * <pre>assertThat(1, greaterThanOrEqualTo(1))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param value the value which, when passed to the compareTo method of the examined object, should return greater
      *              than or equal to zero
      * @return The matcher.
@@ -59,6 +65,8 @@ public class OrderingComparison {
      * For example:
      * <pre>assertThat(1, lessThan(2))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param value the value which, when passed to the compareTo method of the examined object, should return less
      *              than zero
      * @return The matcher.
@@ -74,6 +82,8 @@ public class OrderingComparison {
      * For example:
      * <pre>assertThat(1, lessThanOrEqualTo(1))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param value the value which, when passed to the compareTo method of the examined object, should return less
      *              than or equal to zero
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/object/HasEqualValues.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasEqualValues.java
@@ -82,5 +82,4 @@ public class HasEqualValues<T> extends TypeSafeDiagnosingMatcher<T> {
         }
     }
 
-
 }

--- a/hamcrest/src/main/java/org/hamcrest/object/HasEqualValues.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasEqualValues.java
@@ -13,6 +13,7 @@ import java.util.List;
 import static java.lang.String.format;
 
 public class HasEqualValues<T> extends TypeSafeDiagnosingMatcher<T> {
+
     private final T expectedObject;
     private final List<FieldMatcher> fieldMatchers;
 

--- a/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
@@ -29,7 +29,7 @@ public class HasToString<T> extends FeatureMatcher<T, String> {
      * @return The matcher.
      */
     public static <T> Matcher<T> hasToString(Matcher<? super String> toStringMatcher) {
-        return new HasToString<T>(toStringMatcher);
+        return new HasToString<>(toStringMatcher);
     }
 
     /**
@@ -45,7 +45,7 @@ public class HasToString<T> extends FeatureMatcher<T, String> {
      * @return The matcher.
      */
     public static <T> Matcher<T> hasToString(String expectedToString) {
-        return new HasToString<T>(equalTo(expectedToString));
+        return new HasToString<>(equalTo(expectedToString));
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
@@ -9,7 +9,7 @@ public class HasToString<T> extends FeatureMatcher<T, String> {
     public HasToString(Matcher<? super String> toStringMatcher) {
       super(toStringMatcher, "with toString()", "toString()");
     }
-    
+
     @Override
     protected String featureValueOf(T actual) {
       return String.valueOf(actual);

--- a/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class HasToString<T> extends FeatureMatcher<T, String> {
+
     public HasToString(Matcher<? super String> toStringMatcher) {
       super(toStringMatcher, "with toString()", "toString()");
     }

--- a/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
@@ -46,4 +46,5 @@ public class HasToString<T> extends FeatureMatcher<T, String> {
     public static <T> Matcher<T> hasToString(String expectedToString) {
         return new HasToString<T>(equalTo(expectedToString));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/HasToString.java
@@ -21,6 +21,8 @@ public class HasToString<T> extends FeatureMatcher<T, String> {
      * For example:
      * <pre>assertThat(true, hasToString(equalTo("TRUE")))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param toStringMatcher
      *     the matcher used to verify the toString result
      * @return The matcher.
@@ -35,6 +37,8 @@ public class HasToString<T> extends FeatureMatcher<T, String> {
      * For example:
      * <pre>assertThat(true, hasToString("TRUE"))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param expectedToString
      *     the expected toString result
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -40,7 +40,7 @@ public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
      * @return The matcher.
      */
     public static <T> Matcher<Class<?>> typeCompatibleWith(Class<T> baseType) {
-        return new IsCompatibleType<T>(baseType);
+        return new IsCompatibleType<>(baseType);
     }
 
 }

--- a/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -5,6 +5,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
+
     private final Class<T> type;
 
     public IsCompatibleType(Class<T> type) {

--- a/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -41,4 +41,5 @@ public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
     public static <T> Matcher<Class<?>> typeCompatibleWith(Class<T> baseType) {
         return new IsCompatibleType<T>(baseType);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -32,6 +32,8 @@ public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
      * For example:
      * <pre>assertThat(Integer.class, typeCompatibleWith(Number.class))</pre>
      *
+     * @param <T>
+     *     the matcher type.
      * @param baseType
      *     the base class to examine classes against
      * @return The matcher.

--- a/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsCompatibleType.java
@@ -6,26 +6,26 @@ import org.hamcrest.TypeSafeMatcher;
 
 public class IsCompatibleType<T> extends TypeSafeMatcher<Class<?>> {
     private final Class<T> type;
-    
+
     public IsCompatibleType(Class<T> type) {
         this.type = type;
     }
-    
+
     @Override
     public boolean matchesSafely(Class<?> cls) {
         return type.isAssignableFrom(cls);
     }
-    
+
     @Override
     public void describeMismatchSafely(Class<?> cls, Description mismatchDescription) {
       mismatchDescription.appendValue(cls.getName());
     }
-    
+
     @Override
     public void describeTo(Description description) {
         description.appendText("type < ").appendText(type.getName());
     }
-    
+
     /**
      * Creates a matcher of {@link Class} that matches when the specified baseType is
      * assignable from the examined class.

--- a/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -10,6 +10,7 @@ import java.util.EventObject;
  * Tests if the value is an event announced by a specific object.
  */
 public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
+
     private final Class<?> eventClass;
     private final Object source;
 

--- a/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -6,7 +6,6 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.EventObject;
 
-
 /**
  * Tests if the value is an event announced by a specific object.
  */
@@ -32,7 +31,6 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
         }
         return true;
     }
-
 
     private boolean eventHasSameSource(EventObject ev) {
         return ev.getSource() == source;

--- a/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -75,4 +75,5 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
     public static Matcher<EventObject> eventFrom(Object source) {
         return eventFrom(EventObject.class, source);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
+++ b/hamcrest/src/main/java/org/hamcrest/object/IsEventFrom.java
@@ -25,7 +25,7 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
           mismatchDescription.appendText("item type was " + item.getClass().getName());
           return false;
         }
-        
+
         if (!eventHasSameSource(item)) {
           mismatchDescription.appendText("source was ").appendValue(item.getSource());
           return false;
@@ -33,7 +33,7 @@ public class IsEventFrom extends TypeSafeDiagnosingMatcher<EventObject> {
         return true;
     }
 
-    
+
     private boolean eventHasSameSource(EventObject ev) {
         return ev.getSource() == source;
     }

--- a/hamcrest/src/main/java/org/hamcrest/text/CharSequenceLength.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/CharSequenceLength.java
@@ -54,6 +54,5 @@ public class CharSequenceLength extends FeatureMatcher<CharSequence, Integer> {
      public static Matcher<CharSequence> hasLength(Matcher<? super Integer> lengthMatcher) {
          return new CharSequenceLength(lengthMatcher);
      }
+
 }
-
-

--- a/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
@@ -1,4 +1,3 @@
-
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
@@ -55,4 +55,5 @@ public final class IsBlankString extends TypeSafeMatcher<String> {
     public static Matcher<String> blankOrNullString() {
         return NULL_OR_BLANK_INSTANCE;
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsBlankString.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.IsNull.nullValue;
  * Matches blank Strings (and null).
  */
 public final class IsBlankString extends TypeSafeMatcher<String> {
+
     private static final IsBlankString BLANK_INSTANCE = new IsBlankString();
     @SuppressWarnings("unchecked")
     private static final Matcher<String> NULL_OR_BLANK_INSTANCE = anyOf(nullValue(), BLANK_INSTANCE);

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
@@ -1,4 +1,3 @@
-
 package org.hamcrest.text;
 
 import org.hamcrest.Description;

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
@@ -11,6 +11,7 @@ import static org.hamcrest.core.IsNull.nullValue;
  * Matches empty Strings (and null).
  */
 public final class IsEmptyString extends TypeSafeMatcher<String> {
+
     private static final IsEmptyString INSTANCE = new IsEmptyString();
     @SuppressWarnings("unchecked")
     private static final Matcher<String> NULL_OR_EMPTY_INSTANCE = anyOf(nullValue(), INSTANCE);

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEmptyString.java
@@ -77,4 +77,5 @@ public final class IsEmptyString extends TypeSafeMatcher<String> {
     public static Matcher<String> emptyOrNullString() {
         return NULL_OR_EMPTY_INSTANCE;
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
@@ -29,12 +29,12 @@ public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
     public boolean matchesSafely(String item) {
         return stripSpaces(string).equals(stripSpaces(item));
     }
-    
+
     @Override
     public void describeMismatchSafely(String item, Description mismatchDescription) {
       mismatchDescription.appendText("was ").appendValue(item);
     }
-    
+
     @Override
     public void describeTo(Description description) {
         description.appendText("a string equal to ")

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
@@ -21,6 +21,10 @@ public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
         this.string = string;
     }
 
+    protected String getString() {
+        return string;
+    }
+
     @Override
     public boolean matchesSafely(String item) {
         return stripSpaces(string).equals(stripSpaces(item));

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java
@@ -30,7 +30,7 @@ public class IsEqualIgnoringCase extends TypeSafeMatcher<String> {
     public void describeMismatchSafely(String item, Description mismatchDescription) {
       mismatchDescription.appendText("was ").appendValue(item);
     }
-    
+
     @Override
     public void describeTo(Description description) {
         description.appendText("a string equal to ")

--- a/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
@@ -46,4 +46,5 @@ public class MatchesPattern extends TypeSafeMatcher<String> {
     public static Matcher<String> matchesPattern(String regex) {
         return new MatchesPattern(Pattern.compile(regex));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
@@ -7,6 +7,7 @@ import org.hamcrest.TypeSafeMatcher;
 import java.util.regex.Pattern;
 
 public class MatchesPattern extends TypeSafeMatcher<String> {
+
     private final Pattern pattern;
 
     public MatchesPattern(Pattern pattern) {

--- a/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/MatchesPattern.java
@@ -27,6 +27,8 @@ public class MatchesPattern extends TypeSafeMatcher<String> {
      * Creates a matcher of {@link java.lang.String} that matches when the examined string
      * exactly matches the given {@link java.util.regex.Pattern}.
      *
+     * @param pattern
+     *     the text pattern to match.
      * @return The matcher.
      */
     public static Matcher<String> matchesPattern(Pattern pattern) {
@@ -37,6 +39,8 @@ public class MatchesPattern extends TypeSafeMatcher<String> {
      * Creates a matcher of {@link java.lang.String} that matches when the examined string
      * exactly matches the given regular expression, treated as a {@link java.util.regex.Pattern}.
      *
+     * @param regex
+     *     the regex to match.
      * @return The matcher.
      */
     public static Matcher<String> matchesPattern(String regex) {

--- a/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
@@ -69,4 +69,5 @@ public class StringContainsInOrder extends TypeSafeMatcher<String> {
     public static Matcher<String> stringContainsInOrder(String... substrings) {
         return new StringContainsInOrder(Arrays.asList(substrings));
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
@@ -7,6 +7,7 @@ import org.hamcrest.TypeSafeMatcher;
 import java.util.Arrays;
 
 public class StringContainsInOrder extends TypeSafeMatcher<String> {
+
     private final Iterable<String> substrings;
 
     public StringContainsInOrder(Iterable<String> substrings) {

--- a/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/StringContainsInOrder.java
@@ -16,7 +16,7 @@ public class StringContainsInOrder extends TypeSafeMatcher<String> {
     @Override
     public boolean matchesSafely(String s) {
         int fromIndex = 0;
-        
+
         for (String substring : substrings) {
             fromIndex = s.indexOf(substring, fromIndex);
             if (fromIndex == -1) {
@@ -24,22 +24,22 @@ public class StringContainsInOrder extends TypeSafeMatcher<String> {
             }
             fromIndex++;
         }
-        
+
         return true;
     }
-    
+
     @Override
     public void describeMismatchSafely(String item, Description mismatchDescription) {
         mismatchDescription.appendText("was \"").appendText(item).appendText("\"");
     }
-    
+
     @Override
     public void describeTo(Description description) {
         description.appendText("a string containing ")
                    .appendValueList("", ", ", "", substrings)
                    .appendText(" in order");
     }
-    
+
     /**
      * Creates a matcher of {@link String} that matches when the examined string contains all of
      * the specified substrings, considering the order of their appearance.

--- a/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
+++ b/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
@@ -25,7 +25,7 @@ public class HasXPath extends TypeSafeDiagnosingMatcher<Node> {
 
     public static final NamespaceContext NO_NAMESPACE_CONTEXT = null;
     private static final IsAnything<String> WITH_ANY_CONTENT = new IsAnything<String>("");
-    private static final Condition.Step<Object,String> NODE_EXISTS = nodeExists();
+    private static final Condition.Step<Object, String> NODE_EXISTS = nodeExists();
     private final Matcher<String> valueMatcher;
     private final XPathExpression compiledXPath;
     private final String xpathString;

--- a/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
+++ b/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Condition.notMatched;
  * @author Steve Freeman
  */
 public class HasXPath extends TypeSafeDiagnosingMatcher<Node> {
+
     public static final NamespaceContext NO_NAMESPACE_CONTEXT = null;
     private static final IsAnything<String> WITH_ANY_CONTENT = new IsAnything<String>("");
     private static final Condition.Step<Object,String> NODE_EXISTS = nodeExists();

--- a/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
+++ b/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
@@ -170,4 +170,5 @@ public class HasXPath extends TypeSafeDiagnosingMatcher<Node> {
     public static Matcher<Node> hasXPath(String xPath, NamespaceContext namespaceContext) {
         return new HasXPath(xPath, namespaceContext, WITH_ANY_CONTENT, XPathConstants.NODE);
     }
+
 }

--- a/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
+++ b/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
@@ -105,7 +105,6 @@ public class HasXPath extends TypeSafeDiagnosingMatcher<Node> {
         }
     }
 
-
     /**
      * Creates a matcher of {@link org.w3c.dom.Node}s that matches when the examined node has a value at the
      * specified <code>xPath</code> that satisfies the specified <code>valueMatcher</code>.

--- a/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
+++ b/hamcrest/src/main/java/org/hamcrest/xml/HasXPath.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Condition.notMatched;
 public class HasXPath extends TypeSafeDiagnosingMatcher<Node> {
 
     public static final NamespaceContext NO_NAMESPACE_CONTEXT = null;
-    private static final IsAnything<String> WITH_ANY_CONTENT = new IsAnything<String>("");
+    private static final IsAnything<String> WITH_ANY_CONTENT = new IsAnything<>("");
     private static final Condition.Step<Object, String> NODE_EXISTS = nodeExists();
     private final Matcher<String> valueMatcher;
     private final XPathExpression compiledXPath;

--- a/hamcrest/src/test/java/org/hamcrest/AbstractMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/AbstractMatcherTest.java
@@ -9,7 +9,7 @@ public abstract class AbstractMatcherTest extends TestCase {
    * Create an instance of the Matcher so some generic safety-net tests can be run on it.
    */
   protected abstract Matcher<?> createMatcher();
-  
+
   public static <T> void assertMatches(Matcher<T> matcher, T arg) {
       assertMatches("Expected match, but mismatched", matcher, arg);
   }
@@ -38,7 +38,7 @@ public abstract class AbstractMatcherTest extends TestCase {
     Assert.assertFalse("Precondition: Matcher should not match item.", matcher.matches(arg));
     Assert.assertEquals("Expected mismatch description", expected, mismatchDescription(matcher, arg));
   }
-  
+
   public static void assertNullSafe(Matcher<?> matcher) {
       try {
           matcher.matches(null);

--- a/hamcrest/src/test/java/org/hamcrest/BaseDescriptionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/BaseDescriptionTest.java
@@ -111,4 +111,5 @@ public final class BaseDescriptionTest {
         baseDescription.appendValue(value);
         assertEquals("<" + expected + ">", result.toString());
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/BaseDescriptionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/BaseDescriptionTest.java
@@ -14,19 +14,19 @@ public final class BaseDescriptionTest {
         }
     };
 
-    @Test public void 
+    @Test public void
     describesAppendedNullValue() {
         baseDescription.appendValue(null);
         assertEquals("null", result.toString());
     }
 
-    @Test public void 
+    @Test public void
     quotesAppendedStringValue() {
         baseDescription.appendValue("foo");
         assertEquals("\"foo\"", result.toString());
     }
 
-    @Test public void 
+    @Test public void
     quotesAppendedCharacterValue() {
         baseDescription.appendValue('f');
         assertEquals("\"f\"", result.toString());
@@ -74,39 +74,39 @@ public final class BaseDescriptionTest {
         assertEquals("<2s>", result.toString());
     }
 
-    @Test public void 
+    @Test public void
     bracketsAppendedLongValue() {
         baseDescription.appendValue(Long.valueOf("2"));
         assertEquals("<2L>", result.toString());
     }
 
-    @Test public void 
+    @Test public void
     bracketsAppendedFloatValue() {
         baseDescription.appendValue(Float.valueOf("1.2"));
         assertEquals("<1.2F>", result.toString());
     }
 
-    @Test public void 
+    @Test public void
     describesAppendedArrayValue() {
         baseDescription.appendValue(new String[] {"2", "3"});
         assertEquals("[\"2\", \"3\"]", result.toString());
     }
 
-    @Test public void 
+    @Test public void
     bracketsAppendedObjectValue() {
         final Object value = new Object();
         baseDescription.appendValue(value);
         assertEquals("<" + value.toString() + ">", result.toString());
     }
-    
-    @Test public void 
+
+    @Test public void
     safelyDescribesAppendedValueOfObjectWhoseToStringThrowsAnException() {
         final Object value = new Object() {
             @Override public String toString() {
                 throw new UnsupportedOperationException();
             }
         };
-        
+
         final String expected = value.getClass().getName() + "@" + Integer.toHexString(value.hashCode());
         baseDescription.appendValue(value);
         assertEquals("<" + expected + ">", result.toString());

--- a/hamcrest/src/test/java/org/hamcrest/BaseMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/BaseMatcherTest.java
@@ -23,4 +23,5 @@ public final class BaseMatcherTest {
 
         assertEquals("SOME DESCRIPTION", someMatcher.toString());
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/CustomMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/CustomMatcherTest.java
@@ -17,4 +17,5 @@ public final class CustomMatcherTest {
 
         assertDescription("I match strings", matcher);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
@@ -38,4 +38,5 @@ public final class CustomTypeSafeMatcherTest {
     copesWithUnknownTypes() {
         assertUnknownTypeSafe(customMatcher);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
@@ -33,7 +33,7 @@ public final class CustomTypeSafeMatcherTest {
     isNullSafe() {
         assertNullSafe(customMatcher);
     }
-    
+
     @Test public void
     copesWithUnknownTypes() {
         assertUnknownTypeSafe(customMatcher);

--- a/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/CustomTypeSafeMatcherTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import static org.hamcrest.AbstractMatcherTest.*;
 
 public final class CustomTypeSafeMatcherTest {
+
     private static final String STATIC_DESCRIPTION = "I match non empty strings";
 
     private final Matcher<String> customMatcher = new CustomTypeSafeMatcher<String>(STATIC_DESCRIPTION) {

--- a/hamcrest/src/test/java/org/hamcrest/FeatureMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/FeatureMatcherTest.java
@@ -28,7 +28,7 @@ public final class FeatureMatcherTest {
     @Test public void
     doesNotThrowClassCastException() {
         resultMatcher.matches(new ShouldNotMatch());
-        StringDescription mismatchDescription = new StringDescription(); 
+        StringDescription mismatchDescription = new StringDescription();
         resultMatcher.describeMismatch(new ShouldNotMatch(), mismatchDescription);
         assertEquals("was ShouldNotMatch <ShouldNotMatch>", mismatchDescription.toString());
     }
@@ -54,7 +54,7 @@ public final class FeatureMatcherTest {
 
     public static class ShouldNotMatch {
         @Override public String toString() { return "ShouldNotMatch"; }
-    } 
+    }
 
     private static FeatureMatcher<Thingy, String> resultMatcher() {
         return new FeatureMatcher<Thingy, String>(new Match("bar"), "Thingy with result", "result") {

--- a/hamcrest/src/test/java/org/hamcrest/FeatureMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/FeatureMatcherTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.AbstractMatcherTest.*;
 import static org.junit.Assert.assertEquals;
 
 public final class FeatureMatcherTest {
+
     private final FeatureMatcher<Thingy, String> resultMatcher = resultMatcher();
 
     @Test public void

--- a/hamcrest/src/test/java/org/hamcrest/MatcherAssertTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/MatcherAssertTest.java
@@ -96,4 +96,5 @@ public final class MatcherAssertTest {
     canAssertSubtypes() {
         assertThat(1, equalTo((Number) 1));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/MatchersTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/MatchersTest.java
@@ -1,0 +1,28 @@
+package org.hamcrest;
+
+import java.util.Arrays;
+import org.hamcrest.core.AnyOf;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class MatchersTest {
+
+    @Test
+    public void matchersContainsInAnyOrderCastTest() {
+        String[] truth = new String[] { "1", "2" };
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), containsInAnyOrder(truth));
+        Object otherTruth = truth;
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), containsInAnyOrder(otherTruth));
+    }
+
+    @Test
+    public void matchersContainsCastTest() {
+        String[] truth = new String[] { "1", "2" };
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), contains(truth));
+        Object otherTruth = truth;
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), contains(otherTruth));
+    }
+}

--- a/hamcrest/src/test/java/org/hamcrest/TypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/TypeSafeMatcherTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertFalse;
 
 @SuppressWarnings("WeakerAccess")
 public final class TypeSafeMatcherTest {
+
     private final Matcher<String> matcher = new TypeSafeMatcherSubclass();
 
     public static class TypeSafeMatcherSubclass extends TypeSafeMatcher<String> {

--- a/hamcrest/src/test/java/org/hamcrest/TypeSafeMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/TypeSafeMatcherTest.java
@@ -38,4 +38,5 @@ public final class TypeSafeMatcherTest {
       assertMismatchDescription("was a java.lang.Integer (<3>)", (Matcher)matcher, 3);
       assertMismatchDescription("The mismatch", matcher, "a string");
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyTest.java
@@ -20,7 +20,7 @@ public final class HasPropertyTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<Object> matcher = hasProperty("irrelevant");
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyTest.java
@@ -45,4 +45,5 @@ public final class HasPropertyTest {
         assertMismatchDescription("no \"aNonExistentProp\" in <[Person: a bean]>",
                                   hasProperty("aNonExistentProp"), bean);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  */
 @SuppressWarnings("UnusedDeclaration")
 public class HasPropertyWithValueTest extends AbstractMatcherTest {
+
   private final BeanWithoutInfo shouldMatch = new BeanWithoutInfo("is expected", true);
   private final BeanWithoutInfo shouldNotMatch = new BeanWithoutInfo("not expected", false);
 

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -96,7 +96,6 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
       new BeanWithBug());
   }
 
-
   public void testCanAccessAnAnonymousInnerClass() {
     class X implements IX {
       @Override

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -48,18 +48,18 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
 
   public void testMatchesBeanWithInfoWithMatchedNamedProperty() {
     assertMatches("with bean info", hasProperty("property", equalTo("with info")), beanWithInfo);
-    assertMismatchDescription("property 'property' was \"with info\"", 
+    assertMismatchDescription("property 'property' was \"with info\"",
         hasProperty("property", equalTo("without info")), beanWithInfo);
   }
 
   public void testDoesNotMatchBeanWithoutInfoOrMatchedNamedProperty() {
-    assertMismatchDescription("No property \"nonExistentProperty\"", 
+    assertMismatchDescription("No property \"nonExistentProperty\"",
                               hasProperty("nonExistentProperty", anything()), shouldNotMatch);
    }
 
   public void testDoesNotMatchWriteOnlyProperty() {
     assertMismatchDescription("property \"writeOnlyProperty\" is not readable",
-                              hasProperty("writeOnlyProperty", anything()), shouldNotMatch); 
+                              hasProperty("writeOnlyProperty", anything()), shouldNotMatch);
   }
 
   public void testMatchesPath() {
@@ -78,7 +78,7 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
   public void testMatchesPropertyAndValue() {
     assertMatches("property with value", hasProperty("property", anything()), beanWithInfo);
   }
-  
+
   public void testDoesNotWriteMismatchIfPropertyMatches() {
     Description description = new StringDescription();
     hasProperty( "property", anything()).describeMismatch(beanWithInfo, description);
@@ -161,8 +161,8 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
     @Override
     public PropertyDescriptor[] getPropertyDescriptors() {
       try {
-        return new PropertyDescriptor[] { 
-            new PropertyDescriptor("property", BeanWithInfo.class, "property", null) 
+        return new PropertyDescriptor[] {
+            new PropertyDescriptor("property", BeanWithInfo.class, "property", null)
           };
       } catch (IntrospectionException e) {
         throw new AssertionError("Introspection exception", e);

--- a/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/HasPropertyWithValueTest.java
@@ -181,4 +181,5 @@ public class HasPropertyWithValueTest extends AbstractMatcherTest {
   public static class BeanFailed extends RuntimeException {
     public BeanFailed() { super("bean failed"); }
   }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.beans.SamePropertyValuesAs.samePropertyValuesAs;
 
 @SuppressWarnings("WeakerAccess")
 public class SamePropertyValuesAsTest extends AbstractMatcherTest {
+
   private static final Value aValue = new Value("expected");
   private static final ExampleBean expectedBean = new ExampleBean("same", 1, aValue);
   private static final ExampleBean actualBean = new ExampleBean("same", 1, aValue);

--- a/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -128,4 +128,5 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
     @SuppressWarnings("unused")
     public String getExtraProperty() { return "extra"; }
   }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -10,8 +10,8 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
   private static final Value aValue = new Value("expected");
   private static final ExampleBean expectedBean = new ExampleBean("same", 1, aValue);
   private static final ExampleBean actualBean = new ExampleBean("same", 1, aValue);
-  
-  
+
+
   @Override
   protected Matcher<?> createMatcher() {
     return samePropertyValuesAs(expectedBean);
@@ -20,9 +20,9 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
   public void test_reports_match_when_all_properties_match() {
     assertMatches("matched properties", samePropertyValuesAs(expectedBean), actualBean);
   }
-  
+
   public void test_reports_mismatch_when_actual_type_is_not_assignable_to_expected_type() {
-    assertMismatchDescription("is incompatible type: ExampleBean", 
+    assertMismatchDescription("is incompatible type: ExampleBean",
                               samePropertyValuesAs((Object)aValue), actualBean);
   }
 
@@ -36,7 +36,7 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
   }
 
   public void test_matches_beans_with_inheritance_but_no_extra_properties() {
-    assertMatches("sub type with same properties", 
+    assertMatches("sub type with same properties",
         samePropertyValuesAs(expectedBean), new SubBeanWithNoExtraProperties("same", 1, aValue));
   }
 
@@ -89,7 +89,7 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
       return "Value " + value;
     }
   }
-  
+
   @SuppressWarnings("unused")
   public static class ExampleBean {
     private String stringProperty;
@@ -101,7 +101,7 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
       this.intProperty = intProperty;
       this.valueProperty = valueProperty;
     }
-    
+
     public String getStringProperty() {
       return stringProperty;
     }
@@ -114,13 +114,13 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
 
     @Override public String toString() { return "an ExampleBean"; }
   }
-  
+
   public static class SubBeanWithNoExtraProperties extends ExampleBean {
     public SubBeanWithNoExtraProperties(String stringProperty, int intProperty, Value valueProperty) {
       super(stringProperty, intProperty, valueProperty);
     }
   }
-  
+
   public static class SubBeanWithExtraProperty extends ExampleBean {
     public SubBeanWithExtraProperty(String stringProperty, int intProperty, Value valueProperty) {
       super(stringProperty, intProperty, valueProperty);

--- a/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/beans/SamePropertyValuesAsTest.java
@@ -11,7 +11,6 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
   private static final ExampleBean expectedBean = new ExampleBean("same", 1, aValue);
   private static final ExampleBean actualBean = new ExampleBean("same", 1, aValue);
 
-
   @Override
   protected Matcher<?> createMatcher() {
     return samePropertyValuesAs(expectedBean);
@@ -66,7 +65,6 @@ public class SamePropertyValuesAsTest extends AbstractMatcherTest {
             samePropertyValuesAs(expectedBean, "stringProperty", "intProperty", "valueProperty"),
             differentBean);
   }
-
 
   public void testDescribesItself() {
     assertDescription(

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
@@ -18,7 +18,7 @@ public class ArrayMatchingInAnyOrderTest extends AbstractMatcherTest {
         assertDescription("[<1>, <2>] in any order", ArrayMatching.arrayContainingInAnyOrder(equalTo(1), equalTo(2)));
         assertDescription("[<1>, <2>] in any order", ArrayMatching.arrayContainingInAnyOrder(1, 2));
     }
-    
+
     public void testMatchesItemsInAnyOrder() {
       assertMatches("in order", ArrayMatching.arrayContainingInAnyOrder(1, 2, 3), new Integer[] {1, 2, 3});
       assertMatches("out of order", ArrayMatching.arrayContainingInAnyOrder(1, 2, 3), new Integer[] {3, 2, 1});

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInAnyOrderTest.java
@@ -39,4 +39,5 @@ public class ArrayMatchingInAnyOrderTest extends AbstractMatcherTest {
       assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
       assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
@@ -42,4 +42,5 @@ public class ArrayMatchingInOrderTest extends AbstractMatcherTest {
     public void testCanHandleNullValuesInAnArray() {
       assertMatches("with nulls", arrayContaining(null, null), new Object[]{null, null});
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/ArrayMatchingInOrderTest.java
@@ -18,7 +18,7 @@ public class ArrayMatchingInOrderTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("[<1>, <2>]", arrayContaining(equalTo(1), equalTo(2)));
     }
-    
+
     public void testMatchesItemsInOrder() {
       assertMatches("in order", arrayContaining(1, 2, 3), new Integer[] {1, 2, 3});
       assertMatches("single", arrayContaining(1), new Integer[] {1});
@@ -29,7 +29,7 @@ public class ArrayMatchingInOrderTest extends AbstractMatcherTest {
       assertMatches("in order", arrayContaining(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
       assertMatches("single", arrayContaining(equalTo(1)), new Integer[] {1});
     }
-    
+
     public void testMismatchesItemsInOrder() {
       Matcher<Integer[]> matcher = arrayContaining(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -40,4 +40,5 @@ public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
       assertMismatchDescription("no item matches: <2>, <3> in [<1>]", matcher, new Integer[] {1});
       assertMismatchDescription("not matched: <4>", matcher, new Integer[] {4,3,2,1});
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInAnyOrderTest.java
@@ -19,7 +19,7 @@ public class IsArrayContainingInAnyOrderTest extends AbstractMatcherTest {
         assertDescription("[<1>, <2>] in any order", arrayContainingInAnyOrder(equalTo(1), equalTo(2)));
         assertDescription("[<1>, <2>] in any order", arrayContainingInAnyOrder(1, 2));
     }
-    
+
     public void testMatchesItemsInAnyOrder() {
       assertMatches("in order", arrayContainingInAnyOrder(1, 2, 3), new Integer[] {1, 2, 3});
       assertMatches("out of order", arrayContainingInAnyOrder(1, 2, 3), new Integer[] {3, 2, 1});

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
@@ -18,7 +18,7 @@ public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("[<1>, <2>]", arrayContaining(equalTo(1), equalTo(2)));
     }
-    
+
     public void testMatchesItemsInOrder() {
       assertMatches("in order", arrayContaining(1, 2, 3), new Integer[] {1, 2, 3});
       assertMatches("single", arrayContaining(1), new Integer[] {1});
@@ -29,7 +29,7 @@ public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
       assertMatches("in order", arrayContaining(equalTo(1), equalTo(2), equalTo(3)), new Integer[] {1, 2, 3});
       assertMatches("single", arrayContaining(equalTo(1)), new Integer[] {1});
     }
-    
+
     public void testMismatchesItemsInOrder() {
       Matcher<Integer[]> matcher = arrayContaining(1, 2, 3);
       assertMismatchDescription("was null", matcher, null);

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayContainingInOrderTest.java
@@ -38,4 +38,5 @@ public class IsArrayContainingInOrderTest extends AbstractMatcherTest {
       assertMismatchDescription("item 0: was <4>", matcher, new Integer[] {4,3,2,1});
       assertMismatchDescription("item 2: was <4>", matcher, new Integer[] {1,2, 4});
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayTest.java
@@ -56,4 +56,5 @@ public class IsArrayTest extends AbstractMatcherTest {
         };
         assertMismatchDescription("element <0> didn't match", array(m, equalTo("b")), new String[]{"c", "b"});
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayTest.java
@@ -20,32 +20,32 @@ public class IsArrayTest extends AbstractMatcherTest {
         assertMatches("should match array with matching elements",
                 array(equalTo("a"), equalTo("b"), equalTo("c")), new String[]{"a", "b", "c"});
     }
-    
+
     public void testDoesNotMatchAnArrayWhenElementsDoNotMatch() {
         assertDoesNotMatch("should not match array with different elements",
                 array(equalTo("a"), equalTo("b")), new String[]{"b", "c"});
     }
-    
+
     public void testDoesNotMatchAnArrayOfDifferentSize() {
         assertDoesNotMatch("should not match larger array",
                            array(equalTo("a"), equalTo("b")), new String[]{"a", "b", "c"});
         assertDoesNotMatch("should not match smaller array",
                            array(equalTo("a"), equalTo("b")), new String[]{"a"});
     }
-    
+
     public void testDoesNotMatchNull() {
         assertDoesNotMatch("should not match null",
                 array(equalTo("a")), null);
     }
-    
+
     public void testHasAReadableDescription() {
         assertDescription("[\"a\", \"b\"]", array(equalTo("a"), equalTo("b")));
     }
-    
+
     public void testHasAReadableMismatchDescriptionUsing() {
         assertMismatchDescription("element <0> was \"c\"", array(equalTo("a"), equalTo("b")), new String[]{"c", "b"});
     }
-    
+
     public void testHasAReadableMismatchDescriptionUsingCustomMatchers() {
         final BaseMatcher<String> m = new BaseMatcher<String>() {
             @Override public boolean matches(Object item) { return false; }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsArrayWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsArrayWithSizeTest.java
@@ -33,4 +33,5 @@ public class IsArrayWithSizeTest extends AbstractMatcherTest {
         assertDescription("an array with size <3>", arrayWithSize(equalTo(3)));
         assertDescription("an empty array", emptyArray());
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
@@ -74,4 +74,5 @@ public class IsCollectionWithSizeTest extends AbstractMatcherTest {
       ArrayList<String> arrayList = new ArrayList<String>();
       MatcherAssert.assertThat(arrayList, hasSize(0));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
@@ -68,7 +68,7 @@ public class IsCollectionWithSizeTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("a collection with size <3>", hasSize(equalTo(3)));
     }
-    
+
     public void testCompilesWithATypedCollection() {
       // To prove Issue 43
       ArrayList<String> arrayList = new ArrayList<String>();

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsCollectionWithSizeTest.java
@@ -71,7 +71,7 @@ public class IsCollectionWithSizeTest extends AbstractMatcherTest {
 
     public void testCompilesWithATypedCollection() {
       // To prove Issue 43
-      ArrayList<String> arrayList = new ArrayList<String>();
+      ArrayList<String> arrayList = new ArrayList<>();
       MatcherAssert.assertThat(arrayList, hasSize(0));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
@@ -36,11 +36,11 @@ public class IsEmptyCollectionTest extends AbstractMatcherTest {
     private void needs(@SuppressWarnings("unused") Matcher<Collection<String>> bar) { }
 
     private static Collection<String> collectionOfValues() {
-        return new ArrayList<String>(asList("one", "three"));
+        return new ArrayList<>(asList("one", "three"));
     }
 
     private static Collection<Integer> emptyCollection() {
-        return new ArrayList<Integer>();
+        return new ArrayList<>();
     }
 
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
@@ -34,7 +34,7 @@ public class IsEmptyCollectionTest extends AbstractMatcherTest {
     }
 
     private void needs(@SuppressWarnings("unused") Matcher<Collection<String>> bar) { }
-    
+
     private static Collection<String> collectionOfValues() {
         return new ArrayList<String>(asList("one", "three"));
     }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyCollectionTest.java
@@ -42,4 +42,5 @@ public class IsEmptyCollectionTest extends AbstractMatcherTest {
     private static Collection<Integer> emptyCollection() {
         return new ArrayList<Integer>();
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
@@ -41,4 +41,5 @@ public class IsEmptyIterableTest extends AbstractMatcherTest {
     private static Collection<Integer> emptyCollection() {
         return new ArrayList<Integer>();
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsEmptyIterableTest.java
@@ -35,11 +35,11 @@ public class IsEmptyIterableTest extends AbstractMatcherTest {
     private void needs(@SuppressWarnings("unused") Matcher<Iterable<String>> bar) { }
 
     private static Collection<String> collectionOfValues() {
-        return new ArrayList<String>(asList("one", "three"));
+        return new ArrayList<>(asList("one", "three"));
     }
 
     private static Collection<Integer> emptyCollection() {
-        return new ArrayList<Integer>();
+        return new ArrayList<>();
     }
 
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class IsInTest extends AbstractMatcherTest {
+
     String[] elements = {"a", "b", "c"};
 
     @Override

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
@@ -13,12 +13,12 @@ public class IsInTest extends AbstractMatcherTest {
 
     @Override
     protected Matcher<?> createMatcher() {
-        return new IsIn<String>(elements);
+        return new IsIn<>(elements);
     }
 
     public void testReturnsTrueIfArgumentIsInCollection() {
         Collection<String> collection = Arrays.asList(elements);
-        Matcher<String> isIn = new IsIn<String>(collection);
+        Matcher<String> isIn = new IsIn<>(collection);
 
         assertMatches("a", isIn, "a");
         assertMatches("b", isIn, "b");
@@ -27,7 +27,7 @@ public class IsInTest extends AbstractMatcherTest {
     }
 
     public void testReturnsTrueIfArgumentIsInArray() {
-        Matcher<String> isIn = new IsIn<String>(elements);
+        Matcher<String> isIn = new IsIn<>(elements);
 
         assertMatches("a", isIn, "a");
         assertMatches("b", isIn, "b");
@@ -36,7 +36,7 @@ public class IsInTest extends AbstractMatcherTest {
     }
 
     public void testHasReadableDescription() {
-        Matcher<String> isIn = new IsIn<String>(elements);
+        Matcher<String> isIn = new IsIn<>(elements);
 
         assertEquals("description",
             "one of {\"a\", \"b\", \"c\"}",

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
@@ -41,4 +41,5 @@ public class IsInTest extends AbstractMatcherTest {
             "one of {\"a\", \"b\", \"c\"}", 
             StringDescription.toString(isIn));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsInTest.java
@@ -18,27 +18,27 @@ public class IsInTest extends AbstractMatcherTest {
     public void testReturnsTrueIfArgumentIsInCollection() {
         Collection<String> collection = Arrays.asList(elements);
         Matcher<String> isIn = new IsIn<String>(collection);
-        
+
         assertMatches("a", isIn, "a");
         assertMatches("b", isIn, "b");
         assertMatches("c", isIn, "c");
         assertDoesNotMatch("d", isIn, "d");
     }
-    
+
     public void testReturnsTrueIfArgumentIsInArray() {
         Matcher<String> isIn = new IsIn<String>(elements);
-        
+
         assertMatches("a", isIn, "a");
         assertMatches("b", isIn, "b");
         assertMatches("c", isIn, "c");
         assertDoesNotMatch("d", isIn, "d");
     }
-    
+
     public void testHasReadableDescription() {
         Matcher<String> isIn = new IsIn<String>(elements);
-        
-        assertEquals("description", 
-            "one of {\"a\", \"b\", \"c\"}", 
+
+        assertEquals("description",
+            "one of {\"a\", \"b\", \"c\"}",
             StringDescription.toString(isIn));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
@@ -51,4 +51,5 @@ public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("iterable with items [<1>, <2>] in any order", containsInAnyOrder(1, 2));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInAnyOrderTest.java
@@ -16,7 +16,7 @@ public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
     @Override
     protected Matcher<?> createMatcher() {
         return containsInAnyOrder(1, 2);
-    }   
+    }
 
     public void testMatchesSingleItemIterable() {
       assertMatches("single item", containsInAnyOrder(1), asList(1));
@@ -25,15 +25,15 @@ public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
     public void testDoesNotMatchEmpty() {
         assertMismatchDescription("no item matches: <1>, <2> in []", containsInAnyOrder(1, 2), Collections.<Integer>emptyList());
     }
-    
+
     public void testMatchesIterableOutOfOrder() {
         assertMatches("Out of order", containsInAnyOrder(1, 2), asList(2, 1));
     }
-    
+
     public void testMatchesIterableInOrder() {
         assertMatches("In order", containsInAnyOrder(1, 2), asList(1, 2));
     }
-    
+
     public void testDoesNotMatchIfOneOfMultipleElementsMismatches() {
         assertMismatchDescription("not matched: <4>", containsInAnyOrder(1, 2, 3), asList(1, 2, 4));
     }
@@ -43,7 +43,7 @@ public class IsIterableContainingInAnyOrderTest extends AbstractMatcherTest {
         final Matcher<Iterable<? extends WithValue>> helpTheCompilerOut = containsInAnyOrder(value(1), value(3));
         assertMismatchDescription("not matched: <WithValue 2>", helpTheCompilerOut, asList(make(1), make(2), make(3)));
     }
-    
+
     public void testDoesNotMatchIfThereAreMoreMatchersThanElements() {
         assertMismatchDescription("no item matches: <4> in [<1>, <2>, <3>]", containsInAnyOrder(1, 2, 3, 4), asList(1, 2, 3));
     }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
@@ -52,7 +52,7 @@ public class IsIterableContainingInOrderTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("iterable containing [<1>, <2>]", contains(1, 2));
     }
-    
+
     public void testCanHandleNullMatchers() {
         assertMatches(contains(null, null), asList(null, null));
     }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 
 @SuppressWarnings("unchecked")
 public class IsIterableContainingInOrderTest extends AbstractMatcherTest {
+
     // temporary hack until the Java type system works
     private final Matcher<Iterable<? extends WithValue>> contains123 = contains(value(1), value(2), value(3));
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInOrderTest.java
@@ -73,4 +73,5 @@ public class IsIterableContainingInOrderTest extends AbstractMatcherTest {
         @Override protected Integer featureValueOf(WithValue actual) { return actual.getValue(); }
       };
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInRelativeOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInRelativeOrderTest.java
@@ -90,4 +90,5 @@ public class IsIterableContainingInRelativeOrderTest extends AbstractMatcherTest
         @Override protected Integer featureValueOf(WithValue actual) { return actual.getValue(); }
       };
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInRelativeOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableContainingInRelativeOrderTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 
 @SuppressWarnings("unchecked")
 public class IsIterableContainingInRelativeOrderTest extends AbstractMatcherTest {
+
     // temporary hack until the Java type system works
     private final Matcher<Iterable<? extends WithValue>> contains123 = containsInRelativeOrder(value(1), value(2), value(3));
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsIterableWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsIterableWithSizeTest.java
@@ -34,4 +34,5 @@ public class IsIterableWithSizeTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("an iterable with size <4>", iterableWithSize(4));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -18,14 +18,14 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     }
 
     public void testMatchesSingletonMapContainingKey() {
-        Map<String, Integer> map = new HashMap<String, Integer>();
+        Map<String, Integer> map = new HashMap<>();
         map.put("a", 1);
 
         assertMatches("Matches single key", hasKey("a"), map);
     }
 
     public void testMatchesMapContainingKey() {
-        Map<String, Integer> map = new HashMap<String, Integer>();
+        Map<String, Integer> map = new HashMap<>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);
@@ -46,7 +46,7 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
 //    }
 
     public void testMatchesMapContainingKeyWithIntegerKeys() throws Exception {
-        Map<Integer, String> map = new HashMap<Integer, String>();
+        Map<Integer, String> map = new HashMap<>();
         map.put(1, "A");
         map.put(2, "B");
 
@@ -54,7 +54,7 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     }
 
     public void testMatchesMapContainingKeyWithNumberKeys() throws Exception {
-        Map<Number, String> map = new HashMap<Number, String>();
+        Map<Number, String> map = new HashMap<>();
         map.put(1, "A");
         map.put(2, "B");
 
@@ -73,7 +73,7 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     }
 
     public void testDoesNotMatchMapMissingKey() {
-        Map<String, Integer> map = new TreeMap<String, Integer>();
+        Map<String, Integer> map = new TreeMap<>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -18,14 +18,14 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     }
 
     public void testMatchesSingletonMapContainingKey() {
-        Map<String,Integer> map = new HashMap<String, Integer>();
+        Map<String, Integer> map = new HashMap<String, Integer>();
         map.put("a", 1);
 
         assertMatches("Matches single key", hasKey("a"), map);
     }
 
     public void testMatchesMapContainingKey() {
-        Map<String,Integer> map = new HashMap<String, Integer>();
+        Map<String, Integer> map = new HashMap<String, Integer>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);
@@ -69,11 +69,11 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     }
 
     public void testDoesNotMatchEmptyMap() {
-        assertMismatchDescription("map was []", hasKey("Foo"), new HashMap<String,Integer>());
+        assertMismatchDescription("map was []", hasKey("Foo"), new HashMap<String, Integer>());
     }
 
     public void testDoesNotMatchMapMissingKey() {
-        Map<String,Integer> map = new TreeMap<String, Integer>();
+        Map<String, Integer> map = new TreeMap<String, Integer>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -20,20 +20,20 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     public void testMatchesSingletonMapContainingKey() {
         Map<String,Integer> map = new HashMap<String, Integer>();
         map.put("a", 1);
-        
+
         assertMatches("Matches single key", hasKey("a"), map);
     }
-    
+
     public void testMatchesMapContainingKey() {
         Map<String,Integer> map = new HashMap<String, Integer>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);
-        
+
         assertMatches("Matches a", hasKey("a"), map);
         assertMatches("Matches c", hasKey("c"), map);
     }
-    
+
 
 //    No longer compiles
 //    public void testMatchesMapContainingKeyWithNoGenerics() {
@@ -68,17 +68,17 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
     public void testHasReadableDescription() {
         assertDescription("map containing [\"a\"->ANYTHING]", hasKey("a"));
     }
-    
+
     public void testDoesNotMatchEmptyMap() {
         assertMismatchDescription("map was []", hasKey("Foo"), new HashMap<String,Integer>());
     }
-    
+
     public void testDoesNotMatchMapMissingKey() {
         Map<String,Integer> map = new TreeMap<String, Integer>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);
-        
+
         assertMismatchDescription("map was [<a=1>, <b=2>, <c=3>]", hasKey("d"), map);
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -81,4 +81,5 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
         
         assertMismatchDescription("map was [<a=1>, <b=2>, <c=3>]", hasKey("d"), map);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingKeyTest.java
@@ -34,7 +34,6 @@ public class IsMapContainingKeyTest extends AbstractMatcherTest {
         assertMatches("Matches c", hasKey("c"), map);
     }
 
-
 //    No longer compiles
 //    public void testMatchesMapContainingKeyWithNoGenerics() {
 //        Map map = new HashMap();

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
@@ -46,4 +46,5 @@ public class IsMapContainingTest extends AbstractMatcherTest {
     public void testHasReadableDescription() {
         assertDescription("map containing [\"a\"-><2>]", hasEntry(equalTo("a"), (equalTo(2))));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
@@ -19,7 +19,7 @@ public class IsMapContainingTest extends AbstractMatcherTest {
     }
 
     public void testMatchesMapContainingMatchingKeyAndValue() {
-        Map<String,Integer> map = new TreeMap<>();
+        Map<String, Integer> map = new TreeMap<>();
         map.put("a", 1);
         map.put("b", 2);
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -1,6 +1,5 @@
 package org.hamcrest.collection;
 
-
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -43,4 +43,5 @@ public class IsMapContainingValueTest extends AbstractMatcherTest {
         assertMatches("hasValue 3", hasValue(3), map);      
         assertMismatchDescription("map was [<a=1>, <b=2>, <c=3>]", hasValue(4), map);      
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -21,19 +21,19 @@ public class IsMapContainingValueTest extends AbstractMatcherTest {
     }
 
     public void testDoesNotMatchEmptyMap() {
-        Map<String,Integer> map = new HashMap<String,Integer>();
+        Map<String, Integer> map = new HashMap<String, Integer>();
         assertMismatchDescription("map was []", hasValue(1), map);
     }
 
     public void testMatchesSingletonMapContainingValue() {
-        Map<String,Integer> map = new HashMap<String,Integer>();
+        Map<String, Integer> map = new HashMap<String, Integer>();
         map.put("a", 1);
 
         assertMatches("Singleton map", hasValue(1), map);
     }
 
     public void testMatchesMapContainingValue() {
-        Map<String,Integer> map = new TreeMap<String,Integer>();
+        Map<String, Integer> map = new TreeMap<String, Integer>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -20,16 +20,16 @@ public class IsMapContainingValueTest extends AbstractMatcherTest {
     public void testHasReadableDescription() {
         assertDescription("map containing [ANYTHING->\"a\"]", hasValue("a"));
     }
-    
+
     public void testDoesNotMatchEmptyMap() {
         Map<String,Integer> map = new HashMap<String,Integer>();
         assertMismatchDescription("map was []", hasValue(1), map);
     }
-    
+
     public void testMatchesSingletonMapContainingValue() {
         Map<String,Integer> map = new HashMap<String,Integer>();
         map.put("a", 1);
-        
+
         assertMatches("Singleton map", hasValue(1), map);
     }
 
@@ -38,10 +38,10 @@ public class IsMapContainingValueTest extends AbstractMatcherTest {
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);
-        
-        assertMatches("hasValue 1", hasValue(1), map);      
-        assertMatches("hasValue 3", hasValue(3), map);      
-        assertMismatchDescription("map was [<a=1>, <b=2>, <c=3>]", hasValue(4), map);      
+
+        assertMatches("hasValue 1", hasValue(1), map);
+        assertMatches("hasValue 3", hasValue(3), map);
+        assertMismatchDescription("map was [<a=1>, <b=2>, <c=3>]", hasValue(4), map);
     }
 
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingValueTest.java
@@ -21,19 +21,19 @@ public class IsMapContainingValueTest extends AbstractMatcherTest {
     }
 
     public void testDoesNotMatchEmptyMap() {
-        Map<String, Integer> map = new HashMap<String, Integer>();
+        Map<String, Integer> map = new HashMap<>();
         assertMismatchDescription("map was []", hasValue(1), map);
     }
 
     public void testMatchesSingletonMapContainingValue() {
-        Map<String, Integer> map = new HashMap<String, Integer>();
+        Map<String, Integer> map = new HashMap<>();
         map.put("a", 1);
 
         assertMatches("Singleton map", hasValue(1), map);
     }
 
     public void testMatchesMapContainingValue() {
-        Map<String, Integer> map = new TreeMap<String, Integer>();
+        Map<String, Integer> map = new TreeMap<>();
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
@@ -66,12 +66,12 @@ public final class IsMapWithSizeTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("a map with size <3>", aMapWithSize(equalTo(3)));
     }
-    
+
     public void testCompilesWithATypedMap() {
       Map<String, Integer> arrayList = new HashMap<String, Integer>();
       MatcherAssert.assertThat(arrayList, aMapWithSize(0));
     }
-    
+
     private static <K, V> Map<K, V> mapWithKeys(K... keys) {
         final Map<K, V> result = new HashMap<K, V>();
         for (K key : keys) {

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
@@ -79,4 +79,5 @@ public final class IsMapWithSizeTest extends AbstractMatcherTest {
         }
         return result;
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapWithSizeTest.java
@@ -68,12 +68,12 @@ public final class IsMapWithSizeTest extends AbstractMatcherTest {
     }
 
     public void testCompilesWithATypedMap() {
-      Map<String, Integer> arrayList = new HashMap<String, Integer>();
+      Map<String, Integer> arrayList = new HashMap<>();
       MatcherAssert.assertThat(arrayList, aMapWithSize(0));
     }
 
     private static <K, V> Map<K, V> mapWithKeys(K... keys) {
-        final Map<K, V> result = new HashMap<K, V>();
+        final Map<K, V> result = new HashMap<>();
         for (K key : keys) {
             result.put(key, null);
         }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsUnmodifiableCollectionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsUnmodifiableCollectionTest.java
@@ -1,0 +1,140 @@
+package org.hamcrest.collection;
+
+import org.hamcrest.AbstractMatcherTest;
+import org.hamcrest.Matcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.hamcrest.collection.IsUnmodifiableCollection.isUnmodifiable;
+
+public class IsUnmodifiableCollectionTest extends AbstractMatcherTest {
+
+    @Override
+    protected Matcher<?> createMatcher() {
+        return isUnmodifiable();
+    }
+
+    public void testMatchesUnmodifiableList() {
+        assertMatches("truly unmodifiable list", isUnmodifiable(), Collections.unmodifiableList(Collections.emptyList()));
+    }
+
+    public void testMatchesUnmodifiableSet() {
+        assertMatches("truly unmodifiable set", isUnmodifiable(), Collections.unmodifiableSet(Collections.emptySet()));
+    }
+
+    public void testMatchesUnmodifiableCollection() {
+        assertMatches("truly unmodifiable collection", isUnmodifiable(), Collections.unmodifiableCollection(Arrays.asList(1,2,3)));
+    }
+
+    public void testMismatchesArrayList() {
+        assertMismatchDescription("was able to add a value into the collection", isUnmodifiable(), new ArrayList<>());
+    }
+
+    public void testMismatchesArraysList() {
+        assertMismatchDescription("was able to remove a value from the collection", isUnmodifiable(), Arrays.asList(1,2,3));
+    }
+
+    public void testMismatchesHashSet() {
+        assertMismatchDescription("was able to add a value into the collection", isUnmodifiable(), new HashSet<>());
+    }
+
+    public void testMismatchesPartiallyUnmodifiableListAllowingAddAll() {
+        assertMismatchDescription("was able to perform addAll on the collection", isUnmodifiable(), new ArrayList<String>() {
+            @Override
+            public boolean add(String s) {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    public void testMismatchesPartiallyUnmodifiableListAllowingRemove() {
+        assertMismatchDescription("was able to remove a value from the collection", isUnmodifiable(), new ArrayList<String>() {
+            @Override
+            public boolean add(String s) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean addAll(Collection<? extends String> c) {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    public void testMismatchesPartiallyUnmodifiableListAllowingRemoveAll() {
+        assertMismatchDescription("was able to perform removeAll on the collection", isUnmodifiable(), new ArrayList<String>() {
+            @Override
+            public boolean add(String s) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean addAll(Collection<? extends String> c) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean remove(Object o) {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    public void testMismatchesPartiallyUnmodifiableListAllowingRetainAll() {
+        assertMismatchDescription("was able to perform retainAll on the collection", isUnmodifiable(), new ArrayList<String>() {
+            @Override
+            public boolean add(String s) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean addAll(Collection<? extends String> c) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean remove(Object o) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean removeAll(Collection<?> c) {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    public void testMismatchesPartiallyUnmodifiableListAllowingClear() {
+        assertMismatchDescription("was able to clear the collection", isUnmodifiable(), new ArrayList<String>() {
+            @Override
+            public boolean add(String s) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean addAll(Collection<? extends String> c) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean remove(Object o) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean removeAll(Collection<?> c) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean retainAll(Collection<?> c) {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+}

--- a/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherBuilderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherBuilderTest.java
@@ -69,7 +69,6 @@ public class ComparatorMatcherBuilderTest extends AbstractMatcherTest {
         assertThat(0, integerComparatorMatcherBuilder.lessThan(1));
     }
 
-
     public void testComparesObjectsForEquality() {
         assertThat(3, integerComparatorMatcherBuilder.comparesEqualTo(3));
         assertThat("aa", stringComparatorMatcherBuilder.comparesEqualTo("aa"));

--- a/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherBuilderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherBuilderTest.java
@@ -125,4 +125,5 @@ public class ComparatorMatcherBuilderTest extends AbstractMatcherTest {
             return value - other.value;
         }
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherTest.java
@@ -47,7 +47,6 @@ public class ComparatorMatcherTest extends AbstractMatcherTest {
         assertThat(0, lessThan(1));
     }
 
-
     public void testComparesObjectsForEquality() {
         assertThat(3, comparesEqualTo(3));
         assertThat("aa", comparesEqualTo("aa"));

--- a/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/comparator/ComparatorMatcherTest.java
@@ -84,4 +84,5 @@ public class ComparatorMatcherTest extends AbstractMatcherTest {
             return value - other.value;
         }
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
@@ -67,4 +67,5 @@ public final class AllOfTest {
     varargs(){
         assertThat("the text!", new AllOf<>(startsWith("the"), containsString("text"), endsWith("!")));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
@@ -18,15 +18,15 @@ public final class AllOfTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = allOf(equalTo("irrelevant"), startsWith("irr"));
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
-    
+
     @Test public void
     evaluatesToTheTheLogicalConjunctionOfTwoOtherMatchers() {
         Matcher<String> matcher = allOf(startsWith("goo"), endsWith("ood"));
-        
+
         assertMatches("didn't pass both sub-matchers", matcher, "good");
         assertDoesNotMatch("didn't fail first sub-matcher", matcher, "mood");
         assertDoesNotMatch("didn't fail second sub-matcher", matcher, "goon");
@@ -36,11 +36,11 @@ public final class AllOfTest {
     @Test public void
     evaluatesToTheTheLogicalConjunctionOfManyOtherMatchers() {
         Matcher<String> matcher = allOf(startsWith("g"), startsWith("go"), endsWith("d"), startsWith("go"), startsWith("goo"));
-        
+
         assertMatches("didn't pass all sub-matchers", matcher, "good");
         assertDoesNotMatch("didn't fail middle sub-matcher", matcher, "goon");
     }
-    
+
     @Test public void
     supportsMixedTypes() {
         final Matcher<SampleSubClass> matcher = allOf(
@@ -48,10 +48,10 @@ public final class AllOfTest {
                 is(notNullValue()),
                 equalTo(new SampleBaseClass("good")),
                 equalTo(new SampleSubClass("ugly")));
-        
+
         assertDoesNotMatch("didn't fail last sub-matcher", matcher, new SampleSubClass("good"));
     }
-    
+
     @Test public void
     hasAReadableDescription() {
         assertDescription("(\"good\" and \"bad\" and \"ugly\")",

--- a/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AllOfTest.java
@@ -64,7 +64,7 @@ public final class AllOfTest {
     }
 
     @Test public void
-    varargs(){
+    varargs() {
         assertThat("the text!", new AllOf<>(startsWith("the"), containsString("text"), endsWith("!")));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
@@ -15,7 +15,7 @@ public final class AnyOfTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = anyOf(equalTo("irrelevant"), startsWith("irr"));
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
@@ -23,7 +23,7 @@ public final class AnyOfTest {
     @Test public void
     evaluatesToTheTheLogicalDisjunctionOfTwoOtherMatchers() {
         Matcher<String> matcher = anyOf(startsWith("goo"), endsWith("ood"));
-        
+
         assertMatches("didn't pass both sub-matchers", matcher, "good");
         assertMatches("didn't pass second sub-matcher", matcher, "mood");
         assertMatches("didn't pass first sub-matcher", matcher, "goon");
@@ -33,7 +33,7 @@ public final class AnyOfTest {
     @Test public void
     evaluatesToTheTheLogicalDisjunctionOfManyOtherMatchers() {
         Matcher<String> matcher = anyOf(startsWith("g"), startsWith("go"), endsWith("d"), startsWith("go"), startsWith("goo"));
-        
+
         assertMatches("didn't pass middle sub-matcher", matcher, "vlad");
         assertDoesNotMatch("didn't fail all sub-matchers", matcher, "flan");
     }
@@ -45,7 +45,7 @@ public final class AnyOfTest {
                 equalTo(new SampleBaseClass("bad")),
                 equalTo(new SampleBaseClass("good")),
                 equalTo(new SampleSubClass("ugly")));
-        
+
         assertMatches("didn't pass middle sub-matcher", matcher, new SampleSubClass("good"));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
@@ -56,7 +56,7 @@ public final class AnyOfTest {
     }
 
     @Test public void
-    varargs(){
+    varargs() {
         assertThat("the text!", new AnyOf<>(startsWith("the"), endsWith(".")));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/AnyOfTest.java
@@ -59,4 +59,5 @@ public final class AnyOfTest {
     varargs(){
         assertThat("the text!", new AnyOf<>(startsWith("the"), endsWith(".")));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
@@ -65,4 +65,5 @@ public final class CombinableTest {
         @SuppressWarnings("unused")
         Matcher<String> matcher = CombinableMatcher.both(equalTo("yellow")).and(notNullValue(String.class));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
@@ -29,7 +29,7 @@ public final class CombinableTest {
     @Test public void
     acceptsAndRejectsThreeAnds() {
         CombinableMatcher<? super Integer> tripleAnd = NOT_3_AND_NOT_4.and(equalTo(2));
-        
+
         assertMatches("tripleAnd didn't pass", tripleAnd, 2);
         assertDoesNotMatch("tripleAnd didn't fail", tripleAnd, 3);
     }
@@ -49,7 +49,7 @@ public final class CombinableTest {
     @Test public void
     acceptsAndRejectsThreeOrs() {
         final CombinableMatcher<Integer> tripleOr = EITHER_3_OR_4.or(equalTo(11));
-        
+
         assertMatches("tripleOr didn't pass", tripleOr, 11);
         assertDoesNotMatch("tripleOr didn't fail", tripleOr, 9);
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/CombinableTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 public final class CombinableTest {
+
     private static final CombinableMatcher<Integer> EITHER_3_OR_4 = CombinableMatcher.either(equalTo(3)).or(equalTo(4));
     private static final CombinableMatcher<Integer> NOT_3_AND_NOT_4 = CombinableMatcher.both(not(equalTo(3))).and(not(equalTo(4)));
 

--- a/hamcrest/src/test/java/org/hamcrest/core/DescribedAsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/DescribedAsTest.java
@@ -46,4 +46,5 @@ public final class DescribedAsTest {
 
         assertMismatchDescription("was <1>", matcher, 1);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/EveryTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/EveryTest.java
@@ -40,5 +40,5 @@ public final class EveryTest {
     describesAMismatch() {
         assertMismatchDescription("an item was \"BXB\"", matcher, singletonList("BXB"));
     }
-}
 
+}

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -99,5 +99,5 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
         }
       };
     }
-}
 
+}

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -48,9 +48,9 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
     public void testCanMatchItemWhenCollectionHoldsSuperclass() // Issue 24
     {
       final Set<Number> s = new HashSet<Number>();
-      s.add(Integer.valueOf(2));
-      assertThat(s, new IsCollectionContaining<Number>(new IsEqual<Number>(Integer.valueOf(2))));
-      assertThat(s, IsCollectionContaining.hasItem(Integer.valueOf(2)));
+      s.add(2);
+      assertThat(s, new IsCollectionContaining<Number>(new IsEqual<Number>(2)));
+      assertThat(s, IsCollectionContaining.hasItem(2));
     }
 
     @SuppressWarnings("unchecked")

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class IsCollectionContainingTest extends AbstractMatcherTest {
+
     @Override
     protected Matcher<?> createMatcher() {
         return hasItem(equalTo("irrelevant"));

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -23,7 +23,7 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
 
     public void testMatchesACollectionThatContainsAnElementMatchingTheGivenMatcher() {
         Matcher<Iterable<? super String>> itemMatcher = hasItem(equalTo("a"));
-        
+
         assertMatches("should match list that contains 'a'",
                 itemMatcher, asList("a", "b", "c"));
     }
@@ -31,8 +31,8 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
     public void testDoesNotMatchCollectionThatDoesntContainAnElementMatchingTheGivenMatcher() {
         final Matcher<Iterable<? super String>> matcher1 = hasItem(mismatchable("a"));
         assertMismatchDescription("mismatches were: [mismatched: b, mismatched: c]", matcher1, asList("b", "c"));
-        
-        
+
+
         final Matcher<Iterable<? super String>> matcher2 = hasItem(equalTo("a"));
         assertMismatchDescription("was empty", matcher2, new ArrayList<String>());
     }
@@ -44,7 +44,7 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("a collection containing \"a\"", hasItem(equalTo("a")));
     }
-    
+
     public void testCanMatchItemWhenCollectionHoldsSuperclass() // Issue 24
     {
       final Set<Number> s = new HashSet<Number>();
@@ -59,36 +59,36 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
         assertMatches("should match list containing all items",
                 matcher1,
                 asList("a", "b", "c"));
-        
+
         final Matcher<Iterable<String>> matcher2 = hasItems("a", "b", "c");
         assertMatches("should match list containing all items (without matchers)",
                 matcher2,
                 asList("a", "b", "c"));
-        
+
         final Matcher<Iterable<String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("should match list containing all items in any order",
                 matcher3,
                 asList("c", "b", "a"));
-        
+
         final Matcher<Iterable<String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("should match list containing all items plus others",
                 matcher4,
                 asList("e", "c", "b", "a", "d"));
-        
+
         final Matcher<Iterable<String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertDoesNotMatch("should not match list unless it contains all items",
                 matcher5,
                 asList("e", "c", "b", "d")); // 'a' missing
     }
-    
-    
+
+
     private static Matcher<? super String> mismatchable(final String string) {
       return new TypeSafeDiagnosingMatcher<String>() {
         @Override
         protected boolean matchesSafely(String item, Description mismatchDescription) {
-          if (string.equals(item)) 
+          if (string.equals(item))
             return true;
-          
+
           mismatchDescription.appendText("mismatched: " + item);
           return false;
         }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -47,9 +47,9 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
 
     public void testCanMatchItemWhenCollectionHoldsSuperclass() // Issue 24
     {
-      final Set<Number> s = new HashSet<Number>();
+      final Set<Number> s = new HashSet<>();
       s.add(2);
-      assertThat(s, new IsCollectionContaining<Number>(new IsEqual<Number>(2)));
+      assertThat(s, new IsCollectionContaining<>(new IsEqual<Number>(2)));
       assertThat(s, IsCollectionContaining.hasItem(2));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -32,7 +32,6 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
         final Matcher<Iterable<? super String>> matcher1 = hasItem(mismatchable("a"));
         assertMismatchDescription("mismatches were: [mismatched: b, mismatched: c]", matcher1, asList("b", "c"));
 
-
         final Matcher<Iterable<? super String>> matcher2 = hasItem(equalTo("a"));
         assertMismatchDescription("was empty", matcher2, new ArrayList<String>());
     }
@@ -80,7 +79,6 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
                 matcher5,
                 asList("e", "c", "b", "d")); // 'a' missing
     }
-
 
     private static Matcher<? super String> mismatchable(final String string) {
       return new TypeSafeDiagnosingMatcher<String>() {

--- a/hamcrest/src/test/java/org/hamcrest/core/IsEqualTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsEqualTest.java
@@ -153,5 +153,5 @@ public final class IsEqualTest {
     returnsGoodDescriptionIfCreatedWithNullReference() {
         assertDescription("null", equalTo(null));
     }
-}
 
+}

--- a/hamcrest/src/test/java/org/hamcrest/core/IsEqualTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsEqualTest.java
@@ -33,7 +33,7 @@ public final class IsEqualTest {
     @Test public void
     canCompareNullValues() {
         final Matcher<Object> matcher = equalTo(null);
-        
+
         assertMatches(matcher, null);
         assertDoesNotMatch(matcher, 2);
         assertDoesNotMatch(matcher, "hi");

--- a/hamcrest/src/test/java/org/hamcrest/core/IsInstanceOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsInstanceOfTest.java
@@ -65,5 +65,5 @@ public final class IsInstanceOfTest {
     private static <T> T with(@SuppressWarnings("unused") Matcher<T> matcher) {
         return null;
     }
-}
 
+}

--- a/hamcrest/src/test/java/org/hamcrest/core/IsInstanceOfTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsInstanceOfTest.java
@@ -61,7 +61,6 @@ public final class IsInstanceOfTest {
         Integer anInteger = with(any(Integer.class));
     }
 
-
     private static <T> T with(@SuppressWarnings("unused") Matcher<T> matcher) {
         return null;
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
@@ -103,5 +103,5 @@ public final class IsIterableContainingTest {
             }
         };
     }
-}
 
+}

--- a/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
@@ -6,6 +6,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -13,6 +14,8 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.AbstractMatcherTest.*;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public final class IsIterableContainingTest {
@@ -84,6 +87,25 @@ public final class IsIterableContainingTest {
 
         assertMismatchDescription("a collection containing <4> mismatches were: [was <1>, was <2>, was <3>]",
                                   matcher, asList(1, 2, 3));
+    }
+
+    @Test public void
+    isIterableContainingAnyOrderCast() {
+        String[] array = new String[]{"1", "2"};
+        Object object = array;
+        Iterable<String> real = Arrays.asList("1", "2");
+        final Matcher<Iterable<? extends Object>> matcher = containsInAnyOrder(object);
+        assertTrue("does not match the same object", matcher.matches(real));
+    }
+
+    @Test
+    public void
+    isIterableContainingCast() {
+        String[] array = new String[]{"1", "2"};
+        Object object = array;
+        Iterable<String> real = Arrays.asList("1", "2");
+        final Matcher<Iterable<? extends Object>> matcher = contains(object);
+        assertTrue("does not match the same object", matcher.matches(real));
     }
 
     private static Matcher<? super String> mismatchable(final String string) {

--- a/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
@@ -16,11 +16,11 @@ import static org.hamcrest.core.IsIterableContaining.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public final class IsIterableContainingTest {
-    
+
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<?> matcher = hasItem(equalTo("irrelevant"));
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
@@ -35,7 +35,7 @@ public final class IsIterableContainingTest {
     @Test public void
     doesNotMatchCollectionWithoutAnElementForGivenMatcher() {
         final Matcher<Iterable<? super String>> matcher = hasItem(mismatchable("a"));
-        
+
         assertMismatchDescription("mismatches were: [mismatched: b, mismatched: c]", matcher, asList("b", "c"));
         assertMismatchDescription("was empty", matcher, new ArrayList<String>());
     }
@@ -49,7 +49,7 @@ public final class IsIterableContainingTest {
     hasAReadableDescription() {
         assertDescription("a collection containing mismatchable: a", hasItem(mismatchable("a")));
     }
-    
+
     @Test public void
     canMatchItemWhenCollectionHoldsSuperclass() { // Issue 24
         final Set<Number> s = new HashSet<>();
@@ -64,24 +64,24 @@ public final class IsIterableContainingTest {
     matchesMultipleItemsInCollection() {
         final Matcher<Iterable<String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("list containing all items", matcher1, asList("a", "b", "c"));
-        
+
         final Matcher<Iterable<String>> matcher2 = hasItems("a", "b", "c");
         assertMatches("list containing all items (without matchers)", matcher2, asList("a", "b", "c"));
-        
+
         final Matcher<Iterable<String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("list containing all items in any order", matcher3, asList("c", "b", "a"));
-        
+
         final Matcher<Iterable<String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("list containing all items plus others", matcher4, asList("e", "c", "b", "a", "d"));
-        
+
         final Matcher<Iterable<String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertDoesNotMatch("not match list unless it contains all items", matcher5, asList("e", "c", "b", "d")); // 'a' missing
     }
-    
+
     @Test public void
     reportsMismatchWithAReadableDescriptionForMultipleItems() {
         final Matcher<Iterable<Integer>> matcher = hasItems(3, 4);
-        
+
         assertMismatchDescription("a collection containing <4> mismatches were: [was <1>, was <2>, was <3>]",
                                   matcher, asList(1, 2, 3));
     }
@@ -90,7 +90,7 @@ public final class IsIterableContainingTest {
         return new TypeSafeDiagnosingMatcher<String>() {
             @Override
             protected boolean matchesSafely(String item, Description mismatchDescription) {
-                if (string.equals(item)) 
+                if (string.equals(item))
                     return true;
 
                 mismatchDescription.appendText("mismatched: " + item);

--- a/hamcrest/src/test/java/org/hamcrest/core/IsNotTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsNotTest.java
@@ -39,4 +39,5 @@ public final class IsNotTest {
         assertDescription("not an instance of java.lang.String", not(instanceOf(String.class)));
         assertDescription("not \"A\"", not("A"));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.AbstractMatcherTest.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-
 public final class IsNullTest {
 
     private final Matcher<Object> nullMatcher = nullValue();

--- a/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
@@ -40,4 +40,5 @@ public final class IsNullTest {
     private void requiresStringMatcher(@SuppressWarnings("unused") Matcher<String> arg) {
         // no-op
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsNullTest.java
@@ -17,7 +17,7 @@ public final class IsNullTest {
     copesWithNullsAndUnknownTypes() {
         assertNullSafe(nullMatcher);
         assertUnknownTypeSafe(nullMatcher);
-        
+
         assertNullSafe(notNullMatcher);
         assertUnknownTypeSafe(notNullMatcher);
     }
@@ -26,11 +26,11 @@ public final class IsNullTest {
     evaluatesToTrueIfArgumentIsNull() {
         assertMatches(nullMatcher, null);
         assertDoesNotMatch(nullMatcher, new Object());
-        
+
         assertMatches(notNullMatcher, new Object());
         assertDoesNotMatch(notNullMatcher, null);
     }
-    
+
     @Test public void
     supportsStaticTyping() {
         requiresStringMatcher(nullValue(String.class));

--- a/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
@@ -13,7 +13,7 @@ public final class IsSameTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = sameInstance("irrelevant");
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.AbstractMatcherTest.*;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.hamcrest.core.IsSame.theInstance;
 
-
 public final class IsSameTest {
 
     @Test public void

--- a/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsSameTest.java
@@ -45,4 +45,5 @@ public final class IsSameTest {
     returnsReadableDescriptionFromToStringWhenInitialisedWithNull() {
         assertDescription("sameInstance(null)", sameInstance(null));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsTest.java
@@ -48,4 +48,5 @@ public final class IsTest {
         assertDoesNotMatch(matcher, new Object());
         assertDoesNotMatch(matcher, null);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsTest.java
@@ -13,7 +13,7 @@ public final class IsTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = is("something");
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
@@ -35,7 +35,7 @@ public final class IsTest {
     @Test public void
     providesConvenientShortcutForIsEqualTo() {
         final Matcher<String> matcher = is("A");
-        
+
         assertMatches(matcher, "A");
         assertDoesNotMatch(is("A"), "B");
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/SampleBaseClass.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/SampleBaseClass.java
@@ -21,4 +21,5 @@ public class SampleBaseClass {
     public int hashCode() {
       return value.hashCode();
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/SampleBaseClass.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/SampleBaseClass.java
@@ -1,6 +1,7 @@
 package org.hamcrest.core;
 
 public class SampleBaseClass {
+
     String value;
 
     public SampleBaseClass(String value) {

--- a/hamcrest/src/test/java/org/hamcrest/core/SampleSubClass.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/SampleSubClass.java
@@ -1,7 +1,7 @@
 package org.hamcrest.core;
 
 public class SampleSubClass extends SampleBaseClass {
-    
+
     public SampleSubClass(String value) {
         super(value);
     }

--- a/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
@@ -41,5 +41,4 @@ public class StringContainsTest extends AbstractMatcherTest {
         assertDescription("a string containing \"ExCert\" ignoring case", ignoringCase);
     }
 
-
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringContains.containsStringIgnoringCase;
 
-
 public class StringContainsTest extends AbstractMatcherTest {
     static final String EXCERPT = "EXCERPT";
     final Matcher<String> stringContains = containsString(EXCERPT);

--- a/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringContainsTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringContains.containsStringIgnoringCase;
 
 public class StringContainsTest extends AbstractMatcherTest {
+
     static final String EXCERPT = "EXCERPT";
     final Matcher<String> stringContains = containsString(EXCERPT);
 

--- a/hamcrest/src/test/java/org/hamcrest/core/StringEndsWithTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringEndsWithTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.core.StringEndsWith.endsWithIgnoringCase;
 
-
 public class StringEndsWithTest extends AbstractMatcherTest {
     static final String EXCERPT = "EXCERPT";
     final Matcher<String> stringEndsWith = endsWith(EXCERPT);

--- a/hamcrest/src/test/java/org/hamcrest/core/StringEndsWithTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringEndsWithTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.core.StringEndsWith.endsWithIgnoringCase;
 
 public class StringEndsWithTest extends AbstractMatcherTest {
+
     static final String EXCERPT = "EXCERPT";
     final Matcher<String> stringEndsWith = endsWith(EXCERPT);
 

--- a/hamcrest/src/test/java/org/hamcrest/core/StringMatchingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringMatchingTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
  * @author Steve Freeman 2016 http://www.hamcrest.com
  */
 public class StringMatchingTest {
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test public void

--- a/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.core.StringRegularExpression.matchesRegex;
  * @author Steve Freeman 2016 http://www.hamcrest.com
  */
 public class StringRegularExpressionTest extends AbstractMatcherTest {
+
   public final Matcher<String> matcher = matchesRegex("^[0-9]+$");
 
   @Override

--- a/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
@@ -14,7 +14,6 @@ public class StringRegularExpressionTest extends AbstractMatcherTest {
   @Override
   protected Matcher<?> createMatcher() { return matcher; }
 
-
   public void testMatchingRegex() {
     assertMatches(matcher, "12");
     assertDoesNotMatch(matcher, "abc");

--- a/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringRegularExpressionTest.java
@@ -22,4 +22,5 @@ public class StringRegularExpressionTest extends AbstractMatcherTest {
     assertDescription("a string matching the pattern <^[0-9]+$>", matcher);
     assertMismatchDescription("the string was \"bcd\"", matcher, "bcd");
   }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/StringStartsWithTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringStartsWithTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.hamcrest.core.StringStartsWith.startsWithIgnoringCase;
 
-
 public class StringStartsWithTest extends AbstractMatcherTest {
     static final String EXCERPT = "EXCERPT";
     final Matcher<String> stringStartsWith = startsWith(EXCERPT);

--- a/hamcrest/src/test/java/org/hamcrest/core/StringStartsWithTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/StringStartsWithTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.hamcrest.core.StringStartsWith.startsWithIgnoringCase;
 
 public class StringStartsWithTest extends AbstractMatcherTest {
+
     static final String EXCERPT = "EXCERPT";
     final Matcher<String> stringStartsWith = startsWith(EXCERPT);
 

--- a/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
@@ -19,11 +19,11 @@ public class FileMatchersTest extends AbstractMatcherTest {
         directory = File.createTempFile("myDir", "");
         assertTrue("deleting " + directory, directory.delete());
         assertTrue("mkdir " + directory, directory.mkdirs());
-        
+
         file = new File(directory, "myFile");
         file.createNewFile();
     }
-    
+
     public void testAnExistingDirectory() {
         assertMatches("matches existing directory", FileMatchers.anExistingDirectory(), directory);
         assertDoesNotMatch("doesn't match existing file", FileMatchers.anExistingDirectory(), file);

--- a/hamcrest/src/test/java/org/hamcrest/number/BigDecimalCloseToTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/BigDecimalCloseToTest.java
@@ -15,7 +15,7 @@ public class BigDecimalCloseToTest  extends AbstractMatcherTest {
     BigDecimal irrelevant = new BigDecimal("0.01");
     return closeTo(irrelevant, irrelevant);
   }
-  
+
   public void testEvaluatesToTrueIfArgumentIsEqualToABigDecimalWithinSomeError() {
     assertTrue(matcher.matches(new BigDecimal("1.0")));
     assertTrue(matcher.matches(new BigDecimal("0.5")));
@@ -26,7 +26,7 @@ public class BigDecimalCloseToTest  extends AbstractMatcherTest {
     assertDoesNotMatch("number too small", matcher, new BigDecimal("0.0"));
     assertMismatchDescription("<0.0> differed by <0.5> more than delta <0.5>", matcher, new BigDecimal("0.0"));
   }
-  
+
   public void testEvaluatesToTrueIfArgumentHasDifferentScale() {
     assertTrue(matcher.matches(new BigDecimal("1.000000")));
     assertTrue(matcher.matches(new BigDecimal("0.500000")));

--- a/hamcrest/src/test/java/org/hamcrest/number/BigDecimalCloseToTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/BigDecimalCloseToTest.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
 
 public class BigDecimalCloseToTest  extends AbstractMatcherTest {
+
   private final Matcher<BigDecimal> matcher = closeTo(new BigDecimal("1.0"), new BigDecimal("0.5"));
 
   @Override

--- a/hamcrest/src/test/java/org/hamcrest/number/IsCloseToTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/IsCloseToTest.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 
 public class IsCloseToTest extends AbstractMatcherTest {
+
   private final Matcher<Double> matcher = closeTo(1.0d, 0.5d);
 
   @Override

--- a/hamcrest/src/test/java/org/hamcrest/number/IsNanTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/IsNanTest.java
@@ -11,7 +11,7 @@ public final class IsNanTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<Double> matcher = notANumber();
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }

--- a/hamcrest/src/test/java/org/hamcrest/number/IsNanTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/IsNanTest.java
@@ -40,4 +40,5 @@ public final class IsNanTest {
     describesAMismatch() {
         assertMismatchDescription("was <1.25>", notANumber(), 1.25);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
@@ -77,4 +77,5 @@ public class OrderingComparisonTest extends AbstractMatcherTest {
             return value - other.value;
         }
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
@@ -41,7 +41,6 @@ public class OrderingComparisonTest extends AbstractMatcherTest {
         assertThat(0, lessThan(1));
     }
 
-
     public void testComparesObjectsForEquality() {
       assertThat(3, comparesEqualTo(3));
       assertThat("aa", comparesEqualTo("aa"));

--- a/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/number/OrderingComparisonTest.java
@@ -62,7 +62,7 @@ public class OrderingComparisonTest extends AbstractMatcherTest {
       assertThat(new BigDecimal(10), greaterThanOrEqualTo(new BigDecimal("10.0")));
       assertThat(new BigDecimal("2"), comparesEqualTo(new BigDecimal("2.000")));
     }
-    
+
     public void testComparesCustomTypesWhoseCompareToReturnsValuesGreaterThatOne() {
         assertThat(new CustomInt(5), lessThan(new CustomInt(10)));
     }

--- a/hamcrest/src/test/java/org/hamcrest/object/HasEqualsValuesTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasEqualsValuesTest.java
@@ -53,4 +53,5 @@ public class HasEqualsValuesTest extends AbstractMatcherTest {
             this.c = c;
         }
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/object/HasEqualsValuesTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasEqualsValuesTest.java
@@ -5,6 +5,7 @@ import org.hamcrest.Matcher;
 
 @SuppressWarnings("WeakerAccess")
 public class HasEqualsValuesTest extends AbstractMatcherTest {
+
     private static final WithPublicFields WITH_PUBLIC_FIELDS = new WithPublicFields('x', 666, "a string");
     private static final HasEqualValues<WithPublicFields> WITH_PUBLIC_FIELDS_MATCHER = new HasEqualValues<>(WITH_PUBLIC_FIELDS);
 

--- a/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
@@ -19,11 +19,11 @@ public final class HasToStringTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<Object> matcher = hasToString(equalTo("irrelevant"));
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
-    
+
     @Test public void
     matchesWhenUtilisingANestedMatcher() {
         final Matcher<Object> matcher = hasToString(equalTo(TO_STRING_RESULT));
@@ -35,7 +35,7 @@ public final class HasToStringTest {
     @Test public void
     matchesWhenUsingShortcutForHasToStringEqualTo() {
         final Matcher<Object> matcher = hasToString(TO_STRING_RESULT);
-        
+
         assertMatches(matcher, TEST_OBJECT);
         assertDoesNotMatch(matcher, new Object());
     }

--- a/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
@@ -52,4 +52,5 @@ public final class HasToStringTest {
         String expectedMismatchString = "toString() was \"Cheese\"";
         assertMismatchDescription(expectedMismatchString, matcher, "Cheese");
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/HasToStringTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.object.HasToString.hasToString;
 
 public final class HasToStringTest {
+
     private static final String TO_STRING_RESULT = "toString result";
     private static final Object TEST_OBJECT = new Object() {
         @Override

--- a/hamcrest/src/test/java/org/hamcrest/object/IsCompatibleTypeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/IsCompatibleTypeTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 
 public class IsCompatibleTypeTest extends AbstractMatcherTest {
+
     static class BaseClass {
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/object/IsCompatibleTypeTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/IsCompatibleTypeTest.java
@@ -50,4 +50,5 @@ public class IsCompatibleTypeTest extends AbstractMatcherTest {
     public void testHasReadableDescription() {
         assertDescription("type < java.lang.Runnable", typeCompatibleWith(Runnable.class));
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/object/IsEventFromTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/IsEventFromTest.java
@@ -8,7 +8,6 @@ import java.util.EventObject;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.object.IsEventFrom.eventFrom;
 
-
 public class IsEventFromTest extends AbstractMatcherTest {
 
     @Override

--- a/hamcrest/src/test/java/org/hamcrest/object/IsEventFromTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/IsEventFromTest.java
@@ -49,4 +49,5 @@ public class IsEventFromTest extends AbstractMatcherTest {
         assertMismatchDescription("item type was java.util.EventObject", isEventMatcher, wrongType);
         assertMismatchDescription("item type was java.util.EventObject", isEventMatcher, wrongSourceAndType);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/object/MatchesPatternTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/MatchesPatternTest.java
@@ -56,4 +56,5 @@ public class MatchesPatternTest {
         Matcher<?> m = MatchesPattern.matchesPattern("a[bc](d|e)");
         assertDescription("a string matching the pattern 'a[bc](d|e)'", m );
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/object/MatchesPatternTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/object/MatchesPatternTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.AbstractMatcherTest.*;
 import static org.junit.Assert.assertThat;
 
 public class MatchesPatternTest {
+
     @Test
     public void copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = new MatchesPattern(Pattern.compile("."));

--- a/hamcrest/src/test/java/org/hamcrest/text/CharSequenceLengthTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/CharSequenceLengthTest.java
@@ -25,7 +25,6 @@ public class CharSequenceLengthTest extends AbstractMatcherTest {
         assertMismatchDescription("length was <6>", matcher, "aaaaaa");
     }
 
-
     public void test_matchesRelativeLengthOf_CharSequence() {
         final Matcher<CharSequence> matcher = hasLength(lessThan(4));
         assertMatches(matcher, "aaa");

--- a/hamcrest/src/test/java/org/hamcrest/text/IsBlankStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsBlankStringTest.java
@@ -52,4 +52,5 @@ public final class IsBlankStringTest {
         assertMismatchDescription("was \"a\"", blankString(), "a");
         assertMismatchDescription("was \"a\"", blankOrNullString(), "a");
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsBlankStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsBlankStringTest.java
@@ -12,7 +12,7 @@ public final class IsBlankStringTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = blankString();
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEmptyStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEmptyStringTest.java
@@ -52,4 +52,5 @@ public final class IsEmptyStringTest {
         assertMismatchDescription("was \"a\"", emptyString(), "a");
         assertMismatchDescription("was \"a\"", emptyOrNullString(), "a");
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEmptyStringTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEmptyStringTest.java
@@ -12,7 +12,7 @@ public final class IsEmptyStringTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = emptyString();
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualCompressingWhiteSpaceTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualCompressingWhiteSpaceTest.java
@@ -45,4 +45,5 @@ public class IsEqualCompressingWhiteSpaceTest extends AbstractMatcherTest {
     public void testPassesIfWhitespacesContainsNoBreakSpace() {
         assertMatches(matcher, "Hello" + ((char)160) + "World how are we?");
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -59,4 +59,5 @@ public final class IsEqualIgnoringCaseTest {
         String expectedMismatchString = "was \"Cheese\"";
         assertMismatchDescription(expectedMismatchString, matcher, "Cheese");
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -46,7 +46,6 @@ public final class IsEqualIgnoringCaseTest {
         equalToIgnoringCase(null);
     }
 
-
     @Test public void
     describesItself() {
         final Matcher<String> matcher = equalToIgnoringCase("heLLo");

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java
@@ -11,7 +11,7 @@ public final class IsEqualIgnoringCaseTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<String> matcher = equalToIgnoringCase("irrelevant");
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
@@ -19,25 +19,25 @@ public final class IsEqualIgnoringCaseTest {
     @Test public void
     ignoresCaseOfCharsInString() {
         final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-        
+
         assertMatches(matcher, "HELLO");
         assertMatches(matcher, "hello");
         assertMatches(matcher, "HelLo");
         assertDoesNotMatch(matcher, "bye");
     }
 
-    @Test public void 
+    @Test public void
     mismatchesIfAdditionalWhitespaceIsPresent() {
         final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-        
+
         assertDoesNotMatch(matcher, "hello ");
         assertDoesNotMatch(matcher, " hello");
     }
 
-    @Test public void 
+    @Test public void
     mismatchesNull() {
         final Matcher<String> matcher = equalToIgnoringCase("heLLo");
-        
+
         assertDoesNotMatch(matcher, null);
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -30,4 +30,5 @@ public class StringContainsInOrderTest extends AbstractMatcherTest {
     public void testHasAReadableDescription() {
         assertDescription("a string containing \"a\", \"b\", \"c\", \"c\" in order", matcher);
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -7,6 +7,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 
 public class StringContainsInOrderTest extends AbstractMatcherTest {
+
     final StringContainsInOrder matcher = new StringContainsInOrder(asList("a", "b", "c", "c"));
 
     @Override

--- a/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -14,7 +14,7 @@ public class StringContainsInOrderTest extends AbstractMatcherTest {
     protected Matcher<?> createMatcher() {
         return matcher;
     }
-    
+
     public void testMatchesOnlyIfStringContainsGivenSubstringsInTheSameOrder() {
         assertMatches("substrings in order", matcher, "abcc");
         assertMatches("substrings separated", matcher, "1a2b3c4c5");
@@ -26,7 +26,7 @@ public class StringContainsInOrderTest extends AbstractMatcherTest {
         assertDoesNotMatch("substring missing", matcher, "ac");
         assertDoesNotMatch("empty string", matcher, "");
     }
-    
+
     public void testHasAReadableDescription() {
         assertDescription("a string containing \"a\", \"b\", \"c\", \"c\" in order", matcher);
     }

--- a/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/StringContainsInOrderTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 import static java.util.Arrays.asList;
 import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 
-
 public class StringContainsInOrderTest extends AbstractMatcherTest {
     final StringContainsInOrder matcher = new StringContainsInOrder(asList("a", "b", "c", "c"));
 

--- a/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
@@ -48,7 +48,7 @@ public final class HasXPathTest {
 
         @Override
         public Iterator<String> getPrefixes(String namespaceURI) {
-            HashSet<String> prefixes = new HashSet<String>();
+            HashSet<String> prefixes = new HashSet<>();
             String prefix = getPrefix(namespaceURI);
             if (prefix != null) {
                 prefixes.add(prefix);

--- a/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
@@ -144,4 +144,5 @@ public final class HasXPathTest {
             throw new IllegalStateException(e);
         }
     }
+
 }

--- a/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/xml/HasXPathTest.java
@@ -60,7 +60,7 @@ public final class HasXPathTest {
     @Test public void
     copesWithNullsAndUnknownTypes() {
         Matcher<Node> matcher = hasXPath("//irrelevant");
-        
+
         assertNullSafe(matcher);
         assertUnknownTypeSafe(matcher);
     }
@@ -118,7 +118,7 @@ public final class HasXPathTest {
     describesItself() {
         assertDescription("an XML document with XPath /some/path \"Cheddar\"",
                           hasXPath("/some/path", equalTo("Cheddar")));
-        
+
         assertDescription("an XML document with XPath /some/path",
                           hasXPath("/some/path"));
     }


### PR DESCRIPTION
Fixes #301. 

**Caused:**
- Matcher instantiation depends of `actual` object type

**Fix:**
- Adjusted API to work with arrays embedded in objects

The assumption is that whenever we get to the `contains(T... items)` with an array, the only possible way to get there with an array is by passing `Object` type reference (because of `contains` overloaded methods). Therefore we can safely add extra-check for embedded array