### PR TITLE
Restore public constructors for compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,9 @@ these methods will need to be updated. The following methods are affected:
 
 ### Improvements
 
-* Javadoc improvements and cleanup ([PR #420](https://github.com/hamcrest/JavaHamcrest/pull/420))
+* Javadoc improvements and cleanup ([PR #420](https://github.com/hamcrest/JavaHamcrest/pull/420),
+[#427](https://github.com/hamcrest/JavaHamcrest/issues/427),
+[PR #428](https://github.com/hamcrest/JavaHamcrest/pull/428))
 * Derive version from git tags ([PR #419](https://github.com/hamcrest/JavaHamcrest/pull/419))
 * Migrate all tests to JUnit Jupiter ([PR #424](https://github.com/hamcrest/JavaHamcrest/pull/424))
 

--- a/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/CoreMatchers.java
@@ -13,7 +13,10 @@ import org.hamcrest.core.IsIterableContaining;
 @SuppressWarnings("UnusedDeclaration")
 public class CoreMatchers {
 
-  private CoreMatchers() {
+  /**
+   * Unused
+   */
+  public CoreMatchers() {
   }
 
   /**

--- a/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
+++ b/hamcrest/src/main/java/org/hamcrest/MatcherAssert.java
@@ -6,7 +6,10 @@ package org.hamcrest;
  */
 public class MatcherAssert {
 
-    private MatcherAssert() {
+    /**
+     * Unused.
+     */
+    public MatcherAssert() {
     }
 
     /**

--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -22,7 +22,10 @@ import java.util.regex.Pattern;
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class Matchers {
 
-  private Matchers() {
+  /**
+   * Unused
+   */
+  public Matchers() {
   }
 
   /**


### PR DESCRIPTION
CoreMatchers, MatcherAssert, and Matchers had private contructors added to fix javadoc warnings. Unfortunately, this can break existig users of the classes.

Fixes #427