### PR TITLE
Add file content matcher to FileMatchers

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/io/FileMatchers.java
@@ -5,12 +5,54 @@ import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public final class FileMatchers {
+
+    /**
+     * Matcher for matching file content with given file
+     * @param expected The file has expected content
+     * @return A FeatureMatcher that takes the content of a file as feature
+     */
+    public static Matcher<File> matchesContentOf(File expected) {
+        String expectedContent = "";
+        try {
+             expectedContent = new String(Files.readAllBytes(expected.toPath()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return new FeatureMatcher<File, String>(equalTo(expectedContent), "A file with content", "content") {
+            @Override protected String featureValueOf(File actual) {
+                try {
+                    return new String(Files.readAllBytes(actual.toPath()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return "Exception: " + e.getMessage();
+                }
+            }
+        };
+    }
+
+    /**
+     * Matcher for matching file content with given String Matcher
+     * @param expected The expected content Matcher
+     * @return A FeatureMatcher that takes the content of a file as feature
+     */
+    public static Matcher<File> aFileWithContent(Matcher<String> expected) {
+        return new FeatureMatcher<File, String>(expected, "A file with content", "content") {
+            @Override protected String featureValueOf(File actual) {
+                try {
+                    return new String(Files.readAllBytes(actual.toPath()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return "Exception: " + e.getMessage();
+                }
+            }
+        };
+    }
 
     public static Matcher<File> anExistingDirectory() {
         return fileChecker(IS_DIRECTORY, "an existing directory", "is not a directory");

--- a/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/io/FileMatchersTest.java
@@ -3,7 +3,9 @@ package org.hamcrest.io;
 import org.hamcrest.AbstractMatcherTest;
 import org.hamcrest.Matcher;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -13,6 +15,7 @@ public class FileMatchersTest extends AbstractMatcherTest {
 
     private File directory;
     private File file;
+    private File anotherFile;
 
     @Override
     protected void setUp() throws IOException {
@@ -22,6 +25,13 @@ public class FileMatchersTest extends AbstractMatcherTest {
         
         file = new File(directory, "myFile");
         file.createNewFile();
+
+        anotherFile = new File(directory, "myAnotherFile");
+        anotherFile.createNewFile();
+
+        BufferedWriter anotherFileWriter = new BufferedWriter(new FileWriter(anotherFile));
+        anotherFileWriter.write(("world"));
+        anotherFileWriter.close();
     }
     
     public void testAnExistingDirectory() {
@@ -88,4 +98,21 @@ public class FileMatchersTest extends AbstractMatcherTest {
         return FileMatchers.aFileWithSize(1L);
     }
 
+    public void testFileContentMatcher() {
+        assertMatches("matches file content with a file", FileMatchers.matchesContentOf(file), file);
+        assertDoesNotMatch("content of two files with different content won't match", FileMatchers.matchesContentOf(anotherFile), file);
+    }
+
+    public void testFileContentMatcherDescription() {
+        assertMismatchDescription("content was \"\"", FileMatchers.matchesContentOf(anotherFile), file);
+    }
+
+    public void testAFileWithContent() {
+        assertMatches("matches file content", FileMatchers.aFileWithContent(equalTo("")), file);
+        assertDoesNotMatch("doesn't match incorrect content", FileMatchers.aFileWithContent(equalTo("world")), file);
+    }
+
+    public void testAFileWithContentDescription() {
+        assertMismatchDescription("content was \"\"", FileMatchers.aFileWithContent(equalTo("world")), file);
+    }
 }


### PR DESCRIPTION
Fixed #281 
Add two public methods to `FileMatchers`. The `matchesContentOf` takes a File and returns a `Matcher<File>` that matches the content of the file.
The `aFileWithContent` takes a `Matcher<String>` where the string is the expected file content, and returns a `Matcher<File>` matches the content of the file.