### PR TITLE
Close code section correctly

### DIFF
--- a/hamcrest/src/main/java/org/hamcrest/Matchers.java
+++ b/hamcrest/src/main/java/org/hamcrest/Matchers.java
@@ -643,8 +643,8 @@ public class Matchers {
   }
 
   /**
-   * A shortcut to the frequently used <code>not(nullValue(X.class)). Accepts a
-   * single dummy argument to facilitate type inference.</code>.
+   * A shortcut to the frequently used <code>not(nullValue(X.class))</code>. Accepts a
+   * single dummy argument to facilitate type inference.
    * For example:
    * <pre>assertThat(cheese, is(notNullValue(X.class)))</pre>
    * instead of:


### PR DESCRIPTION
to fix javadoc formatting for `notNullValue`.

I noticed that https://hamcrest.org/JavaHamcrest/javadoc/3.0/org/hamcrest/Matchers.html appears to be a bit broken, and it seems like if this `<code>` section were terminated earlier then things would work correctly.

