### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+cache:
+  directories:
+    - $HOME/.gradle
+
 os: linux
 
 # Need to select an older Ubuntu distribution that supports JDK7


### PR DESCRIPTION
Would be interested to know why gradle dependencies haven't been cached on Travis. Thank you.