### PR TITLE
add license to jar

### DIFF
--- a/hamcrest-core/hamcrest-core.gradle
+++ b/hamcrest-core/hamcrest-core.gradle
@@ -3,6 +3,11 @@ dependencies {
 }
 
 jar {
+    from('../') {
+        include 'LICENSE.txt'
+        into('META-INF')
+    }
+
     manifest {
         attributes 'Implementation-Title': project.name,
                 'Implementation-Vendor': 'hamcrest.org',

--- a/hamcrest-library/hamcrest-library.gradle
+++ b/hamcrest-library/hamcrest-library.gradle
@@ -3,6 +3,11 @@ dependencies {
 }
 
 jar {
+    from('../') {
+        include 'LICENSE.txt'
+        into('META-INF')
+    }
+
     manifest {
         attributes 'Implementation-Title': project.name,
                 'Implementation-Vendor': 'hamcrest.org',

--- a/hamcrest/hamcrest.gradle
+++ b/hamcrest/hamcrest.gradle
@@ -9,6 +9,11 @@ dependencies {
 }
 
 jar {
+    from('../') {
+        include 'LICENSE.txt'
+        into('META-INF')
+    }
+
     manifest {
         attributes 'Implementation-Title': project.name,
                 'Implementation-Vendor': 'hamcrest.org',


### PR DESCRIPTION
### Add license information to Jar.

For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the licence information from our dependencies. This scanner can extract all informaton from the Jar file. Therefore it would be great to have the license information included in the jar file.