### PR TITLE
fix: contains/containsInAnyOrder overloading issue 

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -131,10 +131,17 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
     @SafeVarargs
     public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(T... items) {
         List<Matcher<? super T>> matchers = new ArrayList<>();
-        for (T item : items) {
+        if (items.length == 1 && items[0].getClass().isArray()) {
+          @SuppressWarnings("unchecked")
+          T[] realItems = (T[]) items[0];
+          for (T item : realItems) {
             matchers.add(equalTo(item));
+          }
+        } else {
+          for (T item : items) {
+              matchers.add(equalTo(item));
+          }
         }
-
         return new IsIterableContainingInAnyOrder<>(matchers);
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
@@ -98,6 +98,11 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
      */
     @SafeVarargs
     public static <E> Matcher<Iterable<? extends E>> contains(E... items) {
+        if (items.length == 1 && items[0].getClass().isArray()) {
+            @SuppressWarnings("unchecked")
+            E[] realItems = (E[]) items[0];
+            return contains(asEqualMatchers(realItems));
+        }
         return contains(asEqualMatchers(items));
     }
 

--- a/hamcrest/src/test/java/org/hamcrest/MatchersTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/MatchersTest.java
@@ -1,0 +1,28 @@
+package org.hamcrest;
+
+import java.util.Arrays;
+import org.hamcrest.core.AnyOf;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class MatchersTest {
+
+    @Test
+    public void matchersContainsInAnyOrderCastTest() {
+        String[] truth = new String[] { "1", "2" };
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), containsInAnyOrder(truth));
+        Object otherTruth = truth;
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), containsInAnyOrder(otherTruth));
+    }
+
+    @Test
+    public void matchersContainsCastTest() {
+        String[] truth = new String[] { "1", "2" };
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), contains(truth));
+        Object otherTruth = truth;
+        assertThat("doesn't contain elements", Arrays.asList("1", "2"), contains(otherTruth));
+    }
+}

--- a/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
@@ -6,6 +6,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -13,6 +14,8 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.AbstractMatcherTest.*;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public final class IsIterableContainingTest {
@@ -84,6 +87,25 @@ public final class IsIterableContainingTest {
 
         assertMismatchDescription("a collection containing <4> mismatches were: [was <1>, was <2>, was <3>]",
                                   matcher, asList(1, 2, 3));
+    }
+
+    @Test public void
+    isIterableContainingAnyOrderCast() {
+        String[] array = new String[]{"1", "2"};
+        Object object = array;
+        Iterable<String> real = Arrays.asList("1", "2");
+        final Matcher<Iterable<? extends Object>> matcher = containsInAnyOrder(object);
+        assertTrue("does not match the same object", matcher.matches(real));
+    }
+
+    @Test
+    public void
+    isIterableContainingCast() {
+        String[] array = new String[]{"1", "2"};
+        Object object = array;
+        Iterable<String> real = Arrays.asList("1", "2");
+        final Matcher<Iterable<? extends Object>> matcher = contains(object);
+        assertTrue("does not match the same object", matcher.matches(real));
     }
 
     private static Matcher<? super String> mismatchable(final String string) {


### PR DESCRIPTION
Fixes #301. 

**Caused:**
- Matcher instantiation depends of `actual` object type

**Fix:**
- Adjusted API to work with arrays embedded in objects

The assumption is that whenever we get to the `contains(T... items)` with an array, the only possible way to get there with an array is by passing `Object` type reference (because of `contains` overloaded methods). Therefore we can safely add extra-check for embedded array