### PR TITLE
GitHub Actions add java-18-ea

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        java: [7, 8, 11, 17]
+        java: [7, 8, 11, 17, 18-ea]
       fail-fast: false
       max-parallel: 4
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}


### PR DESCRIPTION
Prep for next java non-LTS whilst still early access.