### PR TITLE
Add related matchers for javax.json objects

### DIFF
--- a/docs/related.md
+++ b/docs/related.md
@@ -30,3 +30,4 @@ Here are some projects that provide additional features and matchers
 * [Shazamcrest](https://github.com/shazam/shazamcrest) (Matchers for beans with custom field matching and nice failure messages)
 * [Spotify's hamcrest matchers](https://github.com/spotify/java-hamcrest) (Matchers for POJOs, JSON, and some of the types introduced in Java 8)
 * [valid4j](https://github.com/valid4j/valid4j) (assertion and validation library, i.e supporting design-by-contract style and/or recoverable input validation)
+* [matchers-json](https://github.com/g4s8/matchers-json) (Matchers for `javax.json` objects, arrays and values, and raw JSON string adapters)


### PR DESCRIPTION
Add related matchers library [g4s8/matchers-json](https://github.com/g4s8/matchers-json) with Hamcrest objects for `javax.json` `JsonObject`, `JsonArray` and `JsonValue`; also, support raw string JSON arrays/objects via adapters.