### PR TITLE
Fix a typo in the javadoc of SelfDescribing

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
+++ b/hamcrest/src/main/java/org/hamcrest/SelfDescribing.java
@@ -7,7 +7,7 @@ public interface SelfDescribing {
 
     /**
      * Generates a description of the object.  The description may be part of a
-     * a description of a larger object of which this is just a component, so it
+     * description of a larger object of which this is just a component, so it
      * should be worded appropriately.
      *
      * @param description


### PR DESCRIPTION
I stumbled upon this small typo while browsing the code. 😄