### PR TITLE
Added equalToWithDiff for comparing strings with diff message

### DIFF
--- a/hamcrest/hamcrest.gradle
+++ b/hamcrest/hamcrest.gradle
@@ -6,6 +6,7 @@ dependencies {
     testImplementation(group: 'junit', name: 'junit', version: '4.13') {
         transitive = false
     }
+    implementation "io.github.java-diff-utils:java-diff-utils:4.5"
 }
 
 jar {

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -1373,6 +1373,19 @@ public class Matchers {
   }
 
   /**
+   * Creates a matcher of {@link String} that matches when the examined string is equal to
+   * the specified expectedString, with markdown style diff message when mismatch
+   * For example:
+   * <pre>assertThat("Foo", equalToWithDiff("FOO"))</pre>
+   *
+   * @param expectedString
+   *     the expected value of matched strings
+   */
+  public static Matcher<java.lang.String> equalToWithDiff(java.lang.String expectedString) {
+    return org.hamcrest.text.IsEqualWithDiff.equalToWithDiff(expectedString);
+  }
+
+  /**
    * @deprecated {@link #equalToCompressingWhiteSpace(String)}
    * @param expectedString
    *     the expected value of matched strings

--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualWithDiff.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualWithDiff.java
@@ -1,0 +1,92 @@
+package org.hamcrest.text;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import com.github.difflib.text.DiffRowGenerator;
+import com.github.difflib.algorithm.DiffException;
+import com.github.difflib.text.DiffRow;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+public class IsEqualWithDiff extends TypeSafeMatcher<String> {
+    private final String string;
+
+    public IsEqualWithDiff(String string) {
+        if (string == null) {
+            throw new IllegalArgumentException("Non-null value required");
+        }
+        this.string = string;
+    }
+
+    @Override
+    public boolean matchesSafely(String item) {
+        return string.equals(item);
+    }
+
+    @Override
+    public void describeMismatchSafely(String item, Description mismatchDescription) {
+        mismatchDescription.appendText("Diff: \n\t");
+        List<String> expected = Arrays.asList(string.split("\n"));
+        List<String> actual = Arrays.asList(item.split("\n"));
+
+        DiffRowGenerator generator = DiffRowGenerator.create()
+                .showInlineDiffs(true)
+                .mergeOriginalRevised(true)
+                .reportLinesUnchanged(false)
+                .inlineDiffByWord(true)
+                .oldTag(new Function<Boolean, String>() {
+                    @Override
+                    public String apply(Boolean aBoolean) {
+                        return "~";
+                    }
+                })
+                .newTag(new Function<Boolean, String>() {
+                    @Override
+                    public String apply(Boolean aBoolean) {
+                        return "**";
+                    }
+                })
+                .build();
+        List<DiffRow> rows = null;
+        try {
+            rows = generator.generateDiffRows(
+                    actual,
+                    expected
+            );
+        } catch (DiffException e) {
+            e.printStackTrace();
+        }
+
+        for (int ii = 0; ii < rows.size(); ii++) {
+            if (rows.get(ii).getTag() == DiffRow.Tag.CHANGE)
+            {
+                mismatchDescription.appendText(String.format("At line %d: ", ii));
+                mismatchDescription.appendText(rows.get(ii).getOldLine()).appendText("\n\t");
+            }
+        }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a string equal to ")
+                .appendValue(string)
+                .appendText(" with diff when mismatch");
+    }
+
+    /**
+     * Creates a matcher of {@link String} that matches when the examined string is equal to
+     * the specified expectedString, with markdown style diff output message when mismatch.
+     * For example:
+     * <pre>assertThat("Foo", equalToIgnoringCase("FOO"))</pre>
+     *
+     * @param expectedString
+     *     the expected value of matched strings
+     */
+    public static Matcher<String> equalToWithDiff(String expectedString) {
+        return new IsEqualWithDiff(expectedString);
+    }
+}

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualWithDiffTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualWithDiffTest.java
@@ -1,0 +1,41 @@
+package org.hamcrest.text;
+
+import org.hamcrest.Matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.hamcrest.AbstractMatcherTest.assertMatches;
+import static org.hamcrest.text.IsEqualWithDiff.equalToWithDiff;
+
+
+public class IsEqualWithDiffTest {
+    /*
+    Test the correctness of diff message
+     */
+    @Test public void
+    testMismatchesWithCorrectDiffMessage() {
+        final String actual = "This is first see you, bye\nhbha";
+        final Description expectedDescription = new StringDescription()
+                .appendText("Diff: \n\t")
+                .appendText("At line 0: This is first ~see~**hello** ~you~**world**, bye\n\t")
+                .appendText("At line 1: ~hbha~**haha**\n\t");
+        Description actualDescription = new StringDescription();
+        final Matcher<String> matcher = equalToWithDiff("This is first hello world, bye\nhaha");
+        matcher.describeMismatch(actual, actualDescription);
+
+        assertMatches(equalToWithDiff(expectedDescription.toString()), actualDescription.toString());
+    }
+
+    /*
+    Test the correctness of Matcher itself
+     */
+    @Test public void
+    testMatcherCorrectness() {
+        final String actual = "This is first see you, bye\nhbha";
+        final String expected = "This is first see you, bye\nhbha";
+
+        assertMatches(equalToWithDiff(expected), actual);
+    }
+}


### PR DESCRIPTION
Fixed #209 
Added a new Matcher `equalToWithDiff` for compare string. When mismatch happens, instead of output two strings, only lines that mismatch would be output. For words in those lines that mismatch would be surrounded by `~`, the expected words would be surrounded by `**`.
* To implement this, the external library `io.github.java-diff-utils:java-diff-utils:4.5` is introduced.
* test class `IsEqualWithDiffTest` is created