### PR TITLE
enhancement on issue #196

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
+++ b/hamcrest/src/main/java/org/hamcrest/text/IsEqualCompressingWhiteSpace.java
@@ -7,18 +7,31 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Tests if a string is equal to another string, compressing any changes in whitespace.
  */
+
 public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
 
     // TODO: Replace String with CharSequence to allow for easy interoperability between
     //       String, StringBuffer, StringBuilder, CharBuffer, etc (joe).
 
-    private final String string;
+    enum whiteSpaceType
+    {
+        SPACE, // \s
+        TAB,// \t
+        LINEFEED,// \n
+        FORMFEED, // \f
+        CARRIAGERETURN, // \r
+        MIX;
+    }
 
-    public IsEqualCompressingWhiteSpace(String string) {
+    private final String string;
+    private final whiteSpaceType type;
+
+    public IsEqualCompressingWhiteSpace(String string, whiteSpaceType type) {
         if (string == null) {
             throw new IllegalArgumentException("Non-null value required");
         }
         this.string = string;
+        this.type = type;
     }
 
     @Override
@@ -39,7 +52,24 @@ public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
     }
 
     public String stripSpaces(String toBeStripped) {
-        return toBeStripped.replaceAll("[\\p{Z}\\p{C}]+", " ").trim();
+        if (this.type == whiteSpaceType.TAB){
+            return toBeStripped.replaceAll("[\\p{Z}\\t]+", " ").trim();
+        }
+        else if (this.type == whiteSpaceType.LINEFEED){
+            return toBeStripped.replaceAll("[\\p{Z}\\n]+", " ").trim();
+        }
+        else if (this.type == whiteSpaceType.FORMFEED){
+            return toBeStripped.replaceAll("[\\p{Z}\\f]+", " ").trim();
+        }
+        else if (this.type == whiteSpaceType.CARRIAGERETURN){
+            return toBeStripped.replaceAll("[\\p{Z}\\r]+", " ").trim();
+        }
+        else if (this.type == whiteSpaceType.SPACE){
+            return toBeStripped.replaceAll("[\\p{Z}]+", " ").trim();
+        }
+        else{
+            return toBeStripped.replaceAll("[\\p{Z}\\t\\n\\f\\r]+", " ").trim();
+        }
     }
 
     /**
@@ -47,8 +77,8 @@ public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
      * @param expectedString
      *     the expected value of matched strings
      */
-    public static Matcher<String> equalToIgnoringWhiteSpace(String expectedString) {
-        return new IsEqualCompressingWhiteSpace(expectedString);
+    public static Matcher<String> equalToIgnoringWhiteSpace(String expectedString, whiteSpaceType type) {
+        return new IsEqualCompressingWhiteSpace(expectedString, type);
     }
 
     /**
@@ -66,7 +96,31 @@ public class IsEqualCompressingWhiteSpace extends TypeSafeMatcher<String> {
      *     the expected value of matched strings
      */
     public static Matcher<String> equalToCompressingWhiteSpace(String expectedString) {
-        return new IsEqualCompressingWhiteSpace(expectedString);
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.MIX);
+    }
+
+    public static Matcher<String> equalToCompressingSPACE(String expectedString) {
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.SPACE);
+    }
+
+    public static Matcher<String> equalToCompressingTAB(String expectedString) {
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.TAB);
+    }
+
+    public static Matcher<String> equalToCompressingLINEFEED(String expectedString) {
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.LINEFEED);
+    }
+
+    public static Matcher<String> equalToCompressingFORMFEED(String expectedString) {
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.FORMFEED);
+    }
+
+    public static Matcher<String> equalToCompressingCARRIAGERETURN(String expectedString) {
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.CARRIAGERETURN);
+    }
+
+    public static Matcher<String> equalToCompressingMIX(String expectedString) {
+        return new IsEqualCompressingWhiteSpace(expectedString, whiteSpaceType.MIX);
     }
 
 }

--- a/hamcrest/src/test/java/org/hamcrest/text/IsEqualCompressingWhiteSpaceTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/text/IsEqualCompressingWhiteSpaceTest.java
@@ -4,10 +4,16 @@ import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
 import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
+import static org.hamcrest.text.IsEqualCompressingWhiteSpace.*;
 
 public class IsEqualCompressingWhiteSpaceTest extends AbstractMatcherTest {
 
-    private final Matcher<String> matcher = equalToCompressingWhiteSpace(" Hello World   how\n are we? ");
+    private final Matcher<String> matcher = equalToCompressingMIX(" Hello World   how\n are we? ");
+    private final Matcher<String> SPACEmatcher = equalToCompressingSPACE(" Hello World   how       are we? ");
+    private final Matcher<String> TABmatcher = equalToCompressingTAB(" Hello World   how\t are\t\t we? ");
+    private final Matcher<String> LINEFEEDmatcher = equalToCompressingLINEFEED(" Hello World   how\n are we? ");
+    private final Matcher<String> FORMFEEDmatcher = equalToCompressingFORMFEED(" Hello World   how\f are\f\f we? ");
+    private final Matcher<String> CARRIAGERETURNmatcher = equalToCompressingCARRIAGERETURN(" Hello \r World   how \r\r are we? ");
 
     @Override
     protected Matcher<?> createMatcher() {
@@ -44,5 +50,26 @@ public class IsEqualCompressingWhiteSpaceTest extends AbstractMatcherTest {
 
     public void testPassesIfWhitespacesContainsNoBreakSpace() {
         assertMatches(matcher, "Hello" + ((char)160) + "World how are we?");
+    }
+
+    public void testFailsIfwordsAreSameButWhiteSpaceDiffers()
+    {
+        assertDoesNotMatch(SPACEmatcher, " Hello World   how\n are we? ");
+        assertDoesNotMatch(TABmatcher, " Hello World   how\n are we? ");
+        assertDoesNotMatch(LINEFEEDmatcher, " Hello World   how\r are we? ");
+    }
+
+    public void testPassesIfwordsAreSameButMixWhiteSpace()
+    {
+        assertMatches(matcher, "Hello\f\f World\t how      are\r we?\n\n");
+    }
+
+    public void testUnitWhiteSpace()
+    {
+        assertMatches(SPACEmatcher, "  Hello     World    how              are we?   ");
+        assertMatches(TABmatcher, " Hello World   how \t are   we? \t");
+        assertMatches(LINEFEEDmatcher, "   Hello World   how\n are  \n we? ");
+        assertMatches(FORMFEEDmatcher, " Hello   World\f   how are we? ");
+        assertMatches(CARRIAGERETURNmatcher, "Hello World how are we?");
     }
 }


### PR DESCRIPTION
To specifying the demand of issue #196. I did research on types of whitespace and I pick some most common whitespace: space, tab, line feed, form feed, carriagereturn. Then I modified `equalToCompressingWhiteSpace` by adding a property whiteSpaceType which is a enum type variable with 6 types of whitespace: space, tab, line feed, form feed, carriagereturn, mix(mix types above). From this, I modify the constructor. To change the match rule, I modified `stripSpaces` to strip string according to different types of whitespace. To prevent conflicts, I added 6 types of matcher generators,  `public static Matcher<String> equalToCompressingSPACE(String expectedString)` as an example.