### PR TITLE
Fix 'Fork me on GitHub' banner

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -8,4 +8,5 @@
   <title>{{ page.title }}</title>
   <link href="css/hamcrest.css" rel="stylesheet" type="text/css">
   <link href="css/pygments-default.css" rel="stylesheet" type="text/css">
+  <style>#forkongithub a{background:#070;color:#fff;text-decoration:none;font-family:arial,sans-serif;text-align:center;font-weight:bold;padding:5px 40px;font-size:1rem;line-height:2rem;position:relative;transition:0.5s;}#forkongithub a:hover{background:#0a0;color:#fff;}#forkongithub a::before,#forkongithub a::after{content:"";width:100%;display:block;position:absolute;top:1px;left:0;height:1px;background:#fff;}#forkongithub a::after{bottom:1px;top:auto;}@media screen and (min-width:800px){#forkongithub{position:absolute;display:block;top:0;right:0;width:200px;overflow:hidden;height:200px;z-index:9999;}#forkongithub a{width:200px;position:absolute;top:60px;right:-60px;transform:rotate(45deg);-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);-moz-transform:rotate(45deg);-o-transform:rotate(45deg);box-shadow:4px 4px 10px rgba(0,0,0,0.8);}}</style>
 </head>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -11,8 +11,8 @@
       <span style="float:right;">
         Released under the <a href="http://opensource.org/licenses/BSD-3-Clause">BSD License</a>.
       </span>
-      Copyright 2012-2019 <a href="http://hamcrest.org">hamcrest.org</a>
+      Copyright 2012-2024 <a href="http://hamcrest.org">hamcrest.org</a>
     </footer>
-    <a href="http://github.com/hamcrest/JavaHamcrest"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
+    <span id="forkongithub"><a href="https://github.com/hamcrest/JavaHamcrest">Fork me on GitHub</a></span>
   </body>
 </html>


### PR DESCRIPTION
Docs are currently pointing to an old image url that doesn't exist