### PR TITLE
Allow matching against polymorphic collections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,22 @@
 
 ## Version 3.1 (Unreleased)
 
+### Breaking Changes
+
+* As a result of the bugfix to allow matching against polymorphic collections
+([PR #422](https://github.com/hamcrest/JavaHamcrest/pull/422)), the signature of the
+`hasItem` and `hasItems` methods has changed. Code relying on the exact signature of
+these methods will need to be updated. The following methods are affected:
+  * `org.hamcrest.CoreMatchers.hasItem`
+  * `org.hamcrest.CoreMatchers.hasItems`
+  * `org.hamcrest.Matchers.hasItem`
+  * `org.hamcrest.Matchers.hasItems`
+  * `org.hamcrest.core.IsCollectionContaining.hasItem`
+  * `org.hamcrest.core.IsCollectionContaining.hasItems`
+  * `org.hamcrest.core.IsIterableContaining.hasItem`
+  * `org.hamcrest.core.IsIterableContaining.hasItems`
+  * TODO: decide if these breaking changes should trigger a major version upgrade (i.e v4.0)
+
 ### Improvements
 
 * Javadoc improvements and cleanup ([PR #420](https://github.com/hamcrest/JavaHamcrest/pull/420))
@@ -10,7 +26,8 @@
 
 ### Bugfixes
 
-* TBD
+* Allow matching against polymorphic collections ([#252](https://github.com/hamcrest/JavaHamcrest/issues/252),
+  [PR #422](https://github.com/hamcrest/JavaHamcrest/pull/422))
 
 ## Version 3.0 (1st August 2024)
 

--- a/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
@@ -231,7 +231,7 @@ public class CoreMatchers {
    *     the matcher to apply to items provided by the examined {@link Iterable}
    * @return The matcher.
    */
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? super T>> hasItem(org.hamcrest.Matcher<? super T> itemMatcher) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItem(org.hamcrest.Matcher<? super T> itemMatcher) {
     return IsIterableContaining.hasItem(itemMatcher);
   }
 
@@ -249,7 +249,7 @@ public class CoreMatchers {
    *     the item to compare against the items provided by the examined {@link Iterable}
    * @return The matcher.
    */
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? super T>> hasItem(T item) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItem(T item) {
     return IsIterableContaining.hasItem(item);
   }
 
@@ -268,7 +268,7 @@ public class CoreMatchers {
    * @return The matcher.
    */
   @SafeVarargs
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<T>> hasItems(org.hamcrest.Matcher<? super T>... itemMatchers) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItems(org.hamcrest.Matcher<? super T>... itemMatchers) {
     return IsIterableContaining.hasItems(itemMatchers);
   }
 
@@ -287,7 +287,7 @@ public class CoreMatchers {
    * @return The matcher.
    */
   @SafeVarargs
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<T>> hasItems(T... items) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItems(T... items) {
     return IsIterableContaining.hasItems(items);
   }
 

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -449,7 +449,7 @@ public class Matchers {
    *     the matcher to apply to items provided by the examined {@link Iterable}
    * @return The matcher.
    */
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? super T>> hasItem(org.hamcrest.Matcher<? super T> itemMatcher) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItem(org.hamcrest.Matcher<? super T> itemMatcher) {
     return IsIterableContaining.hasItem(itemMatcher);
   }
 
@@ -467,7 +467,7 @@ public class Matchers {
    *     the item to compare against the items provided by the examined {@link Iterable}
    * @return The matcher.
    */
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? super T>> hasItem(T item) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItem(T item) {
     return IsIterableContaining.hasItem(item);
   }
 
@@ -486,7 +486,7 @@ public class Matchers {
    * @return The matcher.
    */
   @SafeVarargs
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<T>> hasItems(org.hamcrest.Matcher<? super T>... itemMatchers) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItems(org.hamcrest.Matcher<? super T>... itemMatchers) {
     return IsIterableContaining.hasItems(itemMatchers);
   }
 
@@ -505,7 +505,7 @@ public class Matchers {
    * @return The matcher.
    */
   @SafeVarargs
-  public static <T> org.hamcrest.Matcher<java.lang.Iterable<T>> hasItems(T... items) {
+  public static <T> org.hamcrest.Matcher<java.lang.Iterable<? extends T>> hasItems(T... items) {
     return IsIterableContaining.hasItems(items);
   }
 

--- a/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/HasItemInArray.java
@@ -16,7 +16,7 @@ import static java.util.Arrays.asList;
 public class HasItemInArray<T> extends TypeSafeMatcher<T[]> {
 
     private final Matcher<? super T> elementMatcher;
-    private final TypeSafeDiagnosingMatcher<Iterable<? super T>> collectionMatcher;
+    private final TypeSafeDiagnosingMatcher<Iterable<? extends T>> collectionMatcher;
 
     /**
      * Constructor, best called from {@link ArrayMatching}.

--- a/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+++ b/hamcrest/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
@@ -114,7 +114,8 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
      */
     @SafeVarargs
     public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(Matcher<? super T>... itemMatchers) {
-        return containsInAnyOrder((Collection) Arrays.asList(itemMatchers));
+        List<Matcher<? super T>> itemMatchersList = Arrays.asList(itemMatchers);
+        return containsInAnyOrder(itemMatchersList);
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsCollectionContaining.java
@@ -9,7 +9,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * @deprecated As of release 2.1, replaced by {@link IsIterableContaining}.
  */
 @Deprecated
-public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? super T>> {
+public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
 
     private final IsIterableContaining<T> delegate;
 
@@ -26,7 +26,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<? super T> collection, Description mismatchDescription) {
+    protected boolean matchesSafely(Iterable<? extends T> collection, Description mismatchDescription) {
         return delegate.matchesSafely(collection, mismatchDescription);
     }
 
@@ -51,7 +51,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      *     the matcher to apply to items provided by the examined {@link Iterable}
      * @return The matcher.
      */
-    public static <T> Matcher<Iterable<? super T>> hasItem(Matcher<? super T> itemMatcher) {
+    public static <T> Matcher<Iterable<? extends T>> hasItem(Matcher<? super T> itemMatcher) {
         return IsIterableContaining.hasItem(itemMatcher);
     }
 
@@ -70,7 +70,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      *     the item to compare against the items provided by the examined {@link Iterable}
      * @return The matcher.
      */
-    public static <T> Matcher<Iterable<? super T>> hasItem(T item) {
+    public static <T> Matcher<Iterable<? extends T>> hasItem(T item) {
         // Doesn't forward to hasItem() method so compiler can sort out generics.
         return IsIterableContaining.hasItem(item);
     }
@@ -91,7 +91,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * @return The matcher.
      */
     @SafeVarargs
-    public static <T> Matcher<Iterable<T>> hasItems(Matcher<? super T>... itemMatchers) {
+    public static <T> Matcher<Iterable<? extends T>> hasItems(Matcher<? super T>... itemMatchers) {
         return IsIterableContaining.hasItems(itemMatchers);
     }
 
@@ -111,7 +111,7 @@ public class IsCollectionContaining<T> extends TypeSafeDiagnosingMatcher<Iterabl
      * @return The matcher.
      */
     @SafeVarargs
-    public static <T> Matcher<Iterable<T>> hasItems(T... items) {
+    public static <T> Matcher<Iterable<? extends T>> hasItems(T... items) {
         return IsIterableContaining.hasItems(items);
     }
 

--- a/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
+++ b/hamcrest/src/main/java/org/hamcrest/core/IsIterableContaining.java
@@ -14,7 +14,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * Tests if an iterable contains matching elements.
  * @param <T> the type of items in the iterable
  */
-public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? super T>> {
+public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
 
     private final Matcher<? super T> elementMatcher;
 
@@ -31,7 +31,7 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<? super T> collection, Description mismatchDescription) {
+    protected boolean matchesSafely(Iterable<? extends T> collection, Description mismatchDescription) {
         if (isEmpty(collection)) {
           mismatchDescription.appendText("was empty");
           return false;
@@ -56,7 +56,7 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
         return false;
     }
 
-    private boolean isEmpty(Iterable<? super T> iterable) {
+    private boolean isEmpty(Iterable<? extends T> iterable) {
       return ! iterable.iterator().hasNext();
     }
 
@@ -81,7 +81,7 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      *     the matcher to apply to items provided by the examined {@link Iterable}
      * @return The matcher.
      */
-    public static <T> Matcher<Iterable<? super T>> hasItem(Matcher<? super T> itemMatcher) {
+    public static <T> Matcher<Iterable<? extends T>> hasItem(Matcher<? super T> itemMatcher) {
         return new IsIterableContaining<>(itemMatcher);
     }
 
@@ -99,7 +99,7 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      *     the item to compare against the items provided by the examined {@link Iterable}
      * @return The matcher.
      */
-    public static <T> Matcher<Iterable<? super T>> hasItem(T item) {
+    public static <T> Matcher<Iterable<? extends T>> hasItem(T item) {
         // Doesn't forward to hasItem() method so compiler can sort out generics.
         return new IsIterableContaining<>(equalTo(item));
     }
@@ -119,8 +119,8 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      * @return The matcher.
      */
     @SafeVarargs
-    public static <T> Matcher<Iterable<T>> hasItems(Matcher<? super T>... itemMatchers) {
-        List<Matcher<? super Iterable<T>>> all = new ArrayList<>(itemMatchers.length);
+    public static <T> Matcher<Iterable<? extends T>> hasItems(Matcher<? super T>... itemMatchers) {
+        List<Matcher<? super Iterable<? extends T>>> all = new ArrayList<>(itemMatchers.length);
 
         for (Matcher<? super T> elementMatcher : itemMatchers) {
           // Doesn't forward to hasItem() method so compiler can sort out generics.
@@ -145,8 +145,8 @@ public class IsIterableContaining<T> extends TypeSafeDiagnosingMatcher<Iterable<
      * @return The matcher.
      */
     @SafeVarargs
-    public static <T> Matcher<Iterable<T>> hasItems(T... items) {
-        List<Matcher<? super Iterable<T>>> all = new ArrayList<>(items.length);
+    public static <T> Matcher<Iterable<? extends T>> hasItems(T... items) {
+        List<Matcher<? super Iterable<? extends T>>> all = new ArrayList<>(items.length);
         for (T item : items) {
             all.add(hasItem(item));
         }

--- a/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/collection/IsMapContainingTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -45,6 +46,13 @@ public class IsMapContainingTest extends AbstractMatcherTest {
 
     public void testHasReadableDescription() {
         assertDescription("map containing [\"a\"-><2>]", hasEntry(equalTo("a"), (equalTo(2))));
+    }
+
+    public void testTypeVariance() {
+        Map<String, Number> m = new HashMap<>();
+        Integer foo = 6;
+        m.put("foo", foo);
+        assertThat(m, hasEntry("foo", foo));
     }
 
 }

--- a/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsCollectionContainingTest.java
@@ -23,17 +23,17 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
     }
 
     public void testMatchesACollectionThatContainsAnElementMatchingTheGivenMatcher() {
-        Matcher<Iterable<? super String>> itemMatcher = hasItem(equalTo("a"));
+        Matcher<Iterable<? extends String>> itemMatcher = hasItem(equalTo("a"));
 
         assertMatches("should match list that contains 'a'",
                 itemMatcher, asList("a", "b", "c"));
     }
 
     public void testDoesNotMatchCollectionThatDoesntContainAnElementMatchingTheGivenMatcher() {
-        final Matcher<Iterable<? super String>> matcher1 = hasItem(mismatchable("a"));
+        final Matcher<Iterable<? extends String>> matcher1 = hasItem(mismatchable("a"));
         assertMismatchDescription("mismatches were: [mismatched: b, mismatched: c]", matcher1, asList("b", "c"));
 
-        final Matcher<Iterable<? super String>> matcher2 = hasItem(equalTo("a"));
+        final Matcher<Iterable<? extends String>> matcher2 = hasItem(equalTo("a"));
         assertMismatchDescription("was empty", matcher2, new ArrayList<String>());
     }
 
@@ -55,27 +55,27 @@ public class IsCollectionContainingTest extends AbstractMatcherTest {
 
     @SuppressWarnings("unchecked")
     public void testMatchesAllItemsInCollection() {
-        final Matcher<Iterable<String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("should match list containing all items",
                 matcher1,
                 asList("a", "b", "c"));
 
-        final Matcher<Iterable<String>> matcher2 = hasItems("a", "b", "c");
+        final Matcher<Iterable<? extends String>> matcher2 = hasItems("a", "b", "c");
         assertMatches("should match list containing all items (without matchers)",
                 matcher2,
                 asList("a", "b", "c"));
 
-        final Matcher<Iterable<String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("should match list containing all items in any order",
                 matcher3,
                 asList("c", "b", "a"));
 
-        final Matcher<Iterable<String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("should match list containing all items plus others",
                 matcher4,
                 asList("e", "c", "b", "a", "d"));
 
-        final Matcher<Iterable<String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertDoesNotMatch("should not match list unless it contains all items",
                 matcher5,
                 asList("e", "c", "b", "d")); // 'a' missing

--- a/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
+++ b/hamcrest/src/test/java/org/hamcrest/core/IsIterableContainingTest.java
@@ -6,14 +6,17 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
 import static org.hamcrest.AbstractMatcherTest.*;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
-import static org.hamcrest.core.IsEqual.equalTo;
 
 public final class IsIterableContainingTest {
 
@@ -27,14 +30,14 @@ public final class IsIterableContainingTest {
 
     @Test public void
     matchesACollectionThatContainsAnElementForTheGivenMatcher() {
-        final Matcher<Iterable<? super String>> itemMatcher = hasItem(equalTo("a"));
+        final Matcher<Iterable<? extends String>> itemMatcher = hasItem(equalTo("a"));
 
         assertMatches("list containing 'a'", itemMatcher, asList("a", "b", "c"));
     }
 
     @Test public void
     doesNotMatchCollectionWithoutAnElementForGivenMatcher() {
-        final Matcher<Iterable<? super String>> matcher = hasItem(mismatchable("a"));
+        final Matcher<Iterable<? extends String>> matcher = hasItem(mismatchable("a"));
 
         assertMismatchDescription("mismatches were: [mismatched: b, mismatched: c]", matcher, asList("b", "c"));
         assertMismatchDescription("was empty", matcher, new ArrayList<String>());
@@ -62,31 +65,31 @@ public final class IsIterableContainingTest {
     @SuppressWarnings("unchecked")
     @Test public void
     matchesMultipleItemsInCollection() {
-        final Matcher<Iterable<String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher1 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("list containing all items", matcher1, asList("a", "b", "c"));
 
-        final Matcher<Iterable<String>> matcher2 = hasItems("a", "b", "c");
+        final Matcher<Iterable<? extends String>> matcher2 = hasItems("a", "b", "c");
         assertMatches("list containing all items (without matchers)", matcher2, asList("a", "b", "c"));
 
-        final Matcher<Iterable<String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher3 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("list containing all items in any order", matcher3, asList("c", "b", "a"));
 
-        final Matcher<Iterable<String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher4 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertMatches("list containing all items plus others", matcher4, asList("e", "c", "b", "a", "d"));
 
-        final Matcher<Iterable<String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
+        final Matcher<Iterable<? extends String>> matcher5 = hasItems(equalTo("a"), equalTo("b"), equalTo("c"));
         assertDoesNotMatch("not match list unless it contains all items", matcher5, asList("e", "c", "b", "d")); // 'a' missing
     }
 
     @Test public void
     reportsMismatchWithAReadableDescriptionForMultipleItems() {
-        final Matcher<Iterable<Integer>> matcher = hasItems(3, 4);
+        final Matcher<Iterable<? extends Integer>> matcher = hasItems(3, 4);
 
         assertMismatchDescription("a collection containing <4> mismatches were: [was <1>, was <2>, was <3>]",
                                   matcher, asList(1, 2, 3));
     }
 
-    private static Matcher<? super String> mismatchable(final String string) {
+    private static Matcher<String> mismatchable(final String string) {
         return new TypeSafeDiagnosingMatcher<String>() {
             @Override
             protected boolean matchesSafely(String item, Description mismatchDescription) {
@@ -104,4 +107,67 @@ public final class IsIterableContainingTest {
         };
     }
 
+    @Test public void
+    matchesPolymorphicTypes() {
+        Collection<Dog> dogs = singleton(new Dog("Spot"));
+        Animal spotAsAnimal = new Dog("Spot");
+        assertMatches(hasItem(spotAsAnimal), dogs);
+        Dog spotAsDog = new Dog("Spot");
+        assertMatches(hasItem(spotAsDog), dogs);
+
+        Collection<? extends Animal> animals = asList(
+                new Dog("Fido"), new Cat("Whiskers"));
+        Dog fido = new Dog("Fido");
+        Matcher<Iterable<? extends Animal>> dogsMatcher = hasItem(fido);
+        assertMatches(dogsMatcher, animals);
+
+        Cat whiskers = new Cat("Whiskers");
+        assertMatches(hasItem(whiskers), animals);
+
+        Matcher<Iterable<? extends Animal>> iterableMatcher = hasItems(fido, whiskers);
+        assertMatches(iterableMatcher, animals);
+        assertMatches(not(hasItem(spotAsAnimal)), animals);
+    }
+
+    abstract static class Animal {
+        private final String name;
+
+        Animal(String name) {
+            this.name = name;
+        }
+
+        public String name() {
+            return this.name;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+
+            return name.equals(((Animal) obj).name);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+    }
+
+    static class Dog extends Animal {
+        public Dog(String name) {
+            super(name);
+        }
+    }
+
+    static class Cat extends Animal {
+        public Cat(String name) {
+            super(name);
+        }
+    }
 }


### PR DESCRIPTION
As discussed in #252, there are problems with matching against polymorphic collections.

This fix attempts to apply the PECS rule (producer extends, consumer super) to the Hamcrest IsIterableContaining matcher. In this instance, a collection of items should be treated as a producer according to this rule, while a matcher acts as a consumer. There was some confustion about PECS in the context of collections of matchers, but I'm hoping this change addresses those issues.

I'm keen for others to test this work out